### PR TITLE
force alt attribute to be provided, unless the alt is defined in sanity

### DIFF
--- a/StaticImage.tsx
+++ b/StaticImage.tsx
@@ -26,7 +26,7 @@ export const prioritizeLoading = (
 }
 
 export type StaticImageProps = DefaultImageProps & {
-	alt: string | undefined
+	alt: string
 	objectFit?: "contain" | "cover"
 	objectPosition?: string
 	loading?: LoadingType
@@ -47,7 +47,7 @@ export type StaticImageProps = DefaultImageProps & {
 
 export default function StaticImage({
 	src,
-	alt = "",
+	alt,
 	objectFit = "cover",
 	objectPosition,
 	loading,

--- a/sanity/SanityImage.tsx
+++ b/sanity/SanityImage.tsx
@@ -13,38 +13,47 @@ import { use } from "react"
 import { styled } from "library/styled"
 import { SanityImage } from "sanity-image"
 import { dataset, projectId } from "@/sanity/lib/api"
+import { stegaClean } from "next-sanity"
 
-type SanityImageData<CropType> = {
+type SanityImageData<CropType, WithAlt extends "true" | "false"> = {
 	asset?: { _ref: string }
 	crop?: SanityImageCrop
 	hotspot?: SanityImageHotspot
 	data?: AssetMeta
 	alt?: string
 	cropType?: CropType
+	willHaveAlt?: WithAlt
 }
 
+type SanityProps<CropType> =
+	| {
+			src: SanityImageData<CropType, "false"> | null | undefined
+			alt: string | undefined
+	  }
+	| {
+			src: SanityImageData<CropType, "true"> | null | undefined
+			// the alt should be provided by sanity
+			alt?: undefined
+	  }
+
+type Test = SanityProps<"test">
+
 export type SanityImageProps =
-	| ({
-			src: SanityImageData<"sanity"> | null | undefined
-			alt?: string
+	| (SanityProps<"sanity"> & {
 			objectFit?: "contain" | "cover"
 			objectPosition?: undefined
 			loading?: "eager" | "lazy" | "default"
 			width: number
 			height: number
 	  } & DefaultImageProps)
-	| ({
-			src: SanityImageData<"uncropped"> | null | undefined
-			alt?: string
+	| (SanityProps<"uncropped"> & {
 			objectFit?: undefined
 			objectPosition?: undefined
 			loading?: "eager" | "lazy" | "default"
 			width?: undefined
 			height?: undefined
 	  } & DefaultImageProps)
-	| ({
-			src: SanityImageData<"css"> | null | undefined
-			alt?: string
+	| (SanityProps<"css"> & {
 			objectFit?: "contain" | "cover"
 			objectPosition?: string
 			loading?: "eager" | "lazy" | "default"
@@ -78,7 +87,7 @@ export default function SanityUniversalImage(
 	return (
 		<DefaultSanityImage
 			{...rest}
-			alt={rest.alt ?? src.alt}
+			alt={stegaClean(rest.alt ?? src.alt)}
 			loading={prioritizedLoading}
 			preview={src.data?.lqip}
 			// @ts-expect-error library type mismatch

--- a/sanity/reusables.ts
+++ b/sanity/reusables.ts
@@ -66,6 +66,15 @@ export const universalImage = <
 				hidden: true,
 				readOnly: true,
 			}),
+			defineField({
+				type: "string",
+				name: "willHaveAlt",
+				options: {
+					list: [withAlt === false ? "false" : "true"],
+				},
+				hidden: true,
+				readOnly: true,
+			}),
 			...(schemaField.fields ?? []),
 		],
 		options: {


### PR DESCRIPTION
if the alt is provided in sanity, we force the opposite behavior- do NOT provide an alt (SanityImage will extract it for you)