### PR TITLE
allow quality per image

### DIFF
--- a/StaticImage.tsx
+++ b/StaticImage.tsx
@@ -32,6 +32,7 @@ export type StaticImageProps = DefaultImageProps & {
 	objectPosition?: string
 	loading?: LoadingType
 	sizes?: string
+	quality?: number
 	priority?: boolean
 	placeholder?: PlaceholderValue
 } & (
@@ -54,6 +55,7 @@ export default function StaticImage({
 	objectPosition,
 	loading,
 	sizes = "100vw",
+	quality = 90,
 	placeholder = "blur",
 	...otherProps
 }: StaticImageProps) {
@@ -89,6 +91,7 @@ export default function StaticImage({
 			placeholder={isSVG ? undefined : placeholder}
 			{...props}
 			src={src}
+			quality={quality}
 			sizes={sizes}
 			aspectRatio={
 				props.width && props.height


### PR DESCRIPTION
There wasn't a way to pass quality down to an image easily in StaticImage. So I added that here. Not sure what our normal quality is, but set it to 90 by default. 