### PR TITLE
Transitioner edits

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -79,6 +79,6 @@ jobs:
       - run: pnpm install
       - run: pnpm run lint
       - if: inputs.isSanity == true
-        run: pnpm typegen && pnpm exec sanity documents validate -y
+        run: pnpm typegen && pnpm exec sanity documents validate --workspace default '!(_id in path("drafts.**"))' -y
       # running a build will also check types
       - run: pnpm run build

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -79,6 +79,6 @@ jobs:
       - run: pnpm install
       - run: pnpm run lint
       - if: inputs.isSanity == true
-        run: pnpm typegen && pnpm exec sanity documents validate --workspace default '!(_id in path("drafts.**"))' -y
+        run: pnpm typegen && pnpm exec sanity documents export --workspace default --dataset production --groq-filter '!(_id in path("drafts.**"))' | pnpm exec sanity documents validate --workspace default --dataset production --file -
       # running a build will also check types
       - run: pnpm run build

--- a/link/transitioner.ts
+++ b/link/transitioner.ts
@@ -139,6 +139,8 @@ export const useTransitioner = () => {
 			await Promise.race([timeout, urlChange])
 			await sleep(10) // give the page a moment to render
 
+			window.lenis?.scrollTo(0, { immediate: true })
+
 			// after the page has changed, an abort does nothing
 			if (signal?.aborted) return
 			signal?.removeEventListener("abort", onAbort)

--- a/sanity/BackgroundVideo.tsx
+++ b/sanity/BackgroundVideo.tsx
@@ -10,6 +10,7 @@ export function BackgroundVideo({
 	videoBlurUrl,
 	videoAspectRatio,
 	videoDuration,
+	eager,
 	play = true,
 	muted = true,
 	minResolution = "480p",
@@ -27,6 +28,13 @@ export function BackgroundVideo({
 	videoBlurUrl?: string
 	videoAspectRatio?: string
 	videoDuration?: number
+	/**
+	 * should the video not show a blur at all if possible? (this is more aggressive than lazy loading)
+	 * @default false
+	 */
+
+	eager?: boolean
+
 	/**
 	 * should the video start playing immediately?
 	 * similar to autoplay, but can also be toggled to pause/play
@@ -103,6 +111,10 @@ export function BackgroundVideo({
 	 * lazy load
 	 */
 	useEffect(() => {
+		if (eager) {
+			setLoadVideo(true)
+			return
+		}
 		// use an intersection observer to watch for when the element is on screen, and trigger the video load
 		const observer = new IntersectionObserver(
 			(entries) => {
@@ -118,7 +130,7 @@ export function BackgroundVideo({
 		)
 		if (video.current) observer.observe(video.current)
 		return () => observer.disconnect()
-	}, [])
+	}, [eager])
 
 	const handleTimeUpdate = (e: React.SyntheticEvent<HTMLVideoElement>) => {
 		const videoElement = e.currentTarget

--- a/sanity/CarouselBGVideo.tsx
+++ b/sanity/CarouselBGVideo.tsx
@@ -71,7 +71,12 @@ export function CarouselBackgroundVideo({
 	)
 	const [loadVideo, setLoadVideo] = useState(false)
 
-	const useSafariOptimization = safariOptimized && browserData.isSafari
+	const [isSafari, setIsSafari] = useState(false)
+
+	useEffect(() => {
+		setIsSafari(browserData.isSafari === true)
+	}, [])
+	const useSafariOptimization = safariOptimized && isSafari
 
 	/***
 	 * if our video id changes, clear the playback failure
@@ -112,10 +117,10 @@ export function CarouselBackgroundVideo({
 	 * lazy load
 	 */
 	useEffect(() => {
-		if (useSafariOptimization) {
-			setLoadVideo(true)
-			return
-		}
+		// if (useSafariOptimization) {
+		// 	setLoadVideo(true)
+		// 	return
+		// }
 
 		// use an intersection observer to watch for when the element is on screen, and trigger the video load
 		const observer = new IntersectionObserver(
@@ -132,7 +137,7 @@ export function CarouselBackgroundVideo({
 		)
 		if (video.current) observer.observe(video.current)
 		return () => observer.disconnect()
-	}, [useSafariOptimization])
+	}, [])
 
 	const handleTimeUpdate = (e: React.SyntheticEvent<HTMLVideoElement>) => {
 		const videoElement = e.currentTarget

--- a/sanity/CarouselBGVideo.tsx
+++ b/sanity/CarouselBGVideo.tsx
@@ -1,0 +1,224 @@
+"use client"
+
+import MuxVideo from "@mux/mux-video-react"
+import { browserData } from "library/deviceDetection"
+import { ScreenContext } from "library/ScreenContext"
+import { css, f, styled } from "library/styled"
+import { use, useEffect, useRef, useState } from "react"
+
+export function CarouselBackgroundVideo({
+	playbackId,
+	videoBlurUrl,
+	videoAspectRatio,
+	videoDuration,
+	play = true,
+	muted = true,
+	minResolution = "480p",
+	className,
+	loop,
+	ref: containerRef,
+	onEnded,
+	onTimeUpdate,
+	onLoadedMetadata,
+	safariOptimized = false,
+}: {
+	/**
+	 * asset metadata from sanity
+	 */
+	playbackId?: string
+	videoBlurUrl?: string
+	videoAspectRatio?: string
+	videoDuration?: number
+	/**
+	 * should the video start playing immediately?
+	 * similar to autoplay, but can also be toggled to pause/play
+	 * @default true
+	 */
+	play?: boolean
+	/**
+	 * should the video be muted?
+	 * can be toggled to mute/unmuted
+	 * @default true
+	 */
+	muted?: boolean
+	/**
+	 * minimum resolution to play the video at
+	 */
+	minResolution?: "480p" | "540p" | "720p" | "1080p" | "1440p" | "2160p"
+	loop?: boolean
+	className?: string
+	ref?: React.Ref<HTMLDivElement>
+	/**
+	 * use safari-optimized loading strategy (immediate load with metadata preload)
+	 * recommended for carousel/preview videos
+	 */
+	safariOptimized?: boolean
+	// other video props
+	onEnded?: (e?: React.SyntheticEvent<HTMLVideoElement, Event>) => void
+	onTimeUpdate?: (currentTime: number, duration: number) => void
+	onLoadedMetadata?: (duration: number) => void
+}) {
+	const video = useRef<HTMLVideoElement>(null)
+	const placeholderRef = useRef<HTMLDivElement>(null)
+	const videoPlayPromise = useRef(Promise.resolve())
+	const [playbackFailure, setPlaybackFailure] = useState<{
+		videoId: string
+	}>()
+	const { innerWidth } = use(ScreenContext)
+	const posterSize = Math.min(
+		1920,
+		Math.max(300, Math.round(innerWidth / 100) * 100),
+	)
+	const [loadVideo, setLoadVideo] = useState(false)
+
+	const useSafariOptimization = safariOptimized && browserData.isSafari
+
+	/***
+	 * if our video id changes, clear the playback failure
+	 */
+	if (playbackFailure && playbackFailure.videoId !== playbackId) {
+		setPlaybackFailure(undefined)
+	}
+
+	/**
+	 * autoplay
+	 */
+	useEffect(() => {
+		if (playbackFailure) return
+
+		const videoHasFinished = video.current?.ended
+
+		if (playbackId && loadVideo && !videoHasFinished)
+			// we never want to interrupt a play call with another play call
+			// so wait for any previous play call to finish before starting a new one
+			videoPlayPromise.current.then(() => {
+				if (video.current)
+					videoPlayPromise.current = video.current
+						?.play()
+						.then(() => {
+							// even if we don't want to play the video, we still want to try!
+							// if autoplay is unavailable we want to know about it ASAP
+							// even if we're not planning on playing the video
+							if (!play) video.current?.pause()
+						})
+						.catch(() => {
+							setPlaybackFailure({ videoId: playbackId })
+							onEnded?.()
+						})
+			})
+	})
+
+	/**
+	 * lazy load
+	 */
+	useEffect(() => {
+		if (useSafariOptimization) {
+			setLoadVideo(true)
+			return
+		}
+
+		// use an intersection observer to watch for when the element is on screen, and trigger the video load
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0]?.isIntersecting) {
+					setLoadVideo(true)
+					observer.disconnect()
+				}
+			},
+			{
+				// we don't want to wait until the video is on screen, but trigger when it's getting close
+				rootMargin: "400px",
+			},
+		)
+		if (video.current) observer.observe(video.current)
+		return () => observer.disconnect()
+	}, [useSafariOptimization])
+
+	const handleTimeUpdate = (e: React.SyntheticEvent<HTMLVideoElement>) => {
+		const videoElement = e.currentTarget
+		if (onTimeUpdate && videoElement.duration) {
+			onTimeUpdate(videoElement.currentTime, videoElement.duration)
+		}
+	}
+
+	const handleLoadedMetadata = (e: React.SyntheticEvent<HTMLVideoElement>) => {
+		const videoElement = e.currentTarget
+		if (onLoadedMetadata && videoElement.duration) {
+			onLoadedMetadata(videoElement.duration)
+		}
+	}
+
+	return (
+		<Container
+			ref={containerRef}
+			className={className}
+			style={{
+				aspectRatio: videoAspectRatio,
+				// we'll ideally only see this on really slow networks
+				// it's small and will have weird colors, but it's better than nothing
+				backgroundImage: videoBlurUrl ? `url('${videoBlurUrl}')` : undefined,
+			}}
+		>
+			{useSafariOptimization && !loadVideo ? (
+				<PlaceholderDiv
+					ref={placeholderRef}
+					style={{
+						backgroundImage: playbackId
+							? `url(https://image.mux.com/${playbackId}/thumbnail.webp?time=0&width=${posterSize})`
+							: undefined,
+					}}
+				/>
+			) : (
+				<MainVideo
+					ref={video}
+					src={
+						playbackFailure || !playbackId
+							? undefined
+							: `https://stream.mux.com/${playbackId}.m3u8?min_resolution=${minResolution}`
+					}
+					preload={
+						useSafariOptimization ? "metadata" : loadVideo ? "auto" : "metadata"
+					}
+					muted={muted}
+					playsInline
+					loop={loop}
+					poster={
+						playbackFailure
+							? `https://image.mux.com/${playbackId}/thumbnail.webp?time=${videoDuration}&width=${posterSize}`
+							: `https://image.mux.com/${playbackId}/thumbnail.webp?time=0&width=${posterSize}`
+					}
+					streamType="on-demand"
+					onEnded={onEnded}
+					onTimeUpdate={handleTimeUpdate}
+					onLoadedMetadata={handleLoadedMetadata}
+				/>
+			)}
+		</Container>
+	)
+}
+
+const Container = styled("div", {
+	...f.responsive(css`
+		isolation: isolate;
+		overflow: clip;
+	`),
+})
+
+const MainVideo = styled(MuxVideo, {
+	...f.responsive(css`
+		width: 100%;
+		height: 100%;
+		display: block;
+		object-fit: cover;
+		object-position: center;
+	`),
+})
+
+const PlaceholderDiv = styled("div", {
+	...f.responsive(css`
+		width: 100%;
+		height: 100%;
+		background-size: cover;
+		background-position: center;
+	`),
+})

--- a/sanity/CarouselBGVideo.tsx
+++ b/sanity/CarouselBGVideo.tsx
@@ -50,6 +50,7 @@ export function CarouselBackgroundVideo({
 	ref?: React.Ref<HTMLDivElement>
 	/**
 	 * use safari-optimized loading strategy (immediate load with metadata preload)
+	 * @default false
 	 * recommended for carousel/preview videos
 	 */
 	safariOptimized?: boolean
@@ -69,14 +70,16 @@ export function CarouselBackgroundVideo({
 		1920,
 		Math.max(300, Math.round(innerWidth / 100) * 100),
 	)
-	const [loadVideo, setLoadVideo] = useState(false)
-
 	const [isSafari, setIsSafari] = useState(false)
-
 	useEffect(() => {
 		setIsSafari(browserData.isSafari === true)
 	}, [])
 	const useSafariOptimization = safariOptimized && isSafari
+
+	// This state now ONLY controls if the <MainVideo> component is rendered.
+	const [shouldRenderVideo, setShouldRenderVideo] = useState(
+		useSafariOptimization,
+	)
 
 	/***
 	 * if our video id changes, clear the playback failure
@@ -85,48 +88,39 @@ export function CarouselBackgroundVideo({
 		setPlaybackFailure(undefined)
 	}
 
-	/**
-	 * autoplay
-	 */
+	// This effect ONLY handles playing and pausing the video.
 	useEffect(() => {
-		if (playbackFailure) return
+		if (!shouldRenderVideo || !video.current || playbackFailure) {
+			return
+		}
 
-		const videoHasFinished = video.current?.ended
-
-		if (playbackId && loadVideo && !videoHasFinished)
-			// we never want to interrupt a play call with another play call
-			// so wait for any previous play call to finish before starting a new one
-			videoPlayPromise.current.then(() => {
-				if (video.current)
-					videoPlayPromise.current = video.current
-						?.play()
-						.then(() => {
-							// even if we don't want to play the video, we still want to try!
-							// if autoplay is unavailable we want to know about it ASAP
-							// even if we're not planning on playing the video
-							if (!play) video.current?.pause()
-						})
-						.catch(() => {
-							setPlaybackFailure({ videoId: playbackId })
-							onEnded?.()
-						})
+		if (play) {
+			video.current.play().catch(() => {
+				if (playbackId) {
+					setPlaybackFailure({ videoId: playbackId })
+				}
+				onEnded?.()
 			})
-	})
+		} else {
+			video.current.pause()
+		}
+	}, [play, shouldRenderVideo, playbackId, playbackFailure, onEnded])
 
 	/**
-	 * lazy load
+	 * This effect handles rendering the video component,
+	 * either immediately on Safari or lazily on others.
 	 */
 	useEffect(() => {
-		// if (useSafariOptimization) {
-		// 	setLoadVideo(true)
-		// 	return
-		// }
+		if (useSafariOptimization) {
+			setShouldRenderVideo(true)
+			return
+		}
 
 		// use an intersection observer to watch for when the element is on screen, and trigger the video load
 		const observer = new IntersectionObserver(
 			(entries) => {
 				if (entries[0]?.isIntersecting) {
-					setLoadVideo(true)
+					setShouldRenderVideo(true)
 					observer.disconnect()
 				}
 			},
@@ -135,9 +129,10 @@ export function CarouselBackgroundVideo({
 				rootMargin: "400px",
 			},
 		)
-		if (video.current) observer.observe(video.current)
+		const elementToObserve = placeholderRef.current
+		if (elementToObserve) observer.observe(elementToObserve)
 		return () => observer.disconnect()
-	}, [])
+	}, [useSafariOptimization])
 
 	const handleTimeUpdate = (e: React.SyntheticEvent<HTMLVideoElement>) => {
 		const videoElement = e.currentTarget
@@ -164,7 +159,7 @@ export function CarouselBackgroundVideo({
 				backgroundImage: videoBlurUrl ? `url('${videoBlurUrl}')` : undefined,
 			}}
 		>
-			{useSafariOptimization && !loadVideo ? (
+			{!shouldRenderVideo ? (
 				<PlaceholderDiv
 					ref={placeholderRef}
 					style={{
@@ -181,9 +176,7 @@ export function CarouselBackgroundVideo({
 							? undefined
 							: `https://stream.mux.com/${playbackId}.m3u8?min_resolution=${minResolution}`
 					}
-					preload={
-						useSafariOptimization ? "metadata" : loadVideo ? "auto" : "metadata"
-					}
+					preload="auto"
 					muted={muted}
 					playsInline
 					loop={loop}


### PR DESCRIPTION
added the following:

New Video component that works better for carousel/safari usage than BG Video
Updated git workflow to only try to validate published content. 
Adde an eager prop to allow for immediate load of hero videos while still allowing lazy load in other situations. 
added scroll to top logic for normal page transition situations. 
