### PR TITLE
fresponsive fix

### DIFF
--- a/fullyResponsive.ts
+++ b/fullyResponsive.ts
@@ -29,7 +29,7 @@ export default function fullyResponsive(
   only?: "mobile" | "tablet" | "desktop"
 ) {
   // if not a string, convert to string
-  const cssAsString = typeof cssIn === "string" ? cssIn : cssIn.join("\n")
+  const cssAsString = typeof cssIn === "string" ? cssIn : cssIn.join("")
   const onlyPxValues = cssAsString
     .replaceAll("{", "{\n")
     .replaceAll("}", "\n}")


### PR DESCRIPTION
using a newline to join CSS together can create invalid CSS if mixins are used in the middle of a syntax.
which meant that things like `${props.width}px` would get parsed to an invalid value like `10 px`

styled components would usually fix these invalid values, which is why they weren't an issue before