### PR TITLE
Refactor useAutoHideHeader hook

### DIFF
--- a/useAnimation.ts
+++ b/useAnimation.ts
@@ -91,7 +91,10 @@ const useAnimation = <F, T>(
 	useEffectToUse(() => {
 		// create animations using a gsap context so they can be reverted easily
 		const ctx = gsap.context(() => {
+			const former = window.gsap
+			window.gsap = gsap
 			const result = createAnimations()
+			window.gsap = former
 			if (typeof result === "function") {
 				return result
 			}

--- a/useAutoHideHeader.ts
+++ b/useAutoHideHeader.ts
@@ -1,6 +1,8 @@
+import gsap from "gsap"
 import { ScrollSmoother } from "gsap/ScrollSmoother"
 import { ScrollTrigger } from "gsap/ScrollTrigger"
-import { type RefObject, useEffect, useRef, useState } from "react"
+import { type RefObject, useRef } from "react"
+import useAnimation from "./useAnimation"
 
 const isElementInViewport = (element: HTMLElement) => {
 	const rect = element?.getBoundingClientRect()
@@ -11,8 +13,12 @@ const isElementInViewport = (element: HTMLElement) => {
 	)
 }
 
-const checkElementsInViewport = (id: string) => {
-	const elements = document.querySelectorAll(`[id^="${id}"]`)
+/**
+ * check if any elements with the given attribute are in the viewport
+ * @param attribute the attribute to check for
+ */
+const checkElementsByAttribute = (attribute: string) => {
+	const elements = document.querySelectorAll(`[${attribute}]`)
 	for (const element of elements) {
 		if (isElementInViewport(element as HTMLElement)) {
 			return true
@@ -24,26 +30,31 @@ const checkElementsInViewport = (id: string) => {
 /**
  * A custom hook that controls header visibility based on scroll position and specified elements.
  *
- * Add the `hide-header` ID to an element to hide the header when it is in view.
- * Add the `stick-header` ID to an element to stick the header when it is in view.
+ * Add the `data-header-hide` attribute to an element to hide the header when it is in view.
+ * Add the `data-header-stick` ID to an element to show the header when it is in view.
  *
- * @param wrapper The ref object of the header element.
- * @returns The current translateY value for the header, which allows for vertical positioning.
+ * @param wrapper ref pointing to the element to the header
+ * @param style the style to use for the header, either "scrub" which will sync with the scroller or "snap" which animates in either direction
  */
 export default function useAutoHideHeader(
-	wrapper: RefObject<HTMLDivElement>,
-	style: "scrub" | "snap" = "snap",
+	wrapper: RefObject<HTMLDivElement> | null | undefined,
+	style: "scrub" | "snap" = "scrub",
 ) {
-	const [translateY, setTranslateY] = useState(0)
-	const translateYRef = useRef(0)
+	const translateY = useRef(0)
 
-	// Update translateYRef whenever the state variables changes.
-	useEffect(() => {
-		translateYRef.current = translateY
-	}, [translateY])
+	// if we're on scrub style, we want instant set, but this would cause a jump
+	// whenever we transition from a forced stick/hide to a normal scroll based value
+	// so tween the duration from 0.5 to 0 to avoid this
+	const duration = useRef(0.5)
 
-	useEffect(() => {
+	useAnimation(() => {
 		let lastScroll = 0
+		if (!wrapper) return
+
+		const props = {
+			ease: "power3.out",
+			duration: 0.3,
+		}
 
 		ScrollTrigger.create({
 			onUpdate: () => {
@@ -52,38 +63,43 @@ export default function useAutoHideHeader(
 				lastScroll = scroll
 				const height = wrapper.current?.offsetHeight ?? 0
 
-				// Check for elements that have the specified IDs.
-				const shouldHideHeader = checkElementsInViewport("hide-header")
-				const shouldStickyHeader = checkElementsInViewport("stick-header")
+				const shouldHideHeader = checkElementsByAttribute("data-header-hide")
+				const shouldStickyHeader = checkElementsByAttribute("data-header-stick")
 
-				if (shouldHideHeader) {
-					setTranslateY(-height)
-				} else if (shouldStickyHeader) {
-					setTranslateY(0)
-				} else {
-					if (scroll === 0) {
-						translateYRef.current = 0
-					} else if (delta > 0) {
-						if (style === "scrub") {
-							translateYRef.current = Math.max(
-								-height,
-								translateYRef.current - delta,
-							)
-						} else {
-							translateYRef.current = -height
-						}
-					} else {
-						if (style === "scrub") {
-							translateYRef.current = Math.min(0, translateYRef.current - delta)
-						} else {
-							translateYRef.current = 0
-						}
-					}
-					setTranslateY(translateYRef.current)
+				// if forced sticky
+				if (
+					shouldStickyHeader ||
+					(style === "snap" && delta < 0) ||
+					scroll === 0
+				) {
+					duration.current = 0.5
+					gsap.to(wrapper.current, {
+						y: 0,
+						...props,
+					})
+				}
+				// if forced not sticky
+				else if (shouldHideHeader || (style === "snap" && delta > 0)) {
+					duration.current = 0.5
+					gsap.to(wrapper.current, {
+						y: -height,
+						...props,
+					})
+				}
+				// scrub behavior, if needed
+				else if (style === "scrub") {
+					translateY.current = Math.min(
+						0,
+						Math.max(-height, translateY.current - delta),
+					)
+					gsap.to(duration, { current: 0, ease: "linear" })
+					gsap.to(wrapper.current, {
+						y: translateY.current,
+						...props,
+						duration: duration.current,
+					})
 				}
 			},
 		})
 	}, [wrapper, style])
-
-	return translateY
 }

--- a/useAutoHideHeader.ts
+++ b/useAutoHideHeader.ts
@@ -31,7 +31,7 @@ const checkElementsByAttribute = (attribute: string) => {
  * A custom hook that controls header visibility based on scroll position and specified elements.
  *
  * Add the `data-header-hide` attribute to an element to hide the header when it is in view.
- * Add the `data-header-stick` ID to an element to show the header when it is in view.
+ * Add the `data-header-stick` attribute to an element to show the header when it is in view.
  *
  * @param wrapper ref pointing to the element to the header
  * @param style the style to use for the header, either "scrub" which will sync with the scroller or "snap" which animates in either direction

--- a/useAutoHideHeader.ts
+++ b/useAutoHideHeader.ts
@@ -70,7 +70,8 @@ export default function useAutoHideHeader(
 				if (
 					shouldStickyHeader ||
 					(style === "snap" && delta < 0) ||
-					scroll === 0
+					scroll === 0 ||
+					window.scrollY === 0
 				) {
 					duration.current = 0.5
 					gsap.to(wrapper.current, {


### PR DESCRIPTION
useAutoHideHeader hook has been refactored to improve performance and readability

internal logic has been heavily simplified

uses attributes instead of id to show/hide header (since having multiple matching id's is bad)

set the translate on the header directly, rather than setting state (because state is slow comparatively)

this also improves the visual experience of a scrubbed header


# Breaking Change
before:
`<div id='stick-header' />`
after:
`<div data-header-stick />`

before:
`<div id='hide-header' />`
after:
`<div data-header-hide />`