### PR TITLE
testing concurrency

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -2,6 +2,10 @@ name: Code Checks
 on:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Automatically_Format:
     # only run if not authored by dependabot


### PR DESCRIPTION
this could reduce our check minutes by quite a bit

just cancels any running actions when you push new code to a pull request