### PR TITLE
Misc Updates

### DIFF
--- a/AutoAnimate.tsx
+++ b/AutoAnimate.tsx
@@ -346,5 +346,5 @@ const AnimationWrapper = styled("div", {
 			},
 		},
 	},
-	variables: { alignment },
+	tokens: { alignment },
 })

--- a/Scroll.tsx
+++ b/Scroll.tsx
@@ -1,8 +1,10 @@
 "use client"
 
 import { gsap, ScrollTrigger } from "gsap/all"
-import Lenis, { type LenisOptions } from "lenis"
-import { useEffect, useState } from "react"
+import type Lenis from "lenis"
+import type { LenisOptions } from "lenis"
+import { type LenisRef, ReactLenis } from "lenis/react"
+import { useEffect, useRef, useState } from "react"
 import { useDeepCompareLayoutEffect } from "use-deep-compare"
 import { isBrowser } from "./deviceDetection"
 import TypedEventEmitter from "./TypedEventEmitter"
@@ -89,35 +91,33 @@ export const useIsSmooth = () => {
 	)
 
 	useEffect(() => {
-		const enableSmooth = () => {
-			setSmooth(true)
-		}
-		const disableSmooth = () => {
-			setSmooth(!!window.lenis?.options.syncTouch)
+		if (!isBrowser) return
+
+		let isMounted = true
+
+		const updateFromLenis = () => {
+			const lenis = window.lenis
+			if (!lenis) return
+
+			const state = window.lenis?.isScrolling
+
+			if (state === "smooth") {
+				if (isMounted) setSmooth(true)
+			} else if (state === "native") {
+				if (isMounted) setSmooth(false)
+			}
 		}
 
-		window.addEventListener("wheel", enableSmooth, { passive: true })
-		window.addEventListener("touchstart", disableSmooth, { passive: true })
+		updateFromLenis()
+
+		const lenis = window.lenis
+		lenis?.on("scroll", updateFromLenis)
 
 		return () => {
-			window.removeEventListener("wheel", enableSmooth)
-			window.removeEventListener("touchstart", disableSmooth)
+			isMounted = false
+			lenis?.off("scroll", updateFromLenis)
 		}
 	}, [])
-
-	// if the device is mobile, set the initial value to false
-	useEffect(() => {
-		const hover = window.matchMedia("(hover: hover)")
-		if (!hover.matches) {
-			setSmooth(false)
-		}
-	}, [])
-
-	// check for url flags
-	if (isBrowser && window.location.search.toLowerCase().includes("nosmooth"))
-		return false
-	if (isBrowser && window.location.search.toLowerCase().includes("forcesmooth"))
-		return true
 
 	return smooth
 }
@@ -132,47 +132,32 @@ ScrollTrigger.config({
 	ignoreMobileResize: true,
 })
 
-export const SmoothScrollStyle = ({
-	infinite,
-	...config
-}: LenisOptions & { infinite?: boolean } = {}) => {
-	useDeepCompareLayoutEffect(() => {
-		/**
-		 * create the smoother
-		 */
-		window.lenis?.destroy()
+export const SmoothScrollStyle = (config: LenisOptions) => {
+	const lenisRef = useRef<LenisRef>(null)
 
-		// allow scrolling in error modals, chrome extensions, sanity studio, etc.
-		// i'd like to clean this up a bit, but ok for now
-		const rootLayout = document.querySelector(".root-layout")
-		if (!rootLayout) throw new Error("root-layout not found")
+	useEffect(() => {
+		function update(time: number) {
+			lenisRef.current?.lenis?.raf(time * 1000)
+		}
 
-		// Initialize a new Lenis instance for smooth scrolling
-		const lenis = new Lenis({
-			...config,
-			eventsTarget: rootLayout,
-			infinite: infinite || false,
-		})
+		gsap.ticker.add(update)
+
+		return () => gsap.ticker.remove(update)
+	}, [])
+
+	useEffect(() => {
+		const lenis = lenisRef.current?.lenis
+		if (!lenis) return
+
 		window.lenis = lenis
 
-		// Synchronize Lenis scrolling with GSAP's ScrollTrigger plugin
-		lenis.on("scroll", ScrollTrigger.update)
-
-		// Add Lenis's requestAnimationFrame (raf) method to GSAP's ticker
-		// This ensures Lenis's smooth scroll animation updates on each GSAP tick
-		gsap.ticker.add((time) => {
-			lenis.raf(time * 1000) // Convert time from seconds to milliseconds
-		})
-
-		// Disable lag smoothing in GSAP to prevent any delay in scroll animations
-		gsap.ticker.lagSmoothing(0)
-
-		// refresh on resize
 		let needsRefresh = false
 		let isMounted = true
+
 		const onResize = () => {
 			needsRefresh = true
 		}
+
 		const check = () => {
 			if (!isMounted) return
 			if (needsRefresh && lenis.velocity === 0) {
@@ -183,9 +168,6 @@ export const SmoothScrollStyle = ({
 		}
 		requestAnimationFrame(check)
 
-		/**
-		 * pull state from the scroll locks
-		 */
 		const onChange = () => {
 			const unlockers = locks.find(
 				(lock) => lock.description === "scroll-unlock",
@@ -201,12 +183,22 @@ export const SmoothScrollStyle = ({
 
 		locksChange.addEventListener("change", onChange)
 		window.addEventListener("resize", onResize)
+
 		return () => {
 			isMounted = false
 			locksChange.removeEventListener("change", onChange)
 			window.removeEventListener("resize", onResize)
 		}
-	}, [config])
+	}, [])
 
-	return null
+	return (
+		<ReactLenis
+			root
+			ref={lenisRef}
+			options={{
+				...config,
+				autoRaf: false,
+			}}
+		/>
+	)
 }

--- a/StaticImage.tsx
+++ b/StaticImage.tsx
@@ -110,7 +110,7 @@ export default function StaticImage({
 
 export const defaultImageConfig = {
 	base: [defaultImageClass],
-	variables: {
+	tokens: {
 		objectFit: { token: objectFitVar },
 		objectPosition: { token: objectPositionVar },
 		aspectRatio: { token: aspectRatioVar },

--- a/sanity/SanityImage.tsx
+++ b/sanity/SanityImage.tsx
@@ -116,7 +116,7 @@ export default function SanityUniversalImage(
 
 const DefaultSanityImage = styled(SanityImage as typeof SanityImage<"img">, {
 	base: [defaultImageClass],
-	variables: {
+	tokens: {
 		objectFit: { token: objectFitVar },
 		objectPosition: { token: objectPositionVar },
 		aspectRatio: { token: aspectRatioVar },

--- a/styled/alpha.ts
+++ b/styled/alpha.ts
@@ -8,7 +8,7 @@ import type {
 	StyledInput,
 	StyledOutProps,
 	StyleRules,
-	VariablesSchema,
+	TokensSchema,
 	VariantsSchema,
 } from "./types"
 
@@ -22,14 +22,14 @@ export function styled<
 	Tag extends keyof JSX.IntrinsicElements,
 	_Props extends { className?: string },
 	const Variants extends VariantsSchema = never,
-	const Variables extends VariablesSchema = never,
+	const Tokens extends TokensSchema = never,
 	const DefaultVariants extends DefaultVariantsSchema<Variants> = never,
 >(
 	Component: Tag,
-	config: GenericConfig<Variants, Variables, DefaultVariants> | StyleRules,
+	config: GenericConfig<Variants, Tokens, DefaultVariants> | StyleRules,
 	debugId?: string,
 ): StyledComponent<
-	StyledOutProps<ComponentProps<Tag>, Variants, Variables, DefaultVariants>
+	StyledOutProps<ComponentProps<Tag>, Variants, Tokens, DefaultVariants>
 >
 
 // Overload: component target (function)
@@ -37,26 +37,26 @@ export function styled<
 	_Tag extends keyof JSX.IntrinsicElements,
 	Props extends { className?: string },
 	const Variants extends VariantsSchema = never,
-	const Variables extends VariablesSchema = never,
+	const Tokens extends TokensSchema = never,
 	const DefaultVariants extends DefaultVariantsSchema<Variants> = never,
 >(
 	Component: FunctionComponent<Props>,
-	config: GenericConfig<Variants, Variables, DefaultVariants> | StyleRules,
+	config: GenericConfig<Variants, Tokens, DefaultVariants> | StyleRules,
 	debugId?: string,
-): StyledComponent<StyledOutProps<Props, Variants, Variables, DefaultVariants>>
+): StyledComponent<StyledOutProps<Props, Variants, Tokens, DefaultVariants>>
 
 // Overload: component target (class)
 export function styled<
 	_Tag extends keyof JSX.IntrinsicElements,
 	Props extends { className?: string },
 	const Variants extends VariantsSchema = never,
-	const Variables extends VariablesSchema = never,
+	const Tokens extends TokensSchema = never,
 	const DefaultVariants extends DefaultVariantsSchema<Variants> = never,
 >(
 	Component: ComponentClass<Props>,
-	config: GenericConfig<Variants, Variables, DefaultVariants> | StyleRules,
+	config: GenericConfig<Variants, Tokens, DefaultVariants> | StyleRules,
 	debugId?: string,
-): StyledComponent<StyledOutProps<Props, Variants, Variables, DefaultVariants>>
+): StyledComponent<StyledOutProps<Props, Variants, Tokens, DefaultVariants>>
 
 // most generic, only exists to catch config errors
 // since if the config is invalid typescript will check against
@@ -65,11 +65,11 @@ export function styled<
 	Tag extends keyof JSX.IntrinsicElements,
 	Props extends { className?: string },
 	const Variants extends VariantsSchema = never,
-	const Variables extends VariablesSchema = never,
+	const Tokens extends TokensSchema = never,
 	const DefaultVariants extends DefaultVariantsSchema<Variants> = never,
 >(
 	target: FunctionComponent<Props> | ComponentClass<Props> | Tag,
-	config: GenericConfig<Variants, Variables, DefaultVariants> | StyleRules,
+	config: GenericConfig<Variants, Tokens, DefaultVariants> | StyleRules,
 	debugId?: string,
 ): "Your styled configuration has errors"
 
@@ -78,11 +78,11 @@ export function styled<
 	Tag extends keyof JSX.IntrinsicElements,
 	Props extends { className?: string },
 	const Variants extends VariantsSchema = never,
-	const Variables extends VariablesSchema = never,
+	const Tokens extends TokensSchema = never,
 	const DefaultVariants extends DefaultVariantsSchema<Variants> = never,
 >(
 	target: FunctionComponent<Props> | ComponentClass<Props> | Tag,
-	config: GenericConfig<Variants, Variables, DefaultVariants> | StyleRules,
+	config: GenericConfig<Variants, Tokens, DefaultVariants> | StyleRules,
 	debugId?: string,
 ): unknown {
 	try {

--- a/styled/core.ts
+++ b/styled/core.ts
@@ -18,7 +18,7 @@ function isStyledOptions(input: StyledInput): input is StyledOptions {
 			"variants" in input ||
 			"defaults" in input ||
 			"defaultVariants" in input ||
-			"vars" in input ||
+			"tokens" in input ||
 			"within" in input ||
 			"compoundVariants" in input ||
 			"compounds" in input) &&
@@ -28,7 +28,7 @@ function isStyledOptions(input: StyledInput): input is StyledOptions {
 				key !== "variants" &&
 				key !== "defaults" &&
 				key !== "defaultVariants" &&
-				key !== "vars" &&
+				key !== "tokens" &&
 				key !== "within" &&
 				key !== "compoundVariants" &&
 				key !== "compounds",
@@ -110,9 +110,9 @@ function classFromStyleRules(input: StyleRules | undefined, debugId?: string) {
 	return className
 }
 
-function processVars(vars: StyledOptions["variables"]) {
-	const varDefs = []
-	for (const [propName, tokenSpec] of Object.entries(vars ?? {})) {
+function processTokens(tokens: StyledOptions["tokens"]) {
+	const tokenDefs = []
+	for (const [propName, tokenSpec] of Object.entries(tokens ?? {})) {
 		const isPrimitive =
 			typeof tokenSpec === "string" || typeof tokenSpec === "number"
 		const tokenObj = isPrimitive ? undefined : tokenSpec
@@ -125,9 +125,9 @@ function processVars(vars: StyledOptions["variables"]) {
 			: trimmed.startsWith("--")
 				? trimmed
 				: `--${trimmed}`
-		varDefs.push({ propName, cssVarName, unit })
+		tokenDefs.push({ propName, cssVarName, unit })
 	}
-	return varDefs
+	return tokenDefs
 }
 
 export function styledCore(tag: string, input: StyledInput, debugId?: string) {
@@ -170,8 +170,8 @@ export function styledCore(tag: string, input: StyledInput, debugId?: string) {
 		})
 		.filter(Boolean)
 
-	// 3) vars → runtime varDefs
-	const varDefs = processVars(config.variables)
+	// 3) tokens → runtime tokenDefs
+	const tokenDefs = processTokens(config.tokens)
 
 	// 4) build runtime options
 	const defaultVariants = config.defaultVariants
@@ -182,7 +182,7 @@ export function styledCore(tag: string, input: StyledInput, debugId?: string) {
 	if (compounds && compounds.length > 0) cvaOptions.compoundVariants = compounds
 
 	const args: RuntimeArgs = { tag, cvaBase, cvaOptions }
-	if (varDefs.length) args.varDefs = varDefs
+	if (tokenDefs.length) args.tokenDefs = tokenDefs
 
 	const Component = runtimeStyled(args)
 	addFunctionSerializer(Component, {

--- a/styled/runtime.tsx
+++ b/styled/runtime.tsx
@@ -29,7 +29,7 @@ export type RuntimeArgs = {
 	tag: string
 	cvaBase: string
 	cvaOptions?: CvaConfig
-	varDefs?: Array<{
+	tokenDefs?: Array<{
 		propName: string
 		cssVarName: string
 		unit?: string
@@ -40,7 +40,7 @@ export function runtimeStyled({
 	tag,
 	cvaBase,
 	cvaOptions,
-	varDefs,
+	tokenDefs,
 }: RuntimeArgs) {
 	// @ts-expect-error generated value won't match for cva
 	const resolve = cva(cvaBase, cvaOptions)
@@ -49,20 +49,20 @@ export function runtimeStyled({
 	const variantKeys = Object.keys(
 		(cvaOptions?.variants ?? {}) as Record<string, unknown>,
 	)
-	const varKeys = (varDefs ?? []).map((d) => d.propName)
-	const blockedSet = new Set<string>([...variantKeys, ...varKeys, "as"])
+	const tokenKeys = (tokenDefs ?? []).map((d) => d.propName)
+	const blockedSet = new Set<string>([...variantKeys, ...tokenKeys, "as"])
 
 	const Component = function StyledRuntime(
 		props: Record<string, unknown> = {},
 	) {
 		const { className, style, children, ...rest } = props
 
-		// compute css variable inline styles from props using pre-normalized var defs
-		const varStyle: Record<string, string> = {}
-		for (const def of varDefs ?? []) {
+		// compute css variable inline styles from props using pre-normalized token defs
+		const tokenStyle: Record<string, string> = {}
+		for (const def of tokenDefs ?? []) {
 			const raw = props[def.propName]
 			if (raw === undefined || raw === null) continue
-			varStyle[def.cssVarName] =
+			tokenStyle[def.cssVarName] =
 				typeof raw === "number" && def.unit ? `${raw}${def.unit}` : String(raw)
 		}
 
@@ -81,7 +81,7 @@ export function runtimeStyled({
 				// @ts-expect-error
 				className={cx(resolved, className)}
 				// @ts-expect-error
-				style={{ ...style, ...varStyle }}
+				style={{ ...style, ...tokenStyle }}
 				{...domProps}
 			>
 				{children}

--- a/styled/styled-gen.test-d.tsx
+++ b/styled/styled-gen.test-d.tsx
@@ -139,12 +139,12 @@ test("boolean variants are typed as boolean; optional when default exists", () =
 	expectTypeOf<RP["on"]>().toEqualTypeOf<boolean>()
 })
 
-// ---------- vars: prop typing and units ----------
+// ---------- tokens: prop typing and units ----------
 
-test("vars yield string | number props; units permit numeric values", () => {
+test("tokens yield string | number props; units permit numeric values", () => {
 	const Box = styled("div", {
 		base: [{ border: "1px solid #333" }],
-		variables: {
+		tokens: {
 			height: { token: "var(--h)", unit: "px" },
 			width: "var(--w)", // string or number, no unit coercion
 		},
@@ -294,9 +294,9 @@ test.fails("generic types are preserved with variants config", () => {
 	)
 })
 
-// ---------- generics preservation with vars ----------
+// ---------- generics preservation with tokens config ----------
 
-test.fails("generic types are preserved with vars config", () => {
+test.fails("generic types are preserved with tokens config", () => {
 	const Component = <SomeText extends string>(_props: {
 		id: `id-${SomeText}`
 		one: NoInfer<SomeText>
@@ -306,7 +306,7 @@ test.fails("generic types are preserved with vars config", () => {
 
 	const Extended = styled(Component, {
 		base: [{}],
-		variables: { height: "var(--h)", width: { token: "var(--w)", unit: "px" } },
+		tokens: { height: "var(--h)", width: { token: "var(--w)", unit: "px" } },
 	} as const)
 
 	const _ok = (
@@ -375,7 +375,7 @@ test.fails(
 // 			},
 // 			// @ts-expect-error: not a valid option
 // 			skib: true,
-// 			variables: {
+// 			tokens: {
 // 				// required by default
 // 				paddingMultiplier: {
 // 					token: "var(--padding-multiplier)",

--- a/styled/styled-gen.test-d.tsx
+++ b/styled/styled-gen.test-d.tsx
@@ -320,34 +320,31 @@ test.fails("generic types are preserved with tokens config", () => {
 
 // ---------- generics with multiple generics and variants ----------
 
-test.fails(
-	"generic types with multiple generics are preserved with variants",
-	() => {
-		const Component = <
-			SomeText extends string,
-			AnotherText extends string,
-		>(_props: {
-			id: `id-${SomeText}-${AnotherText}`
-			one: NoInfer<SomeText>
-			two: NoInfer<AnotherText>
-			className?: string
-		}) => <></>
+test.fails("generic types with multiple generics are preserved with variants", () => {
+	const Component = <
+		SomeText extends string,
+		AnotherText extends string,
+	>(_props: {
+		id: `id-${SomeText}-${AnotherText}`
+		one: NoInfer<SomeText>
+		two: NoInfer<AnotherText>
+		className?: string
+	}) => <></>
 
-		const Extended = styled(Component, {
-			base: [{}],
-			variants: { size: { small: [{}], large: [{}] } },
-			defaultVariants: { size: "small" },
-		} as const)
+	const Extended = styled(Component, {
+		base: [{}],
+		variants: { size: { small: [{}], large: [{}] } },
+		defaultVariants: { size: "small" },
+	} as const)
 
-		const _ok = (
-			<>
-				<Component<"a", "b"> id="id-a-b" one="a" two="b" />
-				<Extended<"a", "b"> id="id-a-b" one="a" two="b" />
-				<Extended<"a", "b"> id="id-a-b" one="a" two="b" size="large" />
-			</>
-		)
-	},
-)
+	const _ok = (
+		<>
+			<Component<"a", "b"> id="id-a-b" one="a" two="b" />
+			<Extended<"a", "b"> id="id-a-b" one="a" two="b" />
+			<Extended<"a", "b"> id="id-a-b" one="a" two="b" size="large" />
+		</>
+	)
+})
 
 // test("errors on config are reported in the right place", () => {
 // 	const SmokeBox = styled(

--- a/styled/styled.md
+++ b/styled/styled.md
@@ -45,8 +45,8 @@ const AdvancedComponent = styled("div", {
 	defaults: {
 		/* default variant values */
 	},
-	variables: {
-		/* CSS variable mappings */
+	tokens: {
+		/* CSS variable mappings (our token system, not vanilla-extract's `vars`) */
 	},
 	within: {
 		/* scoped selectors relative to the component root */
@@ -57,7 +57,7 @@ const AdvancedComponent = styled("div", {
 - **`base`**: An array of style objects that are always applied to the component.
 - **`variants`**: An object where keys are prop names and values are objects mapping prop values to styles. This allows for creating different visual states based on props (e.g., `size`, `color`).
 - **`defaults`**: An object specifying the default values for your variants.
-- **`variables`**: An object for mapping component props to CSS variables, enabling fully dynamic styles like custom sizes or colors.
+- **`tokens`**: An object for mapping component props to CSS variables, enabling fully dynamic styles like custom sizes or colors. This is *distinct* from vanilla-extract’s built-in `vars` option; use `tokens` for the styled token system and reserve `vars` for low-level vanilla-extract usage.
 
 #### Within (scoped descendant selectors)
 
@@ -142,7 +142,7 @@ Constraints and notes:
 
 ### Render target override (`as` prop)
 
-All components created with `styled` accept an `as` prop to change the render target at runtime. This works for both DOM tags and React components. Variant and `variables` props are filtered from the DOM and won’t leak.
+All components created with `styled` accept an `as` prop to change the render target at runtime. This works for both DOM tags and React components. Variant and `tokens` props are filtered from the DOM and won’t leak.
 
 ```tsx
 const Box = styled("div", { base: [{ padding: 12, background: "#123" }] })
@@ -181,7 +181,7 @@ const Button = styled("button", {
 // Usage: <Button color="secondary">Click Me</Button>
 ```
 
-#### CSS Variables (`variables`)
+#### CSS Variables via tokens (`tokens`)
 
 For styles that need to be fully dynamic, you can use CSS variables. This is perfect for properties that can have a wide range of values, like `width`, `height`, or `transform`.
 
@@ -190,7 +190,7 @@ const heightVar = createVar()
 
 const DynamicBox = styled("div", {
 	base: [{ border: "1px solid black" }],
-	variables: {
+	tokens: {
 		height: { token: heightVar, unit: "px" },
 	},
 })

--- a/styled/types.ts
+++ b/styled/types.ts
@@ -13,7 +13,7 @@ export type StyleRules = WithinRule | string | StyleRules[]
 type CompoundVariant<Props> = Props & {
 	base: StyleRules
 }
-type VariableOptions =
+type TokenOptions =
 	| {
 			token: ReturnType<typeof createVar>
 			unit?: string
@@ -24,7 +24,7 @@ type StringToBoolean<T> = T extends "true" | "false" ? boolean : T
 
 // schemas to extend for type safety
 export type VariantsSchema = Record<string, Record<string, StyleRules>>
-export type VariablesSchema = Record<string, VariableOptions>
+export type TokensSchema = Record<string, TokenOptions>
 export type DefaultVariantsSchema<Variants> = {
 	[Key in keyof Variants]?: StringToBoolean<keyof Variants[Key]>
 }
@@ -42,16 +42,16 @@ type VariantProps<
 	[Key in keyof Variants]?: StringToBoolean<keyof Variants[Key]>
 }
 
-type VariableProps<Variables extends VariablesSchema> = {
-	[Key in keyof Variables as Variables[Key] extends string
+type TokenProps<Tokens extends TokensSchema> = {
+	[Key in keyof Tokens as Tokens[Key] extends string
 		? never
-		: Variables[Key] extends { optional: true }
+		: Tokens[Key] extends { optional: true }
 			? never
-			: Variables[Key] extends { optional: false }
+			: Tokens[Key] extends { optional: false }
 				? Key
 				: never]: string | number
 } & {
-	[Key in keyof Variables]?: string | number
+	[Key in keyof Tokens]?: string | number
 }
 
 /**
@@ -59,7 +59,7 @@ type VariableProps<Variables extends VariablesSchema> = {
  */
 export type GenericConfig<
 	Variants extends VariantsSchema,
-	Variables extends VariablesSchema,
+	Tokens extends TokensSchema,
 	DefaultVariants extends DefaultVariantsSchema<Variants>,
 > = {
 	/** The base style rule applied to the component. */
@@ -72,7 +72,7 @@ export type GenericConfig<
 	defaultVariants?: DefaultVariants
 
 	/** CSS variable definitions. */
-	variables?: Variables
+	tokens?: Tokens
 	/** Rules for applying styles when multiple variants are active. */
 	compoundVariants?: NoInfer<
 		Array<CompoundVariant<VariantProps<Variants, DefaultVariants>>>
@@ -93,16 +93,16 @@ type SafeKeyOf<T> = T extends never ? never : keyof T
 export type StyledOutProps<
 	Props,
 	Variants extends VariantsSchema,
-	Variables extends VariablesSchema,
+	Tokens extends TokensSchema,
 	DefaultVariants extends DefaultVariantsSchema<Variants>,
 > = DistributiveOmit<
 	Props,
-	SafeKeyOf<VariantProps<Variants, never>> | SafeKeyOf<VariableProps<Variables>>
+	SafeKeyOf<VariantProps<Variants, never>> | SafeKeyOf<TokenProps<Tokens>>
 > &
 	([Variants] extends [never]
 		? unknown
 		: VariantProps<Variants, DefaultVariants>) &
-	([Variables] extends [never] ? unknown : VariableProps<Variables>)
+	([Tokens] extends [never] ? unknown : TokenProps<Tokens>)
 
 export type StyledComponent<Props> = (
 	props: Props & { className?: string },
@@ -118,7 +118,7 @@ export type FunctionComponent<Props> = (
  */
 export type StyledOptions = GenericConfig<
 	VariantsSchema,
-	VariablesSchema,
+	TokensSchema,
 	DefaultVariantsSchema<VariantsSchema>
 >
 

--- a/vanilla/vanilla-split-loader.ts
+++ b/vanilla/vanilla-split-loader.ts
@@ -1113,7 +1113,7 @@ const transform = async (
 	await fs.writeFile(preProcessDebugPath, virtualSourceResolved)
 
 	// 5) write temp file mirroring the original relative path
-	const tmpRoot = path.join(rootContext, ".next", "cache", "vanilla-split")
+	const tmpRoot = path.join(rootContext, ".next", "vanilla")
 	const tmpFile = path
 		.join(tmpRoot, `${relPathNoExt}.css.ts`)
 		.replace(/\\/g, "/")

--- a/vanilla/vanilla-split-loader.ts
+++ b/vanilla/vanilla-split-loader.ts
@@ -1120,15 +1120,9 @@ const transform = async (
 	fsSync.mkdirSync(path.dirname(tmpFile), { recursive: true })
 	fsSync.writeFileSync(tmpFile, virtualSourceResolved, "utf8")
 
-	// 6) run VE plugin on temp file and delete it immediately after
+	// 6) run VE plugin on temp file (keep file on disk for debugging)
 	let veJs = ""
-	try {
-		veJs = await runVePluginOnTempFile(loaderThis, tmpFile, filePath, options)
-	} finally {
-		try {
-			fsSync.unlinkSync(tmpFile)
-		} catch {}
-	}
+	veJs = await runVePluginOnTempFile(loaderThis, tmpFile, filePath, options)
 
 	// 7) rewrite imports in VE output to tsconfig-safe specifiers
 	const veJsResolved = rewriteToTsconfig(veJs, tmpFile, rootContext)


### PR DESCRIPTION
This pull request introduces a significant terminology and API change across the styled component system, replacing the use of "variables" with "tokens" to clarify the distinction from vanilla-extract's `vars` and to better align with a design token system. It also updates the smooth scrolling implementation to use the latest Lenis React integration and cleans up related logic. The changes affect core styling logic, type definitions, documentation, and usage throughout the codebase.

**Key changes:**

### Styled system: "variables" → "tokens" migration

- Replaced all instances of `variables` with `tokens` in the styled component API, type definitions, and runtime logic, including function signatures, config objects, and internal processing (`styled/alpha.ts`, `styled/core.ts`, `styled/runtime.tsx`, `styled/styled-gen.test-d.tsx`, `styled/styled.md`). [[1]](diffhunk://#diff-ced528de7f15514f435fc84cd411e4eee59e9ca8aca12f39740a360edcf372e8L11-R11) [[2]](diffhunk://#diff-ced528de7f15514f435fc84cd411e4eee59e9ca8aca12f39740a360edcf372e8L25-R59) [[3]](diffhunk://#diff-ced528de7f15514f435fc84cd411e4eee59e9ca8aca12f39740a360edcf372e8L68-R72) [[4]](diffhunk://#diff-ced528de7f15514f435fc84cd411e4eee59e9ca8aca12f39740a360edcf372e8L81-R85) [[5]](diffhunk://#diff-0fc95143fbf5d7560e9d44344cf425c8d8a9a860ee4efce41720f46323074dc0L21-R21) [[6]](diffhunk://#diff-0fc95143fbf5d7560e9d44344cf425c8d8a9a860ee4efce41720f46323074dc0L31-R31) [[7]](diffhunk://#diff-0fc95143fbf5d7560e9d44344cf425c8d8a9a860ee4efce41720f46323074dc0L113-R115) [[8]](diffhunk://#diff-0fc95143fbf5d7560e9d44344cf425c8d8a9a860ee4efce41720f46323074dc0L128-R130) [[9]](diffhunk://#diff-0fc95143fbf5d7560e9d44344cf425c8d8a9a860ee4efce41720f46323074dc0L173-R174) [[10]](diffhunk://#diff-0fc95143fbf5d7560e9d44344cf425c8d8a9a860ee4efce41720f46323074dc0L185-R185) [[11]](diffhunk://#diff-5c2e1aa80ebaf40e8dc7d77e5e6aae9655faba8f8ddd0c4c58b70b5e33b4213cL32-R32) [[12]](diffhunk://#diff-5c2e1aa80ebaf40e8dc7d77e5e6aae9655faba8f8ddd0c4c58b70b5e33b4213cL43-R43) [[13]](diffhunk://#diff-5c2e1aa80ebaf40e8dc7d77e5e6aae9655faba8f8ddd0c4c58b70b5e33b4213cL52-R65) [[14]](diffhunk://#diff-5c2e1aa80ebaf40e8dc7d77e5e6aae9655faba8f8ddd0c4c58b70b5e33b4213cL84-R84) [[15]](diffhunk://#diff-fd52e71eeca02803303add5934ec61a2e9c6f614c11f8cb9dbdbd33bba7dfc1aL142-R147) [[16]](diffhunk://#diff-fd52e71eeca02803303add5934ec61a2e9c6f614c11f8cb9dbdbd33bba7dfc1aL297-R299) [[17]](diffhunk://#diff-fd52e71eeca02803303add5934ec61a2e9c6f614c11f8cb9dbdbd33bba7dfc1aL309-R309) [[18]](diffhunk://#diff-fd52e71eeca02803303add5934ec61a2e9c6f614c11f8cb9dbdbd33bba7dfc1aL378-R378) [[19]](diffhunk://#diff-24c4ad9795327560bff9d6d33219e5191498f03c086a0d8b232f5e756cff7bd2L48-R49) [[20]](diffhunk://#diff-24c4ad9795327560bff9d6d33219e5191498f03c086a0d8b232f5e756cff7bd2L60-R60)
- Updated styled component usage in `AutoAnimate.tsx`, `StaticImage.tsx`, and `sanity/SanityImage.tsx` to use the new `tokens` key. [[1]](diffhunk://#diff-c430f57cc8938addeaee4a9d912effde51749ff22c8f432e75c0d7a2f5ce8d77L349-R349) [[2]](diffhunk://#diff-89edd113f69cc23cb06c08da0461c0926562d56773931fddd3637e9d9b5d2998L113-R113) [[3]](diffhunk://#diff-59a4c4cb3eacb0e5a370aa0ec01497fbfbda9760d252ebe0d4062f0a14d51a92L119-R119)
- Updated documentation and comments to clarify the purpose of `tokens` and distinguish it from vanilla-extract's `vars`. [[1]](diffhunk://#diff-24c4ad9795327560bff9d6d33219e5191498f03c086a0d8b232f5e756cff7bd2L48-R49) [[2]](diffhunk://#diff-24c4ad9795327560bff9d6d33219e5191498f03c086a0d8b232f5e756cff7bd2L60-R60)

### Smooth scrolling: Lenis React integration and logic cleanup

- Refactored the smooth scrolling logic in `Scroll.tsx` to use the `ReactLenis` component and `LenisRef` from `lenis/react`, replacing manual Lenis instantiation and lifecycle management. [[1]](diffhunk://#diff-e2b20508cb3fd0800a764aa2390a8e22b10108be49ce67f1bcedc693476f04a9L4-R7) [[2]](diffhunk://#diff-e2b20508cb3fd0800a764aa2390a8e22b10108be49ce67f1bcedc693476f04a9L135-R160) [[3]](diffhunk://#diff-e2b20508cb3fd0800a764aa2390a8e22b10108be49ce67f1bcedc693476f04a9R186-R203)
- Simplified the `useIsSmooth` hook to listen for Lenis scroll events and determine smooth mode based on Lenis state, removing URL flag checks and event listeners for wheel/touch.
- Cleaned up and streamlined resize and scroll lock logic in the smooth scroll implementation.

These changes modernize the styling API, improve clarity for consumers, and update the smooth scrolling implementation to leverage the latest best practices.