### PR TITLE
loader improvements:

### DIFF
--- a/ImageSequence.tsx
+++ b/ImageSequence.tsx
@@ -1,8 +1,9 @@
 import { useEventListener } from "ahooks"
 import gsap from "gsap"
-import loader, { transitionAwaitPromise } from "library/Loader"
 import { useCallback, useEffect, useRef, useState } from "react"
 import styled from "styled-components"
+import { loader } from "./Loader"
+import { loaderAwaitPromise } from "./Loader/promises"
 
 interface SequenceProps {
 	className?: string
@@ -136,7 +137,7 @@ export default function ImageSequence({
 				.catch(console.error)
 
 			// if this is an auto sequence, the loader should wait for all images to settle (max 5s)
-			if (type === "auto") transitionAwaitPromise(prom)
+			if (type === "auto") loaderAwaitPromise(prom)
 		}
 	}, [createImage, folder, length, type])
 
@@ -197,9 +198,9 @@ export default function ImageSequence({
 						.catch(console.error)
 			}
 
-			loader.addEventListener("anyEnd", onReady)
+			loader.addEventListener("end", onReady)
 			return () => {
-				loader.removeEventListener("anyEnd", onReady)
+				loader.removeEventListener("end", onReady)
 				tween.kill()
 			}
 		}

--- a/Loader/PreloaderUtils.ts
+++ b/Loader/PreloaderUtils.ts
@@ -47,9 +47,9 @@ let loaderIsDone = false
 export const getLoaderIsDone = () => loaderIsDone
 
 // preserve the scroll position throughout the initial render (page height may change because of pins etc)
-document.body.style.minHeight = "9999vh"
+if (isBrowser) document.body.style.minHeight = "9999vh"
 const initialScroll = isBrowser ? window.scrollY : 0
-document.body.style.removeProperty("min-height")
+if (isBrowser) document.body.style.removeProperty("min-height")
 
 /**
  * call all callbacks and set done to true

--- a/Loader/PreloaderUtils.ts
+++ b/Loader/PreloaderUtils.ts
@@ -7,8 +7,8 @@ import { isBrowser } from "library/deviceDetection"
 import { loader } from "."
 import { sleep } from "../functions"
 import { pageReady } from "../pageReady"
-import { scrollToAnchor } from "./scrollToAnchor"
 import { allLoaderPromisesSettled } from "./promises"
+import { scrollToAnchor } from "./scrollToAnchor"
 
 /**
  * we get a percentage by simply guessing how long the page will take to load based on

--- a/Loader/PreloaderUtils.ts
+++ b/Loader/PreloaderUtils.ts
@@ -47,7 +47,9 @@ let loaderIsDone = false
 export const getLoaderIsDone = () => loaderIsDone
 
 // preserve the scroll position throughout the initial render (page height may change because of pins etc)
-if (isBrowser) document.body.style.minHeight = "9999vh"
+document.body.style.minHeight = "9999vh"
+const initialScroll = isBrowser ? window.scrollY : 0
+document.body.style.removeProperty("min-height")
 
 /**
  * call all callbacks and set done to true
@@ -78,6 +80,10 @@ async function onComplete() {
 		ScrollSmoother.get()?.scrollTop(0)
 		ScrollTrigger.refresh()
 		ScrollSmoother.get()?.scrollTop(0)
+	} else {
+		ScrollSmoother.get()?.scrollTop(initialScroll)
+		ScrollTrigger.refresh()
+		ScrollSmoother.get()?.scrollTop(initialScroll)
 	}
 
 	/**
@@ -111,7 +117,7 @@ async function onComplete() {
 		ScrollTrigger.refresh()
 	})
 	ScrollSmoother.get()?.paused(false)
-	document.body.style.removeProperty("min-height")
+	if (!anchor && !isAtTop) ScrollSmoother.get()?.scrollTop(initialScroll)
 
 	// give refresh time to finish
 	await sleep(50)

--- a/Loader/PreloaderUtils.ts
+++ b/Loader/PreloaderUtils.ts
@@ -46,6 +46,9 @@ const timeNeeded = GET_TIME_NEEDED(startTime)
 let loaderIsDone = false
 export const getLoaderIsDone = () => loaderIsDone
 
+// preserve the scroll position throughout the initial render (page height may change because of pins etc)
+if (isBrowser) document.body.style.minHeight = "9999vh"
+
 /**
  * call all callbacks and set done to true
  */
@@ -108,6 +111,7 @@ async function onComplete() {
 		ScrollTrigger.refresh()
 	})
 	ScrollSmoother.get()?.paused(false)
+	document.body.style.removeProperty("min-height")
 
 	// give refresh time to finish
 	await sleep(50)

--- a/Loader/TransitionUtils.ts
+++ b/Loader/TransitionUtils.ts
@@ -241,6 +241,8 @@ export function useBackButton() {
 	useEventListener("popstate", async () => {
 		loader.dispatchEvent("start", "instant")
 		loader.dispatchEvent("routeChange", "instant")
+		document.body.style.minHeight = "9999vh"
+
 		await pageUnmounted()
 		await pageReady()
 
@@ -251,6 +253,7 @@ export function useBackButton() {
 		window.scrollBy(0, 1)
 		await sleep(500)
 		loader.dispatchEvent("end", "instant")
+		document.body.style.removeProperty("min-height")
 	})
 }
 

--- a/Loader/TransitionUtils.ts
+++ b/Loader/TransitionUtils.ts
@@ -1,30 +1,29 @@
-import { navigate as gatsbyNavigate } from "gatsby"
 import gsap from "gsap"
+import { navigate as gatsbyNavigate } from "gatsby"
 import ScrollSmoother from "gsap/ScrollSmoother"
 import { ScrollTrigger } from "gsap/ScrollTrigger"
-import { pathnameMatches, sleep } from "library/functions"
+import { linkIsInternal, pathnameMatches, sleep } from "library/functions"
 import { pageReady, pageUnmounted } from "library/pageReady"
-import { useEffect } from "react"
+import { useDeepCompareEffect, useEventListener } from "ahooks"
+import type { TransitionNames } from "libraryConfig"
+import libraryConfig from "libraryConfig"
+import { loader } from "."
+import { getLoaderIsDone } from "./PreloaderUtils"
+import ScrollToPlugin from "gsap/ScrollToPlugin"
+import { startTransition } from "react"
+import { getScrollOffset, scrollToAnchor } from "./scrollToAnchor"
+import { allLoaderPromisesSettled } from "./promises"
 
-import type { InternalTransitions, Transitions } from "."
-import loader, { promisesToAwait, recursiveAllSettled } from "."
-import { getLoaderIsDone } from "./LoaderUtils"
+gsap.registerPlugin(ScrollToPlugin)
 
-const pushPage = (to: string) => {
-	// the type of the gatsby navigate function is incorrect
-	gatsbyNavigate(to)
-}
-
-/**
- * A function that runs an animation and returns the duration of that animation in seconds
- */
+type LoaderTransitions = TransitionNames | "instant"
 interface Animation {
 	callback: VoidFunction
 	duration: number
 }
 
 /**
- * Object tracking all the registered transitions
+ * all registered transitions
  */
 const allTransitions: Record<
 	string,
@@ -35,159 +34,100 @@ const allTransitions: Record<
 > = {}
 
 /**
- * register a transition that can be run with a UniversalLink or by using loadPage.
- * @deprecated prefer useRegisterTransition, which automatically un-registers the transition
+ * if we click a link during a transition, delay it until the transition is done
  */
-export const registerTransition = (
-	name: Exclude<Transitions, InternalTransitions | undefined>,
-	details: {
-		in: VoidFunction
-		out: VoidFunction
-		inDuration: number
-		outDuration: number
-	},
-) => {
-	const {
-		in: inAnimation,
-		out: outAnimation,
-		inDuration,
-		outDuration,
-	} = details
-	const previous = allTransitions[name] ?? {
-		inAnimation: [],
-		outAnimation: [],
-	}
-	allTransitions[name] = {
-		inAnimation: [
-			...previous.inAnimation,
-			{ callback: inAnimation, duration: inDuration },
-		],
-		outAnimation: [
-			...previous.outAnimation,
-			{ callback: outAnimation, duration: outDuration },
-		],
-	}
-}
+let pendingNavigation: {
+	to: string
+	transition?: LoaderTransitions
+} | null = null
 
 /**
- * unregister a previously registered transition, such as when a transition component unmounts
- * @deprecated prefer useRegisterTransition, which automatically un-registers the transition
+ * and likewise, the currently running navigation
  */
-export const unregisterTransition = (
-	name: string,
-	callbacksToRemove?: VoidFunction[],
-) => {
-	if (callbacksToRemove) {
-		const previous = allTransitions[name] ?? {
-			inAnimation: [],
-			outAnimation: [],
-		}
-		allTransitions[name] = {
-			inAnimation: previous.inAnimation.filter(
-				({ callback }) => !callbacksToRemove.includes(callback),
-			),
-			outAnimation: previous.outAnimation.filter(
-				({ callback }) => !callbacksToRemove.includes(callback),
-			),
-		}
-	} else {
-		allTransitions[name] = { inAnimation: [], outAnimation: [] }
-	}
-}
-
-let pendingTransition: {
-	to: string
-	transition?: Transitions | InternalTransitions
-} | null = null
-let currentAnimation: string | null = null
+let currentNavigation: string | null = null
 
 /**
  * load a page, making use of the specified transition
- * @param to page to load
+ * @param navigateTo page to load
  * @param transition the transition to use
  */
 export const loadPage = async (
 	navigateTo: string,
-	transition?: Transitions | InternalTransitions,
+	transition: LoaderTransitions,
 ) => {
-	// extract the anchor from the pathname if applicable
-	const anchor = new URL(navigateTo, window.location.origin).hash
-	let scrollOffset = 100
-	if (anchor) {
-		const anchorEl = document.querySelector(anchor)
-		// Check if data-anchor-offset exists on the anchor element to allow fine-tuning of scroll position
-		const anchorOffset = anchorEl?.getAttribute("data-anchor-offset")
-		scrollOffset += Number.parseFloat(anchorOffset ?? "0")
-	}
+	const anchorName = new URL(navigateTo, window.location.origin).hash
 	const pathname = new URL(navigateTo, window.location.origin).pathname
 
 	// if a transition is already in progress, wait for it to finish before loading the next page
-	if (currentAnimation !== null) {
-		if (!pathnameMatches(pathname, currentAnimation))
-			pendingTransition = { to: navigateTo, transition }
+	if (currentNavigation !== null) {
+		// ignore double clicks
+		if (!pathnameMatches(pathname, currentNavigation))
+			pendingNavigation = { to: navigateTo, transition }
 		return
 	}
 
-	// if we're already on the page we're trying to load, just scroll to the top
-	if (pathnameMatches(pathname, window.location.pathname)) {
+	/**
+	 * ONLY SCROLLING
+	 *
+	 * if we're already on the page we're trying to load, just scroll to the top ( or to anchor )
+	 */
+	if (
+		navigateTo.startsWith("#") ||
+		pathnameMatches(pathname, window.location.pathname)
+	) {
 		ScrollSmoother.get()?.paused(false)
 
 		// scroll to anchor if applicable, otherwise scroll to top
-		if (anchor) {
-			// ScrollSmoother.get()?.scrollTo(anchor, true, "top 100px")
+		if (anchorName) {
+			const scrollOffset = getScrollOffset(anchorName)
 			gsap.to(window, {
-				scrollTo: { y: anchor, offsetY: scrollOffset },
+				scrollTo: { y: anchorName, offsetY: scrollOffset },
 				duration: 0.4,
 			})
-			loader.dispatchEvent("scrollTo")
+			loader.dispatchEvent("scroll", anchorName)
 		} else {
 			window.scrollTo({
 				top: 0,
 				behavior: "smooth",
 			})
-			loader.dispatchEvent("scrollTo")
+			loader.dispatchEvent("scroll", null)
 		}
 
 		return
 	}
 
-	// if no transition is specified, instantly transition pages
-	if (!transition || !allTransitions[transition]) {
-		loader.dispatchEvent("anyStart", "none")
-		loader.dispatchEvent("transitionStart", "none")
-		loader.dispatchEvent("transitionCenter", "none")
+	/**
+	 * INSTANT TRANSITION
+	 *
+	 * if no transition is specified, instantly transition pages
+	 */
+	if (transition === "instant" || !transition || !allTransitions[transition]) {
+		loader.dispatchEvent("start", "instant")
+		loader.dispatchEvent("routeChange", "instant")
 
 		navigate(navigateTo)
 		await pageUnmounted()
 		await pageReady()
-
-		// if the desired behavior is to scroll to a certain point on the page after the transition, do so.
-		// This is not currently supported for transitions without animations
 		ScrollSmoother.get()?.paused(false)
-		if (anchor) {
-			setTimeout(() => {
-				ScrollSmoother.get()?.scrollTo(anchor, false, `top: ${scrollOffset}px`)
-			})
+
+		// scroll to anchor if applicable, otherwise scroll to top
+		if (anchorName) {
+			await scrollToAnchor(anchorName)
 		} else {
-			// an anchor is not specified, scroll to the top of the page
 			ScrollSmoother.get()?.scrollTo(0, false)
 			window.scrollTo(0, 1)
 		}
 
-		// refresh smoother effects
-		ScrollSmoother.get()?.effects("[data-speed], [data-lag]", {})
-
-		// fire events with detail "none"
-		loader.dispatchEvent("transitionEnd", "none")
-		loader.dispatchEvent("anyEnd", "none")
-
+		loader.dispatchEvent("end", "instant")
 		return
 	}
 
-	// start this animation
-	currentAnimation = navigateTo
+	/**
+	 * NORMAL TRANSITION
+	 */
+	currentNavigation = navigateTo
 
-	// wait for the initial loader to finish animation before starting the transition
+	// wait for the preloader to finish animation before starting the transition
 	while (!getLoaderIsDone()) await sleep(100)
 
 	const animationContext = gsap.context(() => {
@@ -204,13 +144,12 @@ export const loadPage = async (
 	}
 
 	// dispatch events
-	loader.dispatchEvent("anyStart", transition)
-	loader.dispatchEvent("transitionStart", transition)
+	loader.dispatchEvent("start", transition)
 	ScrollSmoother.get()?.paused(true)
 
 	// wait for entrance animation to finish
 	await sleep(entranceDuration * 1000)
-	loader.dispatchEvent("transitionCenter", transition)
+	loader.dispatchEvent("routeChange", transition)
 
 	// actually navigate to the page
 	navigate(navigateTo, () => {
@@ -219,38 +158,19 @@ export const loadPage = async (
 	await pageReady()
 
 	// wait for any promises to settle
-	promisesToAwait.push(sleep(0))
-	await recursiveAllSettled(promisesToAwait)
+	await sleep(0)
+	await allLoaderPromisesSettled()
 
 	// if the desired behavior is to scroll to a certain point on the page
 	// after the transition, do so. This is done after the exit animation
-	// to prevent the page from jumping around, it also recalls the scrollTo
-	// function multiple times to ensure the scroll is maintained
-	if (anchor) {
-		// scroll to the anchor multiple times to ensure we're at the right place
-		let goodAttemptCount = 0
-		let scrollPosition = 0
-		while (goodAttemptCount < 5) {
-			if (document.querySelector(anchor)) {
-				ScrollTrigger.refresh()
-				ScrollSmoother.get()?.scrollTo(anchor, false, "top 100px")
-
-				// if we moved less than 10 pixels, count it as a good attempt
-				const newPosition = ScrollSmoother.get()?.scrollTop() ?? 0
-				if (Math.abs(newPosition - scrollPosition) < 10) goodAttemptCount += 1
-				scrollPosition = newPosition
-			}
-
-			await sleep(50)
-		}
+	// to prevent the page from jumping around
+	if (anchorName) {
+		await scrollToAnchor(anchorName)
 	} else {
 		// if no anchor, scroll to the top of the page
 		window.scrollTo(0, 0)
 		ScrollSmoother.get()?.scrollTo(0, false)
 	}
-
-	// refresh smoother effects
-	ScrollSmoother.get()?.effects("[data-speed], [data-lag]", {})
 
 	const exitAnimations = allTransitions[transition]?.outAnimation ?? []
 
@@ -266,23 +186,18 @@ export const loadPage = async (
 	await sleep(exitDuration * 1000 + 10)
 
 	// dispatch finished events
-	loader.dispatchEvent("anyEnd", transition)
-	loader.dispatchEvent("transitionEnd", transition)
+	loader.dispatchEvent("end", transition)
 	ScrollSmoother.get()?.paused(false)
 	ScrollTrigger.refresh()
 
 	// cleanup and reset
 	animationContext.revert()
-	currentAnimation = null
+	currentNavigation = null
 
 	// start the next transition if applicable
-	if (pendingTransition?.transition) {
-		loadPage(pendingTransition.to, pendingTransition.transition).catch(
-			(error: string) => {
-				throw new Error(error)
-			},
-		)
-		pendingTransition = null
+	if (pendingNavigation?.transition) {
+		loadPage(pendingNavigation.to, pendingNavigation.transition)
+		pendingNavigation = null
 	}
 }
 
@@ -291,8 +206,8 @@ export const loadPage = async (
  * @param to the link to navigate to
  * @param cleanupFunction a function to reset the page to its original state (if back button is pressed after external link)
  */
-export const navigate = (to: string, cleanupFunction?: VoidFunction) => {
-	const isExternal = to.slice(0, 8).includes("//")
+const navigate = (to: string, cleanupFunction?: VoidFunction) => {
+	const isExternal = !linkIsInternal(to)
 
 	if (isExternal) {
 		window.open(to)
@@ -302,32 +217,40 @@ export const navigate = (to: string, cleanupFunction?: VoidFunction) => {
 			cleanupFunction?.()
 		}, 1000)
 	} else {
-		pushPage(to)
+		startTransition(() => {
+			gatsbyNavigate(to)
+		})
 	}
 }
 
 /**
- * tracks when a page is done loading, for use in layout
- * also handles bugs with back/forward buttons
+ * manually track the scroll position so we can restore it when clicking back
+ * gatsby can't restore scroll position if we have a transition animation
+ */
+const scrollPositions = new Map<string, number>()
+
+/**
+ * handles scroll restoration for forward/back buttons
+ * will also dispatch events to make sure nothing gets stuck in an illegal state
  */
 export function useBackButton() {
-	useEffect(() => {
-		const handleBackButton = () => {
-			;(async () => {
-				loader.dispatchEvent("initialStart")
-				loader.dispatchEvent("anyStart", "none")
-				loader.dispatchEvent("transitionStart", "none")
-				loader.dispatchEvent("transitionCenter", "none")
-				await pageUnmounted()
-				await pageReady()
-				window.scrollTo(0, 1)
-				await sleep(500)
-				loader.dispatchEvent("transitionEnd", "none")
-				loader.dispatchEvent("anyEnd", "none")
-			})().catch(console.error)
-		}
-		window.addEventListener("popstate", handleBackButton)
-		return () => window.removeEventListener("popstate", handleBackButton)
+	useEventListener("scroll", () => {
+		scrollPositions.set(window.location.href, window.scrollY)
+	})
+
+	useEventListener("popstate", async () => {
+		loader.dispatchEvent("start", "instant")
+		loader.dispatchEvent("routeChange", "instant")
+		await pageUnmounted()
+		await pageReady()
+
+		if (libraryConfig.scrollRestoration === false) window.scrollTo(0, 1)
+		else window.scrollTo(0, scrollPositions.get(window.location.href) ?? 0)
+
+		// using back then forward can cause page to disappear until we scroll, so we'll do that manually
+		window.scrollBy(0, 1)
+		await sleep(500)
+		loader.dispatchEvent("end", "instant")
 	})
 }
 
@@ -335,14 +258,14 @@ export function useBackButton() {
  * registers a transition that can be run with a UniversalLink or by using loadPage.
  *
  * @param name the name of the transition
- * @param details the details of the transition
+ * @param details
  * @param details.in the animation to run before navigating
  * @param details.out the animation to run after navigating
  * @param details.inDuration the duration of the in animation in seconds
  * @param details.outDuration the duration of the out animation in seconds
  */
-export const useRegisterTransition = (
-	name: Exclude<Transitions, InternalTransitions | undefined>,
+export const usePageTransition = (
+	name: Exclude<LoaderTransitions, "instant">,
 	details: {
 		in: VoidFunction
 		out: VoidFunction
@@ -350,8 +273,47 @@ export const useRegisterTransition = (
 		outDuration: number
 	},
 ) => {
-	useEffect(() => {
-		registerTransition(name, details)
-		return () => unregisterTransition(name)
+	useDeepCompareEffect(() => {
+		const {
+			in: inAnimation,
+			out: outAnimation,
+			inDuration,
+			outDuration,
+		} = details
+
+		// merge the new details into the existing animation of this name
+		const previous = allTransitions[name] ?? {
+			inAnimation: [],
+			outAnimation: [],
+		}
+
+		allTransitions[name] = {
+			inAnimation: [
+				...previous.inAnimation,
+				{ callback: inAnimation, duration: inDuration },
+			],
+			outAnimation: [
+				...previous.outAnimation,
+				{ callback: outAnimation, duration: outDuration },
+			],
+		}
+
+		return () => {
+			const callbacksToRemove = [inAnimation, outAnimation]
+
+			const previous = allTransitions[name] ?? {
+				inAnimation: [],
+				outAnimation: [],
+			}
+
+			allTransitions[name] = {
+				inAnimation: previous.inAnimation.filter(
+					({ callback }) => !callbacksToRemove.includes(callback),
+				),
+				outAnimation: previous.outAnimation.filter(
+					({ callback }) => !callbacksToRemove.includes(callback),
+				),
+			}
+		}
 	}, [name, details])
 }

--- a/Loader/TransitionUtils.ts
+++ b/Loader/TransitionUtils.ts
@@ -1,18 +1,18 @@
-import gsap from "gsap"
+import { useDeepCompareEffect, useEventListener } from "ahooks"
 import { navigate as gatsbyNavigate } from "gatsby"
+import gsap from "gsap"
 import ScrollSmoother from "gsap/ScrollSmoother"
+import ScrollToPlugin from "gsap/ScrollToPlugin"
 import { ScrollTrigger } from "gsap/ScrollTrigger"
 import { linkIsInternal, pathnameMatches, sleep } from "library/functions"
 import { pageReady, pageUnmounted } from "library/pageReady"
-import { useDeepCompareEffect, useEventListener } from "ahooks"
 import type { TransitionNames } from "libraryConfig"
 import libraryConfig from "libraryConfig"
+import { startTransition } from "react"
 import { loader } from "."
 import { getLoaderIsDone } from "./PreloaderUtils"
-import ScrollToPlugin from "gsap/ScrollToPlugin"
-import { startTransition } from "react"
-import { getScrollOffset, scrollToAnchor } from "./scrollToAnchor"
 import { allLoaderPromisesSettled } from "./promises"
+import { getScrollOffset, scrollToAnchor } from "./scrollToAnchor"
 
 gsap.registerPlugin(ScrollToPlugin)
 

--- a/Loader/UniversalLink.tsx
+++ b/Loader/UniversalLink.tsx
@@ -1,10 +1,9 @@
 import { Link } from "gatsby"
+import { linkIsInternal } from "library/functions"
 import libraryConfig from "libraryConfig"
 import type { CSSProperties, MouseEventHandler } from "react"
-
 import type { Transitions } from "."
 import { loadPage } from "./TransitionUtils"
-import { linkIsInternal } from "library/functions"
 
 export type UniversalLinkRef = HTMLButtonElement &
 	(HTMLAnchorElement & Link<unknown>)

--- a/Loader/UniversalLink.tsx
+++ b/Loader/UniversalLink.tsx
@@ -4,6 +4,7 @@ import type { CSSProperties, MouseEventHandler } from "react"
 
 import type { Transitions } from "."
 import { loadPage } from "./TransitionUtils"
+import { linkIsInternal } from "library/functions"
 
 export type UniversalLinkRef = HTMLButtonElement &
 	(HTMLAnchorElement & Link<unknown>)
@@ -94,7 +95,7 @@ export default function UniversalLink({
 		)
 	}
 
-	const internal = /^\/(?!\/)/.test(to)
+	const internal = linkIsInternal(to)
 
 	const handleClick: React.MouseEventHandler = (e) => {
 		e.preventDefault()

--- a/Loader/index.ts
+++ b/Loader/index.ts
@@ -1,80 +1,35 @@
 import TypedEventEmitter from "library/TypedEventEmitter"
-import { sleep } from "library/functions"
 import type { TransitionNames } from "libraryConfig"
 
 /**
  * transitionNames are configured in src/libraryConfig.ts
+ * you should't need to edit this file
  */
-export type Transitions = TransitionNames
-export type InternalTransitions = "initial" | "any" | "none"
+export type Transitions = TransitionNames | "instant"
+export type AllTransitions = Transitions | "initial"
 
-/**
- * EVENTS
- * anyStart
- * - fires when any animation starts, including initial page load
- *
- * anyEnd
- * - fires when any animation ends, including initial page load
- *
- * initialStart
- * - fires when initial page load transition starts
- *
- * initialEnd
- * - fires when initial page load transition ends
- *
- * transitionStart
- * - fires when any page transition starts
- * - event.detail is the transition name
- *
- * transitionCenter
- * - fires when the start of the transition finishes, before the end starts
- *
- * transitionEnd
- * - fires when any page transition ends
- * - event.detail is the transition name
- *
- * progressUpdated
- * - fires when the progress bar is updated
- * - event.detail is the new progress value
- *
- * scrollToTop
- * - fires when the page is scrolled to the top via a link click
- */
-const loader = new TypedEventEmitter<{
-	anyStart: [Transitions | InternalTransitions]
-	anyEnd: [Transitions | InternalTransitions]
-	initialStart: []
-	initialEnd: []
+export const loader = new TypedEventEmitter<{
+	/**
+	 * when the animation begins, i.e. when the page is loaded but the preloader is still fully visible
+	 */
+	start: [AllTransitions]
+	/**
+	 * when the animation ends, e.g. when the page is fully loaded and the preloader is hidden
+	 */
+	end: [AllTransitions]
+	/**
+	 * fires when the route changes. this occurs in between the start and end events
+	 */
+	routeChange: [AllTransitions]
+	/**
+	 * fires when clicking a link that is the current page or when clicking an anchor
+	 * @param transitionName the name of the anchor that was clicked if available
+	 */
+	scroll: [string | null]
+	/**
+	 * progressUpdated
+	 * on the initial page load, this tracks how close the page is to being fully loaded
+	 * @param progress the progress value from 0 to 100
+	 */
 	progressUpdated: [number]
-	transitionStart: [Transitions | InternalTransitions]
-	transitionEnd: [Transitions | InternalTransitions]
-	transitionCenter: [Transitions | InternalTransitions]
-	scrollTo: []
-}>()
-
-export default loader
-
-export const promisesToAwait: Promise<unknown>[] = []
-
-/**
- * wait for a promise to settle before transitioning to the next page
- * useful for waiting on a file, such as a video, to load
- * @param promise promise to await
- */
-export function transitionAwaitPromise(promise: Promise<unknown>) {
-	promisesToAwait.push(Promise.race([promise, sleep(10_000)]))
-}
-
-export const recursiveAllSettled = async (
-	promises: Promise<unknown>[],
-	promisesToExclude: Promise<unknown>[] = [],
-): Promise<void> => {
-	const promisesCopy = [...promises].filter(
-		(promise) => !promisesToExclude.includes(promise),
-	)
-	if (promisesCopy.length === 0) return
-
-	await Promise.allSettled(promisesCopy)
-	await recursiveAllSettled(promises, [...promisesToExclude, ...promisesCopy])
-	promisesToAwait.length = 0
-}
+}>(["end"])

--- a/Loader/index.ts
+++ b/Loader/index.ts
@@ -32,4 +32,7 @@ export const loader = new TypedEventEmitter<{
 	 * @param progress the progress value from 0 to 100
 	 */
 	progressUpdated: [number]
-}>(["end"])
+}>({
+	triggerHappyEvents: ["end"],
+	resetHappyEvents: ["start", "routeChange"],
+})

--- a/Loader/promises.ts
+++ b/Loader/promises.ts
@@ -1,0 +1,30 @@
+import { sleep } from "library/functions"
+
+const promisesToAwait: Promise<unknown>[] = []
+
+const recursiveAllSettled = async (
+	promises: Promise<unknown>[],
+	promisesToExclude: Promise<unknown>[] = [],
+): Promise<void> => {
+	const promisesCopy = [...promises].filter(
+		(promise) => !promisesToExclude.includes(promise),
+	)
+	if (promisesCopy.length === 0) return
+
+	await Promise.allSettled(promisesCopy)
+	await recursiveAllSettled(promises, [...promisesToExclude, ...promisesCopy])
+	promisesToAwait.length = 0
+}
+
+/**
+ * wait for a promise to settle before transitioning to the next page
+ * useful for waiting on a file, such as a video, to load
+ * @param promise promise to await
+ */
+export function loaderAwaitPromise(promise: Promise<unknown>) {
+	promisesToAwait.push(Promise.race([promise, sleep(10_000)]))
+}
+
+export function allLoaderPromisesSettled() {
+	return recursiveAllSettled(promisesToAwait)
+}

--- a/Loader/scrollToAnchor.ts
+++ b/Loader/scrollToAnchor.ts
@@ -26,6 +26,8 @@ export const scrollToAnchor = async (anchor: string) => {
 	let missingAnchorCount = 0
 
 	const attemptsNeeded = 20
+	const scrollForAtLeastMs = 400
+	const scrollUntil = Date.now() + scrollForAtLeastMs
 
 	return new Promise<void>((resolve) => {
 		const check = () => {
@@ -53,7 +55,7 @@ export const scrollToAnchor = async (anchor: string) => {
 				goodAttemptCount = 0
 			}
 
-			if (goodAttemptCount > attemptsNeeded) {
+			if (goodAttemptCount > attemptsNeeded && Date.now() < scrollUntil) {
 				requestAnimationFrame(() => resolve())
 			} else {
 				requestAnimationFrame(check)

--- a/Loader/scrollToAnchor.ts
+++ b/Loader/scrollToAnchor.ts
@@ -1,0 +1,65 @@
+import ScrollSmoother from "gsap/ScrollSmoother"
+import { ScrollTrigger } from "gsap/ScrollTrigger"
+
+/**
+ * returns the scroll offset of a given anchor by extracting it from the anchor element
+ * this allows fine-tuning of the anchor scroll position
+ */
+export const getScrollOffset = (anchor: string) => {
+	let scrollOffset = 100
+
+	if (anchor) {
+		const anchorEl = document.querySelector(anchor)
+		const anchorOffset = anchorEl?.getAttribute("data-anchor-offset")
+		scrollOffset += Number.parseFloat(anchorOffset ?? "0")
+	}
+
+	return scrollOffset
+}
+
+/**
+ * scroll to a given anchor until the scroll position stops changing
+ */
+export const scrollToAnchor = async (anchor: string) => {
+	let scrollPosition = 0
+	let goodAttemptCount = 0
+	let missingAnchorCount = 0
+
+	const attemptsNeeded = 20
+
+	return new Promise<void>((resolve) => {
+		const check = () => {
+			const anchorEl = document.querySelector(anchor)
+			if (!anchorEl) {
+				missingAnchorCount += 1
+				if (missingAnchorCount > 10) resolve()
+				requestAnimationFrame(check)
+				return
+			}
+
+			const scrollOffset = getScrollOffset(anchor)
+			ScrollTrigger.refresh()
+			// in order to properly scroll to the anchor, we need to unpause the smoother
+			ScrollSmoother.get()?.paused(false)
+			ScrollSmoother.get()?.scrollTo(anchor, false, `top: ${scrollOffset}px`)
+			const newPosition = ScrollSmoother.get()?.scrollTop() ?? 0
+
+			// if we moved less than 10 pixels, count it as a good attempt
+			// otherwise reset the counter
+			if (Math.abs(newPosition - scrollPosition) < 10) {
+				goodAttemptCount += 1
+			} else {
+				scrollPosition = newPosition
+				goodAttemptCount = 0
+			}
+
+			if (goodAttemptCount > attemptsNeeded) {
+				requestAnimationFrame(() => resolve())
+			} else {
+				requestAnimationFrame(check)
+			}
+		}
+
+		check()
+	})
+}

--- a/Loader/scrollToAnchor.ts
+++ b/Loader/scrollToAnchor.ts
@@ -26,8 +26,6 @@ export const scrollToAnchor = async (anchor: string) => {
 	let missingAnchorCount = 0
 
 	const attemptsNeeded = 20
-	const scrollForAtLeastMs = 400
-	const scrollUntil = Date.now() + scrollForAtLeastMs
 
 	return new Promise<void>((resolve) => {
 		const check = () => {
@@ -55,7 +53,7 @@ export const scrollToAnchor = async (anchor: string) => {
 				goodAttemptCount = 0
 			}
 
-			if (goodAttemptCount > attemptsNeeded && Date.now() < scrollUntil) {
+			if (goodAttemptCount > attemptsNeeded) {
 				requestAnimationFrame(() => resolve())
 			} else {
 				requestAnimationFrame(check)

--- a/TypedEventEmitter.ts
+++ b/TypedEventEmitter.ts
@@ -8,6 +8,19 @@ export default class TypedEventEmitter<
 	private eventListeners: {
 		[K in keyof EventMap]?: Set<Listener<EventMap[K]>>
 	} = {}
+	private mostRecentEvent:
+		| {
+				[K in keyof EventMap]?: {
+					name: K
+					args: EventMap[K]
+				}
+		  }[keyof EventMap]
+		| null = null
+	private triggerHappyEvents: (keyof EventMap)[]
+
+	public constructor(triggerHappyEvents?: (keyof EventMap)[]) {
+		this.triggerHappyEvents = triggerHappyEvents ?? []
+	}
 
 	public addEventListener<K extends keyof EventMap>(
 		eventName: K,
@@ -16,6 +29,14 @@ export default class TypedEventEmitter<
 		const listeners = this.eventListeners[eventName] ?? new Set()
 		listeners.add(listener)
 		this.eventListeners[eventName] = listeners
+
+		// if this event is a happy event and the most recent event is the same type, fire it immediately
+		if (
+			this.triggerHappyEvents.includes(eventName) &&
+			this.mostRecentEvent?.name === eventName
+		) {
+			listener(...(this.mostRecentEvent.args as EventMap[K]))
+		}
 	}
 
 	public removeEventListener<K extends keyof EventMap>(
@@ -31,6 +52,7 @@ export default class TypedEventEmitter<
 		eventName: K,
 		...args: EventMap[K]
 	) {
+		this.mostRecentEvent = { name: eventName, args }
 		const listeners = this.eventListeners[eventName] ?? new Set()
 		for (const listener of listeners) {
 			listener(...args)

--- a/defaultConfig.ts
+++ b/defaultConfig.ts
@@ -1,4 +1,4 @@
-import type { TransitionNames } from "libraryConfig"
+import type { Transitions } from "./Loader"
 
 /**
  * config schema and config defaults for the reform util library
@@ -18,10 +18,16 @@ export type Config = {
 	/**
 	 * the default transition to use if none is specified
 	 */
-	defaultTransition: TransitionNames
+	defaultTransition: Transitions
+	/**
+	 * should the page preserve the scroll position when reloading or when clicking back/forward
+	 */
+	scrollRestoration: boolean
 }
 
 export const defaultConfig = {
+	defaultTransition: "instant",
 	scaleFully: false,
 	getTimeNeeded: (startTime: number) => startTime * 2 + 1000,
+	scrollRestoration: true,
 } as const satisfies Partial<Config>

--- a/functions.ts
+++ b/functions.ts
@@ -24,6 +24,10 @@ export function pathnameMatches(pathA: string, pathB: string) {
 	return pathA === pathB || pathA === `${pathB}/` || pathB === `${pathA}/`
 }
 
+export function linkIsInternal(to: string) {
+	return /^\/(?!\/)/.test(to) || to.startsWith("#")
+}
+
 export const getRandomInt = (min: number, max: number) => {
 	return Math.floor(Math.random() * (max - min + 1) + min)
 }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
 	"version": "1.0.0",
 	"description": "collection of utilities and helpers for reform collective",
 	"dependencies": {
-		"@contentful/rich-text-react-renderer": "^15.19.6",
-		"@contentful/rich-text-types": "^16.3.5",
+		"@contentful/rich-text-react-renderer": "^15.20.0",
+		"@contentful/rich-text-types": "^16.4.0",
 		"@react-three/drei": "^9.105.6",
-		"@react-three/fiber": "^8.16.3",
-		"@types/three": "^0.164.0",
+		"@react-three/fiber": "^8.16.6",
+		"@types/three": "^0.164.1",
 		"ahooks": "^3.7.11",
 		"use-deep-compare": "1.2.1"
 	}


### PR DESCRIPTION
**- better anchor handling**
behind the scenes the system for scrolling to anchors is a bit more robust, and data-anchor-offset is always used

**- simpler events system**
fewer events, 'start' and 'end' replace 'anyEnd', 'transitionStart', etc. 'transitionCenter' is now 'routeChange' and is also fired for instant route changes. useRegisterLoaderCallback is now usePreloader and useRegisterTransition is now usePageTransition

**- support delayed end event listeners**
'end' events will more consistently fire after the page has loaded

**- improved scroll restoration, which can be disabled entirely if desired**
this is configured in libraryConfig and should now work even on sites with page transitions

**- easily use different preloader animations when scroll position is restored**
this is a new option on usePreloader called 'only'