### PR TITLE
Styled components v6

### DIFF
--- a/StyledManager.tsx
+++ b/StyledManager.tsx
@@ -1,0 +1,14 @@
+import isPropValid from "@emotion/is-prop-valid"
+import { StyleSheetManager } from "styled-components"
+
+export default function StyledManager({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <StyleSheetManager enableVendorPrefixes shouldForwardProp={isPropValid}>
+      {children}
+    </StyleSheetManager>
+  )
+}

--- a/fullyResponsive.ts
+++ b/fullyResponsive.ts
@@ -1,5 +1,5 @@
 import config from "libraryConfig"
-import { css, FlattenSimpleInterpolation } from "styled-components"
+import { RuleSet, css } from "styled-components"
 import media, {
   desktopDesignSize,
   mobileDesignSize,
@@ -24,7 +24,7 @@ const designSizes = {
  * @returns
  */
 export default function fullyResponsive(
-  cssIn: FlattenSimpleInterpolation | string,
+  cssIn: RuleSet<object> | string,
   only?: "mobile" | "tablet" | "desktop"
 ) {
   // if not a string, convert to string
@@ -91,11 +91,11 @@ export default function fullyResponsive(
 
 const fresponsive = fullyResponsive
 
-const fdesktop = (cssIn: FlattenSimpleInterpolation | string) =>
+const fdesktop = (cssIn: RuleSet<object> | string) =>
   fullyResponsive(cssIn, "desktop")
-const ftablet = (cssIn: FlattenSimpleInterpolation | string) =>
+const ftablet = (cssIn: RuleSet<object> | string) =>
   fullyResponsive(cssIn, "tablet")
-const fmobile = (cssIn: FlattenSimpleInterpolation | string) =>
+const fmobile = (cssIn: RuleSet<object> | string) =>
   fullyResponsive(cssIn, "mobile")
 
 export { fdesktop, fmobile, fresponsive, ftablet }


### PR DESCRIPTION
This PR upgrades styled-components to v6.

Steps to upgrade:
1. Remove styled-components v6 from .ncurc.yaml
2. Update styled-components to at least version 6.0.8 (`npx npm-check-updates -u`)
3. Uninstall `@types/styled-components` (types are included by default as of v6)
4. Add StyledManager to your Providers
5. Format your repository (may or may not do anything)