### PR TITLE
library config saveAnchorNames

### DIFF
--- a/Loader/PreloaderUtils.ts
+++ b/Loader/PreloaderUtils.ts
@@ -94,7 +94,6 @@ async function onComplete() {
 	 */
 	const anchor = window.location.hash
 	if (anchor) {
-		console.log(anchor)
 		await scrollToAnchor(anchor)
 	}
 

--- a/Loader/TransitionUtils.ts
+++ b/Loader/TransitionUtils.ts
@@ -240,6 +240,15 @@ const navigate = (to: string, cleanupFunction?: VoidFunction) => {
 		startTransition(() => {
 			gatsbyNavigate(to)
 		})
+
+		pageUnmounted().then(() => {
+			// scrub the anchor from the URL if needed
+			if (!libraryConfig.saveAnchorNames) {
+				const newURL = new URL(window.location.href)
+				newURL.hash = ""
+				window.history.replaceState({}, "", newURL.toString())
+			}
+		})
 	}
 }
 

--- a/Loader/TransitionUtils.ts
+++ b/Loader/TransitionUtils.ts
@@ -79,7 +79,8 @@ export const loadPage = async (
 		const scrollLock = createScrollLock("unlock")
 
 		// save the anchor to the URL
-		window.history.replaceState({}, "", navigateTo)
+		if (libraryConfig.saveAnchorNames)
+			window.history.replaceState({}, "", navigateTo)
 
 		// scroll to anchor if applicable, otherwise scroll to top
 		const scrollTo = (smooth: boolean) => {

--- a/Loader/TransitionUtils.ts
+++ b/Loader/TransitionUtils.ts
@@ -5,7 +5,7 @@ import ScrollSmoother from "gsap/ScrollSmoother"
 import ScrollToPlugin from "gsap/ScrollToPlugin"
 import { ScrollTrigger } from "gsap/ScrollTrigger"
 import { createScrollLock } from "library/Scroll"
-import { linkIsInternal, pathnameMatches, sleep } from "library/functions"
+import { linkIsExternal, pathnameMatches, sleep } from "library/functions"
 import { pageReady, pageUnmounted } from "library/pageReady"
 import type { TransitionNames } from "libraryConfig"
 import libraryConfig from "libraryConfig"
@@ -227,7 +227,7 @@ export const loadPage = async (
  * @param cleanupFunction a function to reset the page to its original state (if back button is pressed after external link)
  */
 const navigate = (to: string, cleanupFunction?: VoidFunction) => {
-	const isExternal = !linkIsInternal(to)
+	const isExternal = linkIsExternal(to)
 
 	if (isExternal) {
 		window.open(to)

--- a/Loader/TransitionUtils.ts
+++ b/Loader/TransitionUtils.ts
@@ -237,17 +237,15 @@ const navigate = (to: string, cleanupFunction?: VoidFunction) => {
 			cleanupFunction?.()
 		}, 1000)
 	} else {
-		startTransition(() => {
-			gatsbyNavigate(to)
-		})
+		const destination = new URL(to, window.location.origin)
 
-		pageUnmounted().then(() => {
-			// scrub the anchor from the URL if needed
-			if (!libraryConfig.saveAnchorNames) {
-				const newURL = new URL(window.location.href)
-				newURL.hash = ""
-				window.history.replaceState({}, "", newURL.toString())
-			}
+		// scrub the hash from the URL if needed
+		if (!libraryConfig.saveAnchorNames) {
+			destination.hash = ""
+		}
+
+		startTransition(() => {
+			gatsbyNavigate(destination.toString())
 		})
 	}
 }

--- a/Loader/scrollToAnchor.ts
+++ b/Loader/scrollToAnchor.ts
@@ -1,6 +1,7 @@
 import ScrollSmoother from "gsap/ScrollSmoother"
 import { ScrollTrigger } from "gsap/ScrollTrigger"
 import { refreshScrollLocks } from "library/Scroll"
+import libraryConfig from "libraryConfig"
 
 /**
  * returns the scroll offset of a given anchor by extracting it from the anchor element
@@ -63,5 +64,12 @@ export const scrollToAnchor = async (anchor: string) => {
 		}
 
 		check()
+	}).then(() => {
+		// scrub the anchor from the URL if needed
+		if (!libraryConfig.saveAnchorNames) {
+			const newURL = new URL(window.location.href)
+			newURL.hash = ""
+			window.history.replaceState({}, "", newURL.toString())
+		}
 	})
 }

--- a/Loader/scrollToAnchor.ts
+++ b/Loader/scrollToAnchor.ts
@@ -1,7 +1,6 @@
 import ScrollSmoother from "gsap/ScrollSmoother"
 import { ScrollTrigger } from "gsap/ScrollTrigger"
 import { refreshScrollLocks } from "library/Scroll"
-import libraryConfig from "libraryConfig"
 
 /**
  * returns the scroll offset of a given anchor by extracting it from the anchor element
@@ -64,12 +63,5 @@ export const scrollToAnchor = async (anchor: string) => {
 		}
 
 		check()
-	}).then(() => {
-		// scrub the anchor from the URL if needed
-		if (!libraryConfig.saveAnchorNames) {
-			const newURL = new URL(window.location.href)
-			newURL.hash = ""
-			window.history.replaceState({}, "", newURL.toString())
-		}
 	})
 }

--- a/UniversalImage.tsx
+++ b/UniversalImage.tsx
@@ -25,5 +25,7 @@ export default function UniversalImage({
 
 	const imageToUse =
 		"childImageSharp" in image ? image.childImageSharp?.gatsbyImageData : image
-	return imageToUse ? <GatsbyImage image={imageToUse} {...props} /> : null
+	return imageToUse ? (
+		<GatsbyImage loading="lazy" image={imageToUse} {...props} />
+	) : null
 }

--- a/defaultConfig.ts
+++ b/defaultConfig.ts
@@ -23,6 +23,10 @@ export type Config = {
 	 * should the page preserve the scroll position when reloading or when clicking back/forward
 	 */
 	scrollRestoration: boolean
+	/**
+	 * should anchor names be saved to the URL? when e.g. scrolling to a section
+	 */
+	saveAnchorNames: boolean
 }
 
 export const defaultConfig = {
@@ -30,4 +34,5 @@ export const defaultConfig = {
 	scaleFully: false,
 	getTimeNeeded: (startTime: number) => startTime * 2 + 1000,
 	scrollRestoration: true,
-} as const satisfies Partial<Config>
+	saveAnchorNames: true,
+} as const satisfies Exclude<Config, "defaultTransition">

--- a/defaultConfig.ts
+++ b/defaultConfig.ts
@@ -35,4 +35,4 @@ export const defaultConfig = {
 	getTimeNeeded: (startTime: number) => startTime * 2 + 1000,
 	scrollRestoration: true,
 	saveAnchorNames: true,
-} as const satisfies Exclude<Config, "defaultTransition">
+} as const satisfies Partial<Config>

--- a/functions.ts
+++ b/functions.ts
@@ -1,3 +1,5 @@
+import { isBrowser } from "./deviceDetection"
+
 export const addDebouncedEventListener = (
 	element: Window | HTMLElement,
 	event: string,
@@ -33,6 +35,9 @@ const parseURL = (url: string, base?: string) => {
 }
 
 export function linkIsInternal(to: string) {
+	// if we're not in the browser, we can't parse URLs accurately
+	if (!isBrowser) return false
+
 	// attempt to parse this as standalone, else try to parse it as relative
 	const parsed = parseURL(to) || parseURL(to, window.location.origin)
 

--- a/functions.ts
+++ b/functions.ts
@@ -24,8 +24,27 @@ export function pathnameMatches(pathA: string, pathB: string) {
 	return pathA === pathB || pathA === `${pathB}/` || pathB === `${pathA}/`
 }
 
+const parseURL = (url: string, base?: string) => {
+	try {
+		return new URL(url, base)
+	} catch (error) {
+		return undefined
+	}
+}
+
 export function linkIsInternal(to: string) {
-	return /^\/(?!\/)/.test(to) || to.startsWith("#")
+	// attempt to parse this as standalone, else try to parse it as relative
+	const parsed = parseURL(to) || parseURL(to, window.location.origin)
+
+	// if we can't parse it, assume it's external
+	if (!parsed) return false
+
+	// if the origin matches, it's internal
+	return parsed.origin === window.location.origin
+}
+
+export function linkIsExternal(to: string) {
+	return !linkIsInternal(to)
 }
 
 export const getRandomInt = (min: number, max: number) => {


### PR DESCRIPTION
if true (default) use standard web behavior of writing the anchor name to the URL
e.g. `https://www.example.com/#section-1`

if false, scrub all anchors from the user facing URL (but maintain the scrolling functionality)
e.g. `https://www.example.com/`