### PR TITLE
Universal image

### DIFF
--- a/UniversalImage.tsx
+++ b/UniversalImage.tsx
@@ -1,3 +1,4 @@
+import type { IGatsbyImageData } from "gatsby-plugin-image"
 import { GatsbyImage } from "gatsby-plugin-image"
 import type { ComponentProps } from "react"
 
@@ -6,6 +7,8 @@ type GatsbyImageProps = ComponentProps<typeof GatsbyImage>
 export type UniversalImageProps = Omit<GatsbyImageProps, "image"> & {
   image: GatsbyImageProps["image"] | null | undefined
 }
+
+export type UniversalImageData = IGatsbyImageData | null | undefined
 
 export default function UniversalImage({
   image,

--- a/UniversalImage.tsx
+++ b/UniversalImage.tsx
@@ -1,0 +1,15 @@
+import { GatsbyImage } from "gatsby-plugin-image"
+import type { ComponentProps } from "react"
+
+type GatsbyImageProps = ComponentProps<typeof GatsbyImage>
+
+export type UniversalImageProps = Omit<GatsbyImageProps, "image"> & {
+  image: GatsbyImageProps["image"] | null | undefined
+}
+
+export default function UniversalImage({
+  image,
+  ...props
+}: UniversalImageProps) {
+  return image ? <GatsbyImage image={image} {...props} /> : null
+}

--- a/useMedia.ts
+++ b/useMedia.ts
@@ -1,4 +1,3 @@
-import type { IGatsbyImageData } from "gatsby-plugin-image"
 import { startTransition, useCallback, useEffect, useState } from "react"
 import {
   desktopBreakpoint as desktop,
@@ -7,6 +6,7 @@ import {
 } from "styles/media"
 
 import { isBrowser } from "./functions"
+import type { UniversalImageData } from "./UniversalImage"
 
 export default function useMedia<
   // anything that doesn't change by reference
@@ -19,7 +19,7 @@ export default function useMedia<
     /**
      * image data technically changes by reference, but is stable when provided by gatsby
      */
-    | IGatsbyImageData,
+    | UniversalImageData,
 >(fw: InputType, d: InputType, t: InputType, m: InputType) {
   const handleUpdate = useCallback(() => {
     if (isBrowser()) {


### PR DESCRIPTION
a new util to replace GatsbyImage to make working with them more convenient

rather than:
```
lots?.of?.optional?.chaining?.childImageSharp?.gatsbyImageData && (
    <GatsbyImage image={lots.of.optional.chaining.childImageSharp.gatsbyImageData} alt="" />
)
```

just pass an image, even if it's null or undefined

```
<UniversalImage image={lots?.of?.optional?.chaining?.childImageSharp?.gatsbyImageData} alt="" />
```