### PR TITLE
Add poster option to Background Video

### DIFF
--- a/sanity/BackgroundVideo.tsx
+++ b/sanity/BackgroundVideo.tsx
@@ -19,7 +19,7 @@ type SanityPosterImage = {
 		_weak?: boolean
 		[internalGroqTypeReferenceTo]?: "sanity.imageAsset"
 	}
-	media: unknown
+	media?: unknown
 	hotspot?: SanityImageHotspot
 	crop?: SanityImageCrop
 	alt?: string

--- a/sanity/BackgroundVideo.tsx
+++ b/sanity/BackgroundVideo.tsx
@@ -1,15 +1,15 @@
 "use client"
 
-import type {
-	internalGroqTypeReferenceTo,
-	SanityImageCrop,
-	SanityImageHotspot,
-} from "@/sanity.types"
 import MuxVideo from "@mux/mux-video-react"
 import { ScreenContext } from "library/ScreenContext"
 import { css, f, styled } from "library/styled"
 import SanityUniversalImage from "library/UniversalImage"
 import { use, useEffect, useRef, useState } from "react"
+import type {
+	internalGroqTypeReferenceTo,
+	SanityImageCrop,
+	SanityImageHotspot,
+} from "@/sanity.types"
 import type { AssetMeta } from "./assetMetadata"
 
 type SanityPosterImage = {

--- a/sanity/BackgroundVideo.tsx
+++ b/sanity/BackgroundVideo.tsx
@@ -222,7 +222,7 @@ export function BackgroundVideo({
 		)
 	}
 
-	// Original "video-as-poster" logic for backward compatibility
+	// original "video-as-poster" logic for backward compatibility
 	return (
 		<Container
 			ref={containerRef}

--- a/sanity/BackgroundVideo.tsx
+++ b/sanity/BackgroundVideo.tsx
@@ -3,9 +3,9 @@
 import MuxVideo from "@mux/mux-video-react"
 import { ScreenContext } from "library/ScreenContext"
 import { css, f, styled } from "library/styled"
+import SanityUniversalImage from "library/UniversalImage"
 import { use, useEffect, useRef, useState } from "react"
 import type { Image } from "sanity"
-import SanityUniversalImage from "library/UniversalImage"
 
 export function BackgroundVideo({
 	playbackId,

--- a/sanity/BackgroundVideo.tsx
+++ b/sanity/BackgroundVideo.tsx
@@ -4,6 +4,7 @@ import MuxVideo from "@mux/mux-video-react"
 import { ScreenContext } from "library/ScreenContext"
 import { css, f, styled } from "library/styled"
 import SanityUniversalImage from "library/UniversalImage"
+import { browserData } from "library/deviceDetection"
 import { use, useEffect, useRef, useState } from "react"
 import type {
 	internalGroqTypeReferenceTo,
@@ -101,6 +102,12 @@ export function BackgroundVideo({
 	)
 	const [loadVideo, setLoadVideo] = useState(eager ?? false)
 	const [videoCanPlay, setVideoCanPlay] = useState(true)
+
+	useEffect(() => {
+		if (loadVideo && video.current && browserData.isSafari) {
+			video.current.load()
+		}
+	}, [loadVideo])
 
 	/***
 	 * if our video id changes, clear the playback failure

--- a/sanity/BackgroundVideo.tsx
+++ b/sanity/BackgroundVideo.tsx
@@ -20,6 +20,7 @@ export function BackgroundVideo({
 	onEnded,
 	onTimeUpdate,
 	onLoadedMetadata,
+	posterOverride,
 }: {
 	/**
 	 * asset metadata from sanity
@@ -54,12 +55,18 @@ export function BackgroundVideo({
 	loop?: boolean
 	className?: string
 	ref?: React.Ref<HTMLDivElement>
+	/**
+	 * A URL for a custom poster image. If provided, this will override the default
+	 * "video-as-poster" behavior and use a simpler, more robust image poster.
+	 */
+	posterOverride?: string
 	// other video props
 	onEnded?: (e?: React.SyntheticEvent<HTMLVideoElement, Event>) => void
 	onTimeUpdate?: (currentTime: number, duration: number) => void
 	onLoadedMetadata?: (duration: number) => void
 }) {
 	const video = useRef<HTMLVideoElement>(null)
+	const placeholderRef = useRef<HTMLDivElement>(null)
 	const videoPlayPromise = useRef(Promise.resolve())
 	const [playbackFailure, setPlaybackFailure] = useState<{
 		videoId: string
@@ -69,7 +76,7 @@ export function BackgroundVideo({
 		1920,
 		Math.max(300, Math.round(innerWidth / 100) * 100),
 	)
-	const [loadVideo, setLoadVideo] = useState(false)
+	const [loadVideo, setLoadVideo] = useState(eager ?? false)
 	const [videoCanPlay, setVideoCanPlay] = useState(true)
 
 	/***
@@ -83,11 +90,11 @@ export function BackgroundVideo({
 	 * autoplay
 	 */
 	useEffect(() => {
-		if (playbackFailure) return
+		if (playbackFailure || !loadVideo) return
 
 		const videoHasFinished = video.current?.ended
 
-		if (playbackId && loadVideo && !videoHasFinished)
+		if (playbackId && !videoHasFinished)
 			// we never want to interrupt a play call with another play call
 			// so wait for any previous play call to finish before starting a new one
 			videoPlayPromise.current.then(() => {
@@ -95,17 +102,16 @@ export function BackgroundVideo({
 					videoPlayPromise.current = video.current
 						?.play()
 						.then(() => {
-							// even if we don't want to play the video, we still want to try!
-							// if autoplay is unavailable we want to know about it ASAP
-							// even if we're not planning on playing the video
 							if (!play) video.current?.pause()
 						})
 						.catch(() => {
-							setPlaybackFailure({ videoId: playbackId })
+							if (playbackId) {
+								setPlaybackFailure({ videoId: playbackId })
+							}
 							onEnded?.()
 						})
 			})
-	})
+	}, [play, loadVideo, playbackId, playbackFailure, onEnded])
 
 	/**
 	 * lazy load
@@ -128,7 +134,8 @@ export function BackgroundVideo({
 				rootMargin: "400px",
 			},
 		)
-		if (video.current) observer.observe(video.current)
+		const elementToObserve = placeholderRef.current ?? video.current
+		if (elementToObserve) observer.observe(elementToObserve)
 		return () => observer.disconnect()
 	}, [eager])
 
@@ -146,6 +153,45 @@ export function BackgroundVideo({
 		}
 	}
 
+	// New, simpler path for when a custom poster is provided
+	if (posterOverride) {
+		return (
+			<Container
+				ref={containerRef}
+				className={className}
+				style={{
+					aspectRatio: videoAspectRatio,
+					backgroundImage: `url('${posterOverride}')`,
+					backgroundSize: "cover",
+					backgroundPosition: "center",
+				}}
+			>
+				{loadVideo && (
+					<MainVideo
+						ref={video}
+						src={
+							playbackFailure || !playbackId
+								? undefined
+								: `https://stream.mux.com/${playbackId}.m3u8?min_resolution=${minResolution}`
+						}
+						preload="auto"
+						muted={muted}
+						playsInline
+						loop={loop}
+						poster={posterOverride}
+						streamType="on-demand"
+						onEnded={onEnded}
+						onTimeUpdate={handleTimeUpdate}
+						onLoadedMetadata={handleLoadedMetadata}
+					/>
+				)}
+				{/* This ref is used by the IntersectionObserver when no video is loaded yet */}
+				{!loadVideo && <div ref={placeholderRef} style={{ height: "1px" }} />}
+			</Container>
+		)
+	}
+
+	// Original "video-as-poster" logic for backward compatibility
 	return (
 		<Container
 			ref={containerRef}
@@ -189,9 +235,7 @@ export function BackgroundVideo({
 					loop={loop}
 					poster={
 						playbackFailure
-							? `https://image.mux.com/${playbackId}/thumbnail.webp?time=${
-									videoDuration
-								}&width=${posterSize}`
+							? `https://image.mux.com/${playbackId}/thumbnail.webp?time=${videoDuration}&width=${posterSize}`
 							: undefined
 					}
 					streamType="on-demand"

--- a/sanity/BackgroundVideo.tsx
+++ b/sanity/BackgroundVideo.tsx
@@ -1,11 +1,32 @@
 "use client"
 
+import type {
+	internalGroqTypeReferenceTo,
+	SanityImageCrop,
+	SanityImageHotspot,
+} from "@/sanity.types"
 import MuxVideo from "@mux/mux-video-react"
 import { ScreenContext } from "library/ScreenContext"
 import { css, f, styled } from "library/styled"
 import SanityUniversalImage from "library/UniversalImage"
 import { use, useEffect, useRef, useState } from "react"
-import type { Image } from "sanity"
+import type { AssetMeta } from "./assetMetadata"
+
+type SanityPosterImage = {
+	asset?: {
+		_ref: string
+		_type: "reference"
+		_weak?: boolean
+		[internalGroqTypeReferenceTo]?: "sanity.imageAsset"
+	}
+	media: unknown
+	hotspot?: SanityImageHotspot
+	crop?: SanityImageCrop
+	alt?: string
+	cropType?: "sanity"
+	willHaveAlt?: "true"
+	data?: AssetMeta
+}
 
 export function BackgroundVideo({
 	playbackId,
@@ -61,7 +82,7 @@ export function BackgroundVideo({
 	 * a Sanity Image object. If provided, this will override the default
 	 * "video-as-poster" behavior and use a simpler, more robust image poster. useful for slower networks.
 	 */
-	posterOverride?: Image
+	posterOverride?: SanityPosterImage
 	// other video props
 	onEnded?: (e?: React.SyntheticEvent<HTMLVideoElement, Event>) => void
 	onTimeUpdate?: (currentTime: number, duration: number) => void

--- a/sanity/BackgroundVideo.tsx
+++ b/sanity/BackgroundVideo.tsx
@@ -4,6 +4,8 @@ import MuxVideo from "@mux/mux-video-react"
 import { ScreenContext } from "library/ScreenContext"
 import { css, f, styled } from "library/styled"
 import { use, useEffect, useRef, useState } from "react"
+import type { Image } from "sanity"
+import SanityUniversalImage from "library/UniversalImage"
 
 export function BackgroundVideo({
 	playbackId,
@@ -56,10 +58,10 @@ export function BackgroundVideo({
 	className?: string
 	ref?: React.Ref<HTMLDivElement>
 	/**
-	 * A URL for a custom poster image. If provided, this will override the default
-	 * "video-as-poster" behavior and use a simpler, more robust image poster.
+	 * a Sanity Image object. If provided, this will override the default
+	 * "video-as-poster" behavior and use a simpler, more robust image poster. useful for slower networks.
 	 */
-	posterOverride?: string
+	posterOverride?: Image
 	// other video props
 	onEnded?: (e?: React.SyntheticEvent<HTMLVideoElement, Event>) => void
 	onTimeUpdate?: (currentTime: number, duration: number) => void
@@ -153,19 +155,27 @@ export function BackgroundVideo({
 		}
 	}
 
-	// New, simpler path for when a custom poster is provided
-	if (posterOverride) {
+	// new, simpler path for when a custom poster is provided (optional)
+	if (posterOverride?.asset) {
 		return (
 			<Container
 				ref={containerRef}
 				className={className}
 				style={{
 					aspectRatio: videoAspectRatio,
-					backgroundImage: `url('${posterOverride}')`,
-					backgroundSize: "cover",
-					backgroundPosition: "center",
 				}}
 			>
+				<PosterImage
+					style={{ opacity: videoCanPlay ? 1 : 0 }}
+					src={{
+						asset: { _ref: posterOverride.asset._ref },
+						alt: posterOverride.alt as string,
+					}}
+					alt={posterOverride.alt as string}
+					width={1920}
+					height={1080}
+					loading="eager"
+				/>
 				{loadVideo && (
 					<MainVideo
 						ref={video}
@@ -178,14 +188,14 @@ export function BackgroundVideo({
 						muted={muted}
 						playsInline
 						loop={loop}
-						poster={posterOverride}
 						streamType="on-demand"
+						onCanPlay={() => setVideoCanPlay(false)}
 						onEnded={onEnded}
 						onTimeUpdate={handleTimeUpdate}
 						onLoadedMetadata={handleLoadedMetadata}
 					/>
 				)}
-				{/* This ref is used by the IntersectionObserver when no video is loaded yet */}
+
 				{!loadVideo && <div ref={placeholderRef} style={{ height: "1px" }} />}
 			</Container>
 		)
@@ -284,5 +294,16 @@ const PosterVideo = styled(MainVideo, {
 		position: absolute;
 		transition: opacity 0.2s ease-in-out;
 		pointer-events: none;
+	`),
+})
+
+const PosterImage = styled(SanityUniversalImage, {
+	...f.responsive(css`
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		object-position: center;
 	`),
 })

--- a/sanity/BackgroundVideoOriginal.tsx
+++ b/sanity/BackgroundVideoOriginal.tsx
@@ -1,0 +1,232 @@
+"use client"
+
+import MuxVideo from "@mux/mux-video-react"
+import { ScreenContext } from "library/ScreenContext"
+import { css, f, styled } from "library/styled"
+import { use, useEffect, useRef, useState } from "react"
+
+export function BackgroundVideo({
+	playbackId,
+	videoBlurUrl,
+	videoAspectRatio,
+	videoDuration,
+	play = true,
+	muted = true,
+	minResolution = "480p",
+	className,
+	loop,
+	ref: containerRef,
+	onEnded,
+	onTimeUpdate,
+	onLoadedMetadata,
+}: {
+	/**
+	 * asset metadata from sanity
+	 */
+	playbackId?: string
+	videoBlurUrl?: string
+	videoAspectRatio?: string
+	videoDuration?: number
+	/**
+	 * should the video start playing immediately?
+	 * similar to autoplay, but can also be toggled to pause/play
+	 * @default true
+	 */
+	play?: boolean
+	/**
+	 * should the video be muted?
+	 * can be toggled to mute/unmuted
+	 * @default true
+	 */
+	muted?: boolean
+	/**
+	 * minimum resolution to play the video at
+	 */
+	minResolution?: "480p" | "540p" | "720p" | "1080p" | "1440p" | "2160p"
+	loop?: boolean
+	className?: string
+	ref?: React.Ref<HTMLDivElement>
+	// other video props
+	onEnded?: (e?: React.SyntheticEvent<HTMLVideoElement, Event>) => void
+	onTimeUpdate?: (currentTime: number, duration: number) => void
+	onLoadedMetadata?: (duration: number) => void
+}) {
+	const video = useRef<HTMLVideoElement>(null)
+	const videoPlayPromise = useRef(Promise.resolve())
+	const [playbackFailure, setPlaybackFailure] = useState<{
+		videoId: string
+	}>()
+	const { innerWidth } = use(ScreenContext)
+	const posterSize = Math.min(
+		1920,
+		Math.max(300, Math.round(innerWidth / 100) * 100),
+	)
+	const [loadVideo, setLoadVideo] = useState(false)
+	const [videoCanPlay, setVideoCanPlay] = useState(true)
+
+	/***
+	 * if our video id changes, clear the playback failure
+	 */
+	if (playbackFailure && playbackFailure.videoId !== playbackId) {
+		setPlaybackFailure(undefined)
+	}
+
+	/**
+	 * autoplay
+	 */
+	useEffect(() => {
+		if (playbackFailure) return
+
+		const videoHasFinished = video.current?.ended
+
+		if (playbackId && loadVideo && !videoHasFinished)
+			// we never want to interrupt a play call with another play call
+			// so wait for any previous play call to finish before starting a new one
+			videoPlayPromise.current.then(() => {
+				if (video.current)
+					videoPlayPromise.current = video.current
+						?.play()
+						.then(() => {
+							// even if we don't want to play the video, we still want to try!
+							// if autoplay is unavailable we want to know about it ASAP
+							// even if we're not planning on playing the video
+							if (!play) video.current?.pause()
+						})
+						.catch(() => {
+							setPlaybackFailure({ videoId: playbackId })
+							onEnded?.()
+						})
+			})
+	})
+
+	/**
+	 * lazy load
+	 */
+	useEffect(() => {
+		// use an intersection observer to watch for when the element is on screen, and trigger the video load
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0]?.isIntersecting) {
+					setLoadVideo(true)
+					observer.disconnect()
+				}
+			},
+			{
+				// we don't want to wait until the video is on screen, but trigger when it's getting close
+				rootMargin: "400px",
+			},
+		)
+		if (video.current) observer.observe(video.current)
+		return () => observer.disconnect()
+	}, [])
+
+	const handleTimeUpdate = (e: React.SyntheticEvent<HTMLVideoElement>) => {
+		const videoElement = e.currentTarget
+		if (onTimeUpdate && videoElement.duration) {
+			onTimeUpdate(videoElement.currentTime, videoElement.duration)
+		}
+	}
+
+	const handleLoadedMetadata = (e: React.SyntheticEvent<HTMLVideoElement>) => {
+		const videoElement = e.currentTarget
+		if (onLoadedMetadata && videoElement.duration) {
+			onLoadedMetadata(videoElement.duration)
+		}
+	}
+
+	return (
+		<Container
+			ref={containerRef}
+			className={className}
+			style={{
+				aspectRatio: videoAspectRatio,
+				// we'll ideally only see this on really slow networks
+				// it's small and will have weird colors, but it's better than nothing
+				backgroundImage: videoBlurUrl ? `url('${videoBlurUrl}')` : undefined,
+			}}
+		>
+			<PosterVideo
+				// mux thumbnails will have different colors than the video itself, so we can't seamlessly
+				// switch between the two without some extra effort. we'll rely on the first frame for this
+				// instead of using a thumbnail. This video is smaller so we get a fast poster load
+				data-poster
+				src={
+					playbackId
+						? `https://stream.mux.com/${playbackId}.m3u8?max_resolution=720p`
+						: undefined
+				}
+				preload="metadata"
+				muted={muted}
+				playsInline
+				style={{ opacity: videoCanPlay ? 1 : 0 }}
+			/>
+			{/* this is to combat a safari rendering bug where the video doesn't render properly if being lazy loaded or dynamically loaded. */}
+			{loadVideo ? (
+				<MainVideo
+					key={`${playbackId}-loaded`}
+					ref={video}
+					src={
+						playbackFailure || !playbackId
+							? undefined
+							: `https://stream.mux.com/${playbackId}.m3u8?min_resolution=${minResolution}`
+					}
+					preload="auto"
+					onCanPlay={() => setVideoCanPlay(false)}
+					muted={muted}
+					playsInline
+					loop={loop}
+					poster={
+						playbackFailure
+							? `https://image.mux.com/${playbackId}/thumbnail.webp?time=${
+									videoDuration
+								}&width=${posterSize}`
+							: undefined
+					}
+					streamType="on-demand"
+					onEnded={onEnded}
+					onTimeUpdate={handleTimeUpdate}
+					onLoadedMetadata={handleLoadedMetadata}
+				/>
+			) : (
+				<MainVideo
+					key={`${playbackId}-placeholder`}
+					ref={video}
+					preload="metadata"
+					onCanPlay={() => setVideoCanPlay(false)}
+					muted={muted}
+					playsInline
+					loop={loop}
+					streamType="on-demand"
+					onEnded={onEnded}
+					onTimeUpdate={handleTimeUpdate}
+					onLoadedMetadata={handleLoadedMetadata}
+				/>
+			)}
+		</Container>
+	)
+}
+
+const Container = styled("div", {
+	...f.responsive(css`
+		isolation: isolate;
+		overflow: clip;
+	`),
+})
+
+const MainVideo = styled(MuxVideo, {
+	...f.responsive(css`
+		width: 100%;
+		height: 100%;
+		display: block;
+		object-fit: cover;
+		object-position: center;
+	`),
+})
+
+const PosterVideo = styled(MainVideo, {
+	...f.responsive(css`
+		position: absolute;
+		transition: opacity 0.2s ease-in-out;
+		pointer-events: none;
+	`),
+})


### PR DESCRIPTION
There was a limitation of Background Video even with the double video hack. On a very slow connection the blurred image placeholder will still be visible since we can't use a true poster image.

So since that is the case, I added the option to pass in an actual image as a manual poster. It will stay visible until the video can play.  It is optional so won't break any existing usage. 

