### PR TITLE
prevent preloaders from getting stuck in an invalid state

### DIFF
--- a/ScaledContent.tsx
+++ b/ScaledContent.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react"
 import styled from "styled-components"
 import { useClientOnly } from "./ClientOnly"
+import { isBrowser } from "./deviceDetection"
 
 /**
  * scales it's content to a certain size while maintaining
@@ -18,7 +19,10 @@ export default function ScaledContent({
 	const outer = useRef<HTMLDivElement | null>(null)
 	const inner = useRef<HTMLDivElement | null>(null)
 
-	const supportsCssZoom = useClientOnly(window.CSS.supports("zoom", "1"), true)
+	const supportsCssZoom = useClientOnly(
+		isBrowser && window.CSS.supports("zoom", "1"),
+		true,
+	)
 
 	useEffect(() => {
 		if (!outer.current || !inner.current) return

--- a/functions.ts
+++ b/functions.ts
@@ -44,8 +44,13 @@ export function linkIsInternal(to: string) {
 	// if we can't parse it, assume it's external
 	if (!parsed) return false
 
-	// if the origin matches, it's internal
-	return parsed.origin === window.location.origin
+	// if the host matches, it's internal
+	return (
+		parsed.host === window.location.host ||
+		// www.origin.com and origin.com are both considered internal
+		`www.${parsed.host}` === window.location.host ||
+		parsed.host === `www.${window.location.host}`
+	)
 }
 
 export function linkIsExternal(to: string) {


### PR DESCRIPTION
this usually happens when the page is updated via HMR, but in theory it could happen in build as well