### PR TITLE
Type Safe Link Support & Cleanup

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -22,7 +22,6 @@ jobs:
         uses: oNaiPs/secrets-to-env-action@v1.5
         with:
           secrets: ${{ secrets.SECRETS_JSON }}
-      - run: touch .env
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -22,6 +22,7 @@ jobs:
         uses: oNaiPs/secrets-to-env-action@v1.5
         with:
           secrets: ${{ secrets.SECRETS_JSON }}
+      - run: touch .env
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -81,7 +81,7 @@ jobs:
         id: deployment
         # don't skip if unlighthouse fails
         if: always()
-        uses: rjwadley/pr-preview-action@v1
+        uses: rjwadley/pr-preview-action@c7b44485908d30d2d062ce01794660fceb4688ab
         with:
           source-dir: ./report/
           umbrella-dir: ${{ github.repository }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -69,7 +69,7 @@ jobs:
         id: deployment
         # don't skip if unlighthouse fails
         if: always()
-        uses: rossjrw/pr-preview-action@v1
+        uses: rjwadley/pr-preview-action@v1
         with:
           source-dir: ./report/
           umbrella-dir: ${{ github.repository }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -27,7 +27,6 @@ jobs:
         uses: oNaiPs/secrets-to-env-action@v1.5
         with:
           secrets: ${{ secrets.SECRETS_JSON }}
-      - run: touch .env
 
       # BEGIN INSTALLATION
       - uses: actions/checkout@v4
@@ -81,7 +80,7 @@ jobs:
         id: deployment
         # don't skip if unlighthouse fails
         if: always()
-        uses: rjwadley/pr-preview-action@c7b44485908d30d2d062ce01794660fceb4688ab
+        uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./report/
           umbrella-dir: ${{ github.repository }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -27,6 +27,7 @@ jobs:
         uses: oNaiPs/secrets-to-env-action@v1.5
         with:
           secrets: ${{ secrets.SECRETS_JSON }}
+      - run: touch .env
 
       # BEGIN INSTALLATION
       - uses: actions/checkout@v4

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -72,7 +72,8 @@ jobs:
         run: pnpm dlx unlighthouse-ci --site http://localhost:${{ steps.port.outputs.port }}/ --router-prefix "/lighthouse/${{ github.repository }}/pr-${{ github.event.pull_request.number }}" --build-static --output-path ./report
 
       - name: kill the server
-        if: github.event.action != 'closed'
+        # don't skip if unlighthouse fails
+        if: always()
         run: kill -9 $(lsof -t -i:${{ steps.port.outputs.port }})
         continue-on-error: true
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -48,14 +48,20 @@ jobs:
         if: github.event.action != 'closed'
         run: pnpm run build
 
-      - name: kill the process running on port 3000
-        if: github.event.action != 'closed'
-        run: kill -9 $(lsof -t -i:3000)
-        continue-on-error: true
+      - name: find an open port >= 3000
+        id: port
+        run: |
+          while true; do
+            port=$((RANDOM%10000 + 3000))
+            if ! lsof -i:$port -t; then
+              echo "port=$port" >> $GITHUB_OUTPUT
+              break
+            fi
+          done
 
       - name: Serve
         if: github.event.action != 'closed'
-        run: pnpm run serve & SERVER_PID=$!
+        run: pnpm run serve --port ${{ steps.port.outputs.port }} & exit 0
 
       - name: Wait for server...
         if: github.event.action != 'closed'
@@ -64,6 +70,11 @@ jobs:
       - name: Run Unlighthouse
         if: github.event.action != 'closed'
         run: pnpm dlx unlighthouse-ci --site http://localhost:3000/ --router-prefix "/lighthouse/${{ github.repository }}/pr-${{ github.event.pull_request.number }}" --build-static --output-path ./report
+
+      - name: kill the server
+        if: github.event.action != 'closed'
+        run: kill -9 $(lsof -t -i:${{ steps.port.outputs.port }})
+        continue-on-error: true
 
       - name: Deploy preview
         id: deployment

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -51,6 +51,7 @@ jobs:
       - name: kill the process running on port 3000
         if: github.event.action != 'closed'
         run: kill -9 $(lsof -t -i:3000)
+        continue-on-error: true
 
       - name: Serve
         if: github.event.action != 'closed'

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Run Unlighthouse
         if: github.event.action != 'closed'
-        run: pnpm dlx unlighthouse-ci --site http://localhost:3000/ --router-prefix "/lighthouse/${{ github.repository }}/pr-${{ github.event.pull_request.number }}" --build-static --output-path ./report
+        run: pnpm dlx unlighthouse-ci --site http://localhost:${{ steps.port.outputs.port }}/ --router-prefix "/lighthouse/${{ github.repository }}/pr-${{ github.event.pull_request.number }}" --build-static --output-path ./report
 
       - name: kill the server
         if: github.event.action != 'closed'

--- a/Loader/UniversalLink.tsx
+++ b/Loader/UniversalLink.tsx
@@ -25,7 +25,7 @@ type AnchorProps = {
 	/**
 	 * where should the link navigate to?
 	 */
-	href: Route | string | null | undefined
+	href: Route | string | null | undefined | { href: `https://${string}` }
 	/**
 	 * which transition should be used when navigating to this link?
 	 */
@@ -65,7 +65,9 @@ export default function UniversalLink({
 
 	const href =
 		props.href && typeof props.href === "object"
-			? route(props.href)
+			? "href" in props.href
+				? props.href.href
+				: route(props.href)
 			: props.href
 	const internal = href ? linkIsInternal(href) : false
 	const router = useRouter()
@@ -90,7 +92,7 @@ export default function UniversalLink({
 		<Link
 			onClick={handleClick}
 			{...props}
-			// biome-ignore lint/suspicious/noExplicitAny: I am very intentionally disabling type checking here because a cast would not be universally compatible
+			// biome-ignore lint/suspicious/noExplicitAny: I am very intentionally disabling type checking here because a cast would not be backwards compatible
 			href={href as any}
 		>
 			{children}

--- a/Loader/UniversalLink.tsx
+++ b/Loader/UniversalLink.tsx
@@ -3,65 +3,40 @@
 import libraryConfig from "libraryConfig"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import type { CSSProperties, MouseEventHandler } from "react"
+import type { Route } from "nextjs-routes"
+import { route } from "nextjs-routes"
+import type { ComponentProps } from "react"
 import type { Transitions } from "."
 import { linkIsInternal } from "../functions"
 import { loadPage } from "./TransitionUtils"
 
-interface BaseLinkProps {
-	/**
-	 * should the link open in a new tab?
-	 */
-	openInNewTab?: boolean
-	children: React.ReactNode
-	className?: string
-	onMouseEnter?: MouseEventHandler
-	onMouseLeave?: MouseEventHandler
-	ariaLabel?: string
-	anchor?: string
-	"aria-disabled"?: boolean
-	style?: CSSProperties
-}
-
-interface ButtonProps extends BaseLinkProps {
-	/**
-	 * what should happen when the button is clicked?
-	 */
-	onClick?: MouseEventHandler
+type ButtonProps = {
 	/**
 	 * what type of button is this?
 	 */
 	type: "submit" | "button" | "reset"
-	/**
-	 * forward a ref to the button
-	 */
-	ref?: React.RefObject<HTMLButtonElement | null>
-	/**
-	 * Do you want to scroll to a specific location after the transition?
-	 */
-	anchor?: string
 
 	href?: undefined
 	transition?: undefined
-}
+	openInNewTab?: undefined
+} & Omit<ComponentProps<"button">, "type">
 
-interface AnchorProps extends BaseLinkProps {
+type AnchorProps = {
 	/**
 	 * where should the link navigate to?
 	 */
-	href: string | null | undefined
+	href: Route | string | null | undefined
 	/**
 	 * which transition should be used when navigating to this link?
 	 */
 	transition?: Transitions
 	/**
-	 * forward a ref to the link or anchor tag
+	 * open this link in a new tab?
 	 */
-	ref?: React.RefObject<HTMLAnchorElement | null>
+	openInNewTab?: boolean
 
-	onClick?: undefined
 	type?: undefined
-}
+} & Omit<ComponentProps<"a">, "href" | "onClick">
 
 export type UniversalLinkProps = ButtonProps | AnchorProps
 
@@ -70,21 +45,14 @@ export type UniversalLinkProps = ButtonProps | AnchorProps
  * @returns
  */
 export default function UniversalLink({
-	href,
-	transition = libraryConfig.defaultTransition,
-	openInNewTab = false,
-	ref,
-	type,
 	children,
-	ariaLabel,
+	transition = libraryConfig.defaultTransition,
+	openInNewTab,
 	...props
 }: UniversalLinkProps) {
-	if (type) {
+	if (props.type) {
 		return (
 			<button
-				type={type}
-				ref={ref}
-				aria-label={ariaLabel}
 				{...props}
 				style={{
 					cursor: "pointer",
@@ -95,6 +63,10 @@ export default function UniversalLink({
 		)
 	}
 
+	const href =
+		props.href && typeof props.href === "object"
+			? route(props.href)
+			: props.href
 	const internal = href ? linkIsInternal(href) : false
 	const router = useRouter()
 
@@ -106,28 +78,25 @@ export default function UniversalLink({
 			window.open(href, "_blank")
 		} else {
 			router.prefetch(href)
-			loadPage({ to: href, transition, routerNavigate: router.push })
+			loadPage({
+				to: href,
+				transition,
+				routerNavigate: router.push as (url: string) => unknown,
+			})
 		}
 	}
 
 	return internal && href ? (
 		<Link
-			href={href}
 			onClick={handleClick}
-			ref={ref}
-			aria-label={ariaLabel}
 			{...props}
+			// biome-ignore lint/suspicious/noExplicitAny: I am very intentionally disabling type checking here because a cast would not be universally compatible
+			href={href as any}
 		>
 			{children}
 		</Link>
 	) : (
-		<a
-			href={href ?? undefined}
-			onClick={handleClick}
-			ref={ref}
-			aria-label={ariaLabel}
-			{...props}
-		>
+		<a onClick={handleClick} {...props} href={href ?? undefined}>
 			{children}
 		</a>
 	)

--- a/gsapHelpers/horizontalLoop.js
+++ b/gsapHelpers/horizontalLoop.js
@@ -237,7 +237,7 @@ export function horizontalLoop(items, config) {
 					hasMoved = false
 					const x = this.x
 					gsap.killTweensOf(tl)
-					wasPlaying = !tl.paused()
+					wasPlaying = wasPlaying || !tl.paused()
 					tl.pause()
 					startProgress = tl.progress()
 					refresh()

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"dependencies": {
 		"@gsap/react": "^2",
 		"ahooks": "^3",
-		"lenis": "^1.1.19",
+		"lenis": "^1.1.20",
 		"minisearch": "^7",
 		"restyle": "^3.1.1",
 		"sanity-image": "^0.2.0",


### PR DESCRIPTION
this lets you optionally write type safe links by passing an object to href.

```javascript
// will be type checked for validity
<UniversalLink href={{ pathname: '/home/blog' }}>blog</UniversalLink>
<UniversalLink href={{ href: 'https://google.com' }}>blog</UniversalLink>

// will not be checked
<UniversalLink href={'/home/blog'}>blog</UniversalLink>
<UniversalLink href={'https://google.com'}>blog</UniversalLink>
```

to add support to existing projects:

```typescript
// next.config.ts
import nextRoutes from "nextjs-routes/config"
const withRoutes = nextRoutes({
	outDir: "app/types",
})

// your config

export default withRoutes(nextConfig)
```

and add to your gitignore:
```
nextjs-routes.d.ts
```