### PR TITLE
Page Transition Support

### DIFF
--- a/defaultConfig.ts
+++ b/defaultConfig.ts
@@ -3,28 +3,11 @@
  * see app/libraryConfig.ts for the actual config
  */
 
-type Config<TransitionName extends string> = {
+type Config = {
 	/**
 	 * if true, the fresponsive util will scale on fullWidth breakpoints
 	 */
 	scaleFully: boolean
-	/**
-	 * get the amount of time needed to load the page
-	 * @param startTime the number of MS the page spent loading on the network so far
-	 */
-	getTimeNeeded: (startTime: number) => number
-	/**
-	 * extra delay to add to preloader
-	 */
-	extraLoaderDelay: number
-	/**
-	 * list of available view transitions
-	 */
-	viewTransitions: Record<TransitionName, () => unknown>
-	/**
-	 * which transition should be used by default?
-	 */
-	defaultViewTransition: NoInfer<TransitionName> | "instant" | "default"
 	/**
 	 * should the page preserve the scroll position when reloading or when clicking back/forward
 	 */
@@ -36,16 +19,12 @@ type Config<TransitionName extends string> = {
 }
 
 const defaultConfig = {
-	defaultViewTransition: "instant",
 	scaleFully: false,
-	getTimeNeeded: (startTime: number) => startTime + 1000,
 	scrollRestoration: true,
 	saveAnchorNames: true,
-	extraLoaderDelay: 0,
-	viewTransitions: {},
-} as const satisfies Config<never>
+} as const satisfies Config
 
-export const defineLibraryConfig = <SetConfig extends Partial<Config<string>>>(
+export const defineLibraryConfig = <SetConfig extends Partial<Config>>(
 	config: SetConfig,
 ) => ({
 	...defaultConfig,

--- a/link/index.tsx
+++ b/link/index.tsx
@@ -1,10 +1,8 @@
 "use client"
 
-import libraryConfig from "libraryConfig"
 import Link, { type LinkProps } from "next/link"
 import type { ComponentProps, Ref } from "react"
 import { linkIsInternal } from "../functions"
-import type { Transitions } from "./loader"
 import { useTransitioner } from "./transitioner"
 
 type CMSLink = {
@@ -42,7 +40,6 @@ type AnchorProps = {
 	 * open this link in a new tab?
 	 */
 	openInNewTab?: boolean
-	transition?: Transitions
 	/**
 	 * take action during, or block, an internal navigation
 	 * this does not apply to external links
@@ -111,7 +108,6 @@ export const resolveRoute = (
 export default function UniversalLink({
 	children,
 	ref,
-	transition = libraryConfig.defaultViewTransition,
 	onNavigate,
 	...props
 }: UniversalLinkProps) {
@@ -139,7 +135,7 @@ export default function UniversalLink({
 		if (!url) return
 
 		if (internal && !newTab) {
-			transitioner({ e, to: url, transition })
+			transitioner({ e, to: url })
 		} else {
 			window.open(url, newTab ? "_blank" : "_self")
 		}

--- a/link/loader.ts
+++ b/link/loader.ts
@@ -1,14 +1,10 @@
 import TypedEventEmitter from "library/TypedEventEmitter"
-import type libraryConfig from "libraryConfig"
 
 /**
  * transition names are configured in app/libraryConfig.ts
  * you should't need to edit this file
  */
-export type Transitions =
-	| keyof typeof libraryConfig.viewTransitions
-	| "instant"
-	| "default"
+export type Transitions = "animated" | "instant"
 
 export const loader = new TypedEventEmitter<{
 	/**

--- a/link/transitioner.ts
+++ b/link/transitioner.ts
@@ -99,6 +99,7 @@ export const useTransitioner = () => {
 			ScrollTrigger.refresh()
 
 			loader.dispatchEvent("routeChange", isInstant ? "instant" : "animated")
+			document.body.inert = true // prevent navigation before we're done animating in
 
 			if (!isInstant) await sleep(10)
 			const afterAnimations = allAnimations.map(({ animateAfter }) =>
@@ -110,6 +111,7 @@ export const useTransitioner = () => {
 				setIsAnimating(false)
 			})
 
+			document.body.inert = false
 			loader.dispatchEvent("end", isInstant ? "instant" : "animated")
 
 			return

--- a/link/transitioner.ts
+++ b/link/transitioner.ts
@@ -3,21 +3,21 @@ import { createScrollLock } from "library/Scroll"
 import { pathnameMatches, sleep } from "library/functions"
 import libraryConfig from "libraryConfig"
 import type { MouseEvent } from "react"
-import { useCallback } from "react"
+import { use, useCallback } from "react"
 import { loader } from "./loader"
 import { getScrollOffset } from "./util"
+import { TransitionsContext } from "./usePageTransition"
+import { useRouter } from "next/navigation"
+import { flushSync } from "react-dom"
+
+// at some point I might re-add support for different transitions (like on newform) but not really needed for now
 
 export const useTransitioner = () => {
+	const { animations, setIsAnimating } = use(TransitionsContext)
+	const router = useRouter()
+
 	return useCallback(
-		async ({
-			e,
-			to,
-			transition,
-		}: {
-			e: MouseEvent
-			to: string
-			transition?: unknown
-		}) => {
+		async ({ e, to }: { e: MouseEvent; to: string }) => {
 			const destination = new URL(to, window.location.origin)
 
 			/**
@@ -55,44 +55,65 @@ export const useTransitioner = () => {
 			}
 
 			/**
-			 * INSTANT TRANSITION
+			 * TRANSITION TO A NEW PAGE
 			 *
-			 * if no transition is specified, instantly transition pages
+			 * both instant and animated transitions
 			 */
-			if (transition === "instant" || !transition) {
-				loader.dispatchEvent("start", "instant")
+			const isInstant = animations.size === 0
+			const allAnimations = Array.from(animations)
+			if (!isInstant) e.preventDefault()
+			router.prefetch(to)
 
-				const existingHref = window.location.href
+			loader.dispatchEvent("start", isInstant ? "instant" : "animated")
 
-				// check for href changes with a timeout
-				const timeout = new Promise((_, reject) =>
-					setTimeout(() => reject(new Error("Navigation timeout")), 30_000),
-				)
-				const urlChange = new Promise<void>((resolve) => {
-					const checkUrlChange = () => {
-						if (window.location.href !== existingHref) {
-							resolve()
-							clearInterval(interval)
-						}
-					}
-					const interval = setInterval(checkUrlChange, 5)
-				})
-				await Promise.race([timeout, urlChange])
-				await sleep(10)
-				window.lenis?.scrollTo(0, { immediate: true })
-				ScrollTrigger.refresh()
+			flushSync(() => {
+				setIsAnimating(true)
+			})
 
-				loader.dispatchEvent("routeChange", "instant")
-				loader.dispatchEvent("end", "instant")
+			const beforeAnimations = allAnimations.map(({ animateBefore }) =>
+				animateBefore?.(),
+			)
+			await Promise.allSettled(beforeAnimations)
 
-				return
+			if (!isInstant) {
+				router.push(to)
 			}
 
-			/**
-			 * NORMAL TRANSITION
-			 */
-			throw new Error("we haven't added support for this yet -robbie")
+			// check for href changes with a timeout
+			const existingHref = window.location.href
+			const timeout = new Promise((_, reject) =>
+				setTimeout(() => reject(new Error("Navigation timeout")), 30_000),
+			)
+			const urlChange = new Promise<void>((resolve) => {
+				const checkUrlChange = () => {
+					if (window.location.href !== existingHref) {
+						resolve()
+						clearInterval(interval)
+					}
+				}
+				const interval = setInterval(checkUrlChange, 5)
+			})
+			await Promise.race([timeout, urlChange])
+			await sleep(10)
+			window.lenis?.scrollTo(0, { immediate: true })
+			ScrollTrigger.refresh()
+
+			loader.dispatchEvent("routeChange", isInstant ? "instant" : "animated")
+
+			if (!isInstant) await sleep(10)
+			const afterAnimations = allAnimations.map(({ animateAfter }) =>
+				animateAfter?.(),
+			)
+			await Promise.allSettled(afterAnimations)
+
+			flushSync(() => {
+				setIsAnimating(false)
+			})
+
+			loader.dispatchEvent("end", isInstant ? "instant" : "animated")
+
+			return
 		},
-		[],
+		[animations, setIsAnimating, router],
 	)
 }

--- a/link/useAnyTransition.ts
+++ b/link/useAnyTransition.ts
@@ -1,0 +1,17 @@
+import { usePageTransition } from "./usePageTransition"
+import { usePreloader } from "./usePreloader"
+
+/**
+ * track if any loader is currently in progress
+ *
+ * this includes both the preloader and page transitions
+ */
+export const useLoadInProgress = () => {
+	const { completed } = usePreloader()
+	const { isAnimating } = usePageTransition()
+
+	return {
+		inProgress: !completed || isAnimating,
+		completed: completed && !isAnimating,
+	}
+}

--- a/link/usePageTransition.tsx
+++ b/link/usePageTransition.tsx
@@ -1,0 +1,43 @@
+import { createContext, use, useEffect, useMemo, useState } from "react"
+
+type PageTransition = {
+	animateBefore?: () => Promise<void> | void
+	animateAfter?: () => Promise<void> | void
+}
+
+export const TransitionsContext = createContext({
+	animations: new Set<PageTransition>(),
+	isAnimating: false,
+	setIsAnimating: (_isAnimating: boolean) => {},
+})
+
+export const PageTransitionProvider = ({
+	children,
+}: {
+	children: React.ReactNode
+}) => {
+	const [isAnimating, setIsAnimating] = useState(false)
+	const animations = useMemo(() => new Set<PageTransition>(), [])
+
+	return (
+		<TransitionsContext.Provider
+			value={{ animations, isAnimating, setIsAnimating }}
+		>
+			{children}
+		</TransitionsContext.Provider>
+	)
+}
+
+export const usePageTransition = (transition: PageTransition = {}) => {
+	const { animations, isAnimating } = use(TransitionsContext)
+
+	useEffect(() => {
+		animations.add(transition)
+
+		return () => {
+			animations.delete(transition)
+		}
+	}, [animations, transition])
+
+	return { isAnimating }
+}

--- a/link/usePreloader.ts
+++ b/link/usePreloader.ts
@@ -78,7 +78,7 @@ export const usePreloader = ({
 	scope,
 }: {
 	/**
-	 * preloader will wait at least this long
+	 * preloader will wait at least this long in ms
 	 * (timed from page load, not affected by react load time)
 	 */
 	minDuration?: number


### PR DESCRIPTION
sample:
```typescript
export default function PageTransition() {
  const wrapper = useRef<HTMLDivElement>(null)
  const { isAnimating } = usePageTransition({
    animateBefore: async () => {
      gsap.set(wrapper.current, {
        "--scale": 1,
      })
      await sleep(1500)
    },
    animateAfter: async () => {
      gsap.set(wrapper.current, {
        "--scale": 0,
      })
      await sleep(1500)
    },
  })

  if (!isAnimating) return null // <- prevent the transition from rendering over the page
  return (
    <>
      <Wrapper ref={wrapper} style={{ "--scale": 0 }}>
        {/* some sort of content*/}
      </Wrapper>
    </>
  )
}

```