### PR TITLE
Refactor useSearchResults

### DIFF
--- a/useSearchResults.ts
+++ b/useSearchResults.ts
@@ -2,55 +2,56 @@ import MiniSearch from "minisearch"
 import { useEffect, useMemo } from "react"
 import { useDeepCompareMemo } from "use-deep-compare"
 
-export const useSearchResults = <T extends { id: string }>(
+type IdLike = string | number
+
+export function useSearchResults<
+	T extends Record<string, unknown>,
+	K extends keyof T = "_id" extends keyof T ? "_id" : "id",
+>(
 	query: string,
 	items: T[],
 	indexableFields: (keyof T)[],
-) => {
-	/**
-	 * create our search indexes
-	 */
+	idField?: K, // defaults to "_id" if present, else "id"
+) {
+	const resolvedIdField = (idField ??
+		("_id" in (items[0] ?? {}) ? ("_id" as K) : ("id" as K))) as K
+
 	const fuzzyMatcher = useDeepCompareMemo(() => {
 		return new MiniSearch<T>({
+			idField: String(resolvedIdField),
 			fields: indexableFields.map(String),
-			searchOptions: {
-				prefix: true,
-				fuzzy: 0.2,
-			},
+			searchOptions: { prefix: true, fuzzy: 0.2 },
 			extractField: (document, fieldName) => {
 				const value = document[fieldName as keyof T]
-
-				if (typeof value === "string") {
-					return value
-				}
-
-				if (typeof value === "number") {
-					return value.toString()
-				}
-
+				if (typeof value === "string") return value
+				if (typeof value === "number") return String(value)
 				return JSON.stringify(value)
 			},
 		})
-	}, [indexableFields])
+	}, [indexableFields, resolvedIdField])
 
-	/**
-	 * add each item to the search index
-	 */
 	useEffect(() => {
-		fuzzyMatcher.addAll(items.filter((item) => !fuzzyMatcher.has(item.id)))
-	}, [fuzzyMatcher, items])
+		fuzzyMatcher.addAll(
+			items.filter((item) => {
+				const id = item[resolvedIdField] as IdLike | undefined
+				return id != null && !fuzzyMatcher.has(String(id))
+			}),
+		)
+	}, [fuzzyMatcher, items, resolvedIdField])
 
-	/**
-	 * search for items based on the search term
-	 */
 	const results = useMemo(() => {
 		if (!query) return items
-
-		return fuzzyMatcher
-			.search(query)
-			.map((result) => items.find((item) => item.id === result.id))
-			.filter(Boolean)
-	}, [fuzzyMatcher, query, items])
+		const found = fuzzyMatcher.search(query)
+		return found
+			.map((res) =>
+				items.find(
+					(it) =>
+						String(it[resolvedIdField] as IdLike | undefined) ===
+						String(res.id),
+				),
+			)
+			.filter(Boolean) as T[]
+	}, [fuzzyMatcher, query, items, resolvedIdField])
 
 	return results
 }


### PR DESCRIPTION
## Update useSearchResults hook
- Added optional `idField` parameter to choose which property uniquely identifies items
- Defaults to `_id` if present, otherwise falls back to `id`
- Improved flexibility to support datasets keyed by `_id`, `id`, `slug`, etc.