### PR TITLE
Style Rewrite

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -4,7 +4,7 @@ on:
     secrets:
       SECRETS_JSON:
         required: false
-    inputs: 
+    inputs:
       runOnGithubActions:
         required: true
         type: boolean
@@ -60,7 +60,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
       # END INSTALLATION
-
       - name: Build
         if: github.event.action != 'closed'
         run: pnpm run build

--- a/biome/biome-library.jsonc
+++ b/biome/biome-library.jsonc
@@ -41,7 +41,7 @@
 		}
 	},
 	"files": {
-		"includes": ["**", "!pnpm-lock.yaml", "!gsapHelpers", "!vanilla/*/dist"]
+		"includes": ["**", "!pnpm-lock.yaml", "!gsapHelpers", "!vanilla/*"]
 	},
 	"vcs": {
 		"enabled": true,

--- a/biome/biome-project.jsonc
+++ b/biome/biome-project.jsonc
@@ -3,8 +3,8 @@
 	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"root": true,
 	"plugins": [
-		"./app/library/biome/memoization.grit",
-		"./app/library/biome/forwardRef.grit"
+		"./library/biome/memoization.grit",
+		"./library/biome/forwardRef.grit"
 	],
 	"linter": {
 		"enabled": true,
@@ -45,7 +45,7 @@
 		}
 	},
 	"files": {
-		"includes": ["**", "!**/pnpm-lock.yaml", "!**/app/library"]
+		"includes": ["**", "!**/pnpm-lock.yaml", "!**/library"]
 	},
 	"vcs": {
 		"enabled": true,

--- a/defaultConfig.ts
+++ b/defaultConfig.ts
@@ -33,6 +33,12 @@ type Config<TransitionNames = never, GroupNames = never> = {
 	 * styling system to use
 	 */
 	stylingSystem: "vanilla" | "restyle" | "both"
+	/**
+	 * for the vanilla extract styling system, which engine to use
+	 * "calc" will wrap each px value in a calc() function that calculates the value based on breakpoints
+	 * "media" will wrap entire statements in a media query based on breakpoints
+	 */
+	vanillaExtractEngine: "calc" | "media"
 }
 
 const defaultConfig = {
@@ -43,6 +49,7 @@ const defaultConfig = {
 	tabletBreakpoint: "tablet",
 	pageSectionGroups: [],
 	stylingSystem: "both",
+	vanillaExtractEngine: "calc",
 } as const satisfies Config
 
 export const defineLibraryConfig = <const TransitionNames, const GroupNames>(

--- a/defaultConfig.ts
+++ b/defaultConfig.ts
@@ -1,6 +1,6 @@
 /**
  * config schema and config defaults for the reform util library
- * see app/libraryConfig.ts for the actual config
+ * see libraryConfig.ts for the actual config
  */
 
 type Config<TransitionNames = never, GroupNames = never> = {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"description": "collection of utilities and helpers for reform collective",
 	"//": "anything that the supermodule may also install should use the ^major syntax. this is so that pnpm can combine duplicate versions to prevent inflating the bundle. this doesn't apply to dev dependencies (e.g. biome)",
 	"dependencies": {
+		"@eslint/css-tree": "3.6.8",
 		"@mux/blurup": "1.0.2",
 		"@mux/mux-video-react": "^0",
 		"@sanity/image-url": "2.0.1",

--- a/reset.tsx
+++ b/reset.tsx
@@ -1,4 +1,4 @@
-import { css } from "library/styled/alpha"
+import { compileTime, css } from "library/styled/alpha"
 import { reset } from "./layers.css"
 
 const style = css`
@@ -286,4 +286,6 @@ display:revert; revert to element instead of attribute */
 	}
 `
 
-export const ResetStyles = () => <style>{style}</style>
+const builtStyle = compileTime(() => style)
+
+export const ResetStyles = () => <style>{builtStyle}</style>

--- a/sanity/reusableFetchClient.ts
+++ b/sanity/reusableFetchClient.ts
@@ -3,8 +3,8 @@
 import { usePathname } from "next/navigation"
 import { isCorsOriginError } from "next-sanity/live"
 import { useEffect, useState } from "react"
-import { toast } from "sonner"
 import { studioUrl } from "sanity/lib/api"
+import { toast } from "sonner"
 
 /**
  * if sanity live is initialized in the studio, the page

--- a/sanity/reusableFetchClient.ts
+++ b/sanity/reusableFetchClient.ts
@@ -4,7 +4,7 @@ import { usePathname } from "next/navigation"
 import { isCorsOriginError } from "next-sanity/live"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
-import { studioUrl } from "../../../sanity/lib/api"
+import { studioUrl } from "sanity/lib/api"
 
 /**
  * if sanity live is initialized in the studio, the page

--- a/styled/README.md
+++ b/styled/README.md
@@ -3,6 +3,7 @@
 the `styled` utility is our zero-runtime css-in-js solution. it wraps `vanilla-extract` to provide an ergonomic API for building reactive, responsive components with static css generation.
 
 it combines the best of both worlds:
+
 - **zero runtime overhead**: styles are extracted to static css files.
 - **developer experience**: type-safe props, variants, and a unified api.
 - **responsive magic**: built-in utilities for fluid scaling and breakpoint switching.
@@ -15,21 +16,21 @@ import `styled` and the `f` utility from `library/styled/alpha`.
 import { styled, f, css } from "library/styled/alpha"
 
 const Box = styled("div", [
-  // static styles with responsive scaling
-  f.responsive(css`
-    background: blue;
-    padding: 20px; /* automatically converts to responsive units */
-    border-radius: 8px;
-  `),
-  // specific overrides
-  f.mobile(css`
-    flex-direction: column;
-  `)
+	// static styles with responsive scaling
+	f.responsive(css`
+		background: blue;
+		padding: 20px; /* automatically converts to responsive units */
+		border-radius: 8px;
+	`),
+	// specific overrides
+	f.mobile(css`
+		flex-direction: column;
+	`),
 ])
 
 // usage
 function App() {
-  return <Box>hello</Box>
+	return <Box>hello</Box>
 }
 ```
 
@@ -40,61 +41,63 @@ function App() {
 `styled(Target, Config)`
 
 ### 1. target
+
 can be an html tag (`"div"`, `"a"`) or a react component.
 
 ### 2. config object
+
 for anything beyond simple static styles, pass a config object.
 
 ```ts
 const Card = styled("article", {
-  // 1. base styles (always applied)
-  base: [
-    f.responsive(css`
-      display: flex;
-      gap: 16px;
-      padding: 24px;
-      background: #fff;
-    `)
-  ],
+	// 1. base styles (always applied)
+	base: [
+		f.responsive(css`
+			display: flex;
+			gap: 16px;
+			padding: 24px;
+			background: #fff;
+		`),
+	],
 
-  // 2. variants (prop-driven styles)
-  variants: {
-    tone: {
-      light: [{ background: "#fff", color: "#000" }],
-      dark: [{ background: "#000", color: "#fff" }]
-    },
-    size: {
-      sm: [{ padding: 12 }],
-      lg: [{ padding: 32 }]
-    }
-  },
+	// 2. variants (prop-driven styles)
+	variants: {
+		tone: {
+			light: [{ background: "#fff", color: "#000" }],
+			dark: [{ background: "#000", color: "#fff" }],
+		},
+		size: {
+			sm: [{ padding: 12 }],
+			lg: [{ padding: 32 }],
+		},
+	},
 
-  // 3. defaults (optional)
-  defaultVariants: {
-    tone: "light",
-    size: "sm"
-  },
+	// 3. defaults (optional)
+	defaultVariants: {
+		tone: "light",
+		size: "sm",
+	},
 
-  // 4. compound variants (styles for specific prop combos)
-  compoundVariants: [
-    {
-      tone: "dark",
-      size: "lg",
-      base: [{ border: "1px solid #333" }]
-    }
-  ],
+	// 4. compound variants (styles for specific prop combos)
+	compoundVariants: [
+		{
+			tone: "dark",
+			size: "lg",
+			base: [{ border: "1px solid #333" }],
+		},
+	],
 
-  // 5. tokens (dynamic css variables)
-  tokens: {
-    // maps the `rotation` prop to a css variable
-    rotation: { token: createVar(), unit: "deg" }
-  },
+	// 5. tokens (dynamic css variables)
+	tokens: {
+		// maps the `rotation` prop to a css variable
+		rotation: { token: createVar(), unit: "deg" },
+	},
 
-  // 6. within (scoped arbitrary child selectors)
-  within: {
-    "& *:hover": { transform: "translateY(-2px)" },
-    "h2": { fontSize: 24, marginBottom: 8 }
-  }
+	// 6. within (scoped arbitrary child selectors)
+	within: {
+		"& *:hover": { transform: "translateY(-2px)" },
+		h2: { fontSize: 24, marginBottom: 8 },
+	},
 })
 ```
 
@@ -105,6 +108,7 @@ const Card = styled("article", {
 the `f` object is your best friend. it handles unit conversion (px to vw), breakpoint isolation, and fluid scaling logic.
 
 ### `f.responsive` (the magic one)
+
 takes standard css with pixel values and converts them into a responsive `calc()` expression that switches based on the viewport.
 
 - **desktop**: scales with viewport width (vw)
@@ -112,12 +116,13 @@ takes standard css with pixel values and converts them into a responsive `calc()
 
 ```ts
 f.responsive({
-  fontSize: "16px", // becomes a complex calc() covering all breakpoints
-  margin: "20px 40px"
+	fontSize: "16px", // becomes a complex calc() covering all breakpoints
+	margin: "20px 40px",
 })
 ```
 
 ### breakpoint helpers
+
 target specific ranges. these wrap your styles in `@media` queries.
 
 - `f.desktop(...)`: desktop only
@@ -127,13 +132,15 @@ target specific ranges. these wrap your styles in `@media` queries.
 - `f.large(...)`: desktop + full width
 
 ### `f.scaledResponsive`
-forces `vw` scaling across *all* breakpoints, ignoring the step-based switching of standard responsive mode.
+
+forces `vw` scaling across _all_ breakpoints, ignoring the step-based switching of standard responsive mode.
 
 ---
 
 ## core features detailed
 
 ### variants
+
 variants are the primary way to define component api. keys in `variants` become props on your component.
 
 **note**: variant props are required by default unless you specify a default in `defaultVariants`.
@@ -155,6 +162,7 @@ defaultVariants: {
 ```
 
 ### tokens (dynamic values)
+
 use `tokens` when you need to pass arbitrary runtime values (like coordinates, colors from an api, or exact dimensions) into your static css.
 
 **note**: token props are always required unless you mark them as optional.
@@ -184,14 +192,17 @@ const Rotator = styled("div", {
 ```
 
 ### within (targeting children)
+
 standard style blocks (like `base` or `variants`) **must** target the component itself using `&`.
 
 ✅ **valid in `base`/`variants`**:
+
 - `&:hover`
 - `html[data-dark] &`
 - `${Component} > &`
 
 ❌ **invalid in `base`/`variants`** (must use `within` to write these):
+
 - `& svg`
 - `& > *:hover`
 
@@ -205,26 +216,30 @@ within: {
 ```
 
 ### referencing components (`toString`)
+
 styled components implement a `toString` method that returns their unique class selector (e.g., `Box_root__1x2y3z`). this allows you to target one component from within another's styles.
 
 ```tsx
 const Icon = styled("span", {
-  base: [{ opacity: 0 }]
+	base: [{ opacity: 0 }],
 })
 
 const Button = styled("button", {
-  base: [{
-    // using template literal interpolation calls .toString() automatically
-    [`&:hover .${Icon}`]: {
-      opacity: 1
-    }
-  }]
+	base: [
+		{
+			// using template literal interpolation calls .toString() automatically
+			[`&:hover .${Icon}`]: {
+				opacity: 1,
+			},
+		},
+	],
 })
 ```
 
 this is extremely powerful for composition, allowing parent components to orchestrate child styles without prop drilling.
 
 ### the `as` prop
+
 at runtime, every styled component accepts an `as` prop to change the rendered element at runtime.
 this is used under the hood, but you should also be able to use it yourself
 
@@ -241,7 +256,8 @@ const Text = styled("p", { ... })
 ---
 
 ### .css.ts vs .tsx
+
 - **preferred**: define styled components in `.tsx` files. the `vanilla-split` loader handles the heavy lifting.
-- **Important:** Only define vanilla-extract styles in the file where they are used, or in a `.css.ts` file that is imported directly by the consumer file. 
+- **Important:** Only define vanilla-extract styles in the file where they are used, or in a `.css.ts` file that is imported directly by the consumer file.
 - **Do not export** styled components or style objects from regular `.ts` or `.tsx` files for use elsewhere—this will fail.
 - Use `.css.ts` files strictly for vanilla-extract variables, keyframes, global styles, or style objects that are imported (not exported) where needed.

--- a/styled/alpha.ts
+++ b/styled/alpha.ts
@@ -14,6 +14,8 @@ import type {
 
 export * from "./vanilla"
 
+export const css = String.raw
+
 export function compileTime<T>(getValue: () => T): T {
 	return getValue()
 }

--- a/styled/alpha.ts
+++ b/styled/alpha.ts
@@ -14,6 +14,10 @@ import type {
 
 export * from "./vanilla"
 
+export function compileTime<T>(getValue: () => T): T {
+	return getValue()
+}
+
 // using a union for the type of Component will cause
 // generic forwarding to fail, so we have overloads for each type
 

--- a/styled/codemod.js
+++ b/styled/codemod.js
@@ -168,7 +168,7 @@ async function run() {
 			"**/node_modules/**",
 			"**/.next/**",
 			"**/dist/**",
-			"**/app/library/**",
+			"**/library/**",
 		],
 		onlyFiles: true,
 		expandDirectories: false,

--- a/styled/styled-gen.test-d.tsx
+++ b/styled/styled-gen.test-d.tsx
@@ -1,5 +1,3 @@
-// app/library/styled.reform.test-d.ts
-
 import { style } from "@vanilla-extract/css"
 import { styled } from "library/styled/alpha"
 import { Component, type ComponentProps, type FC } from "react"

--- a/styled/vanilla.ts
+++ b/styled/vanilla.ts
@@ -1,10 +1,6 @@
+import type { StyleRule } from "@vanilla-extract/css"
+import * as csstree from "@eslint/css-tree"
 import config from "libraryConfig"
-import libraryConfig from "libraryConfig"
-import {
-	type StyleRule,
-	keyframes as vanillaKeyframes,
-} from "@vanilla-extract/css"
-import { type ComponentType, createElement } from "react"
 import {
 	desktopBreakpoint,
 	desktopDesignSize,
@@ -13,246 +9,39 @@ import {
 	tabletBreakpoint,
 	tabletDesignSize,
 } from "styles/media"
-import { COMMENT, compile, DECLARATION, type Element, RULESET } from "stylis"
-import { isDesktop, isFull, isMobile, isTablet } from "./breakpoints.css"
 import { isBrowser } from "../deviceDetection"
+import { isDesktop, isFull, isMobile, isTablet } from "./breakpoints.css"
 
-export type CSSObject = StyleRule
-export type CSSValue = string | number | StyleRule
-
-if (libraryConfig.stylingSystem === "restyle")
+if (config.stylingSystem === "restyle")
 	throw new Error(
 		"this project is only configured to use the restyle styling system",
 	)
 
-if (isBrowser) {
+if (isBrowser)
 	throw new Error(
 		"style system was loaded in the browser! this will explode your bundle size!",
 	)
+
+// =============================================================================
+// Types
+// =============================================================================
+
+type Breakpoint = "mobile" | "tablet" | "desktop" | "fullWidth"
+type DesignSize = "mobile" | "tablet" | "desktop"
+type BreakpointCombo = "small" | "large" | "all"
+
+type OutputType = "fluid" | "pixel" | "scaleFullyConfig"
+type ResponsiveEngine = "calc" | "media"
+
+type BreakpointRule = {
+	breakpoint: Breakpoint
+	designSize: DesignSize
+	output: OutputType
 }
-
-export function attrs<Props>(
-	Component: ComponentType<Props>,
-	addedProps: Partial<Props>,
-) {
-	return (props: Props) =>
-		createElement(
-			Component as ComponentType<unknown>,
-			{
-				...addedProps,
-				...props,
-			} as Record<string, unknown>,
-		)
-}
-
-// Re-exports and helpers from the combined module
-export const px = (n: number) => `${n}px`
-export const vw = (n: number) => `${n}vw`
-export const switchValue4 = (
-	mobile: string,
-	tablet: string,
-	desktop: string,
-	full: string,
-) =>
-	`calc((${mobile}) * ${isMobile} + (${tablet}) * ${isTablet} + (${desktop}) * ${isDesktop} + (${full}) * ${isFull})`
-
-const toCamel = (prop: string) =>
-	prop.startsWith("--")
-		? prop
-		: prop.replace(/-([a-z])/g, (_, c) => c.toUpperCase())
-
-type MutableStyle = Record<string, unknown> & {
-	selectors?: Record<string, MutableStyle>
-	"@media"?: Record<string, MutableStyle>
-	"@supports"?: Record<string, MutableStyle>
-	"@container"?: Record<string, MutableStyle>
-	"@layer"?: Record<string, MutableStyle>
-}
-
-const convert = (elements: Element[]): MutableStyle => {
-	const style: MutableStyle = {}
-	for (const el of elements) {
-		if (el.type === COMMENT) continue
-		if (el.type === DECLARATION) {
-			if (Array.isArray(el.props)) continue
-			style[toCamel(String(el.props))] = String(el.children)
-			continue
-		}
-		if (el.type === RULESET) {
-			if (!Array.isArray(el.children)) continue
-			const sel = String(el.value || el.props).replaceAll("\f", "")
-			style.selectors ||= {}
-			style.selectors[sel] = convert(el.children)
-			continue
-		}
-		if (typeof el.type === "string" && el.type.startsWith("@")) {
-			if (!Array.isArray(el.children)) continue
-			const name = Array.isArray(el.props)
-				? String(el.props[0] ?? "")
-				: String((el.props as string) ?? el.value ?? "")
-			if (el.type === "@media") {
-				style["@media"] ||= {}
-				style["@media"][name] = convert(el.children)
-				continue
-			}
-			if (el.type === "@supports") {
-				style["@supports"] ||= {}
-				style["@supports"][name] = convert(el.children)
-				continue
-			}
-			if (el.type === "@container") {
-				style["@container"] ||= {}
-				style["@container"][name] = convert(el.children)
-				continue
-			}
-			if (el.type === "@layer") {
-				style["@layer"] ||= {}
-				style["@layer"][name] = convert(el.children)
-			}
-			// ignore other at-rules for this POC
-		}
-	}
-	return style
-}
-
-export const css = String.raw
-
-const compileCssText = (content: string): StyleRule =>
-	convert(compile(content)) as unknown as StyleRule
-
-const fromTemplate = (
-	tpl: TemplateStringsArray,
-	values: Array<string | number>,
-): StyleRule => compileCssText(String.raw(tpl, ...values))
-
-const isTemplate = (v: unknown): v is TemplateStringsArray =>
-	Array.isArray(v) && Object.hasOwn(v, "raw")
-
-const isStringOrNumber = (value: unknown): value is string | number =>
-	typeof value === "string" || typeof value === "number"
-
-const resolveStyleRule = (
-	input: TemplateStringsArray | string | StyleRule,
-	optionsOrExpr: unknown,
-	expr: Array<string | number>,
-	hasOptions: boolean,
-): StyleRule => {
-	if (isTemplate(input))
-		return fromTemplate(
-			input,
-			(hasOptions ? expr : [optionsOrExpr, ...expr]).filter(isStringOrNumber),
-		)
-	if (typeof input === "string") return compileCssText(input)
-	return input as StyleRule
-}
-
-export const unresponsive = (
-	input: TemplateStringsArray | string | StyleRule,
-	...expr: Array<string | number>
-): StyleRule =>
-	isTemplate(input)
-		? normalizeSelectorsOnly(fromTemplate(input, expr))
-		: typeof input === "string"
-			? normalizeSelectorsOnly(compileCssText(input))
-			: normalizeSelectorsOnly(input as StyleRule)
-
-export const keyframes = (
-	tpl: TemplateStringsArray,
-	...expr: Array<string | number>
-) => {
-	const rule = fromTemplate(tpl, expr)
-	const selectors = (rule as Record<string, unknown>).selectors as
-		| Record<string, StyleRule>
-		| undefined
-	if (!selectors)
-		throw new Error(
-			"keyframes template must contain at least one frame selector",
-		)
-	return vanillaKeyframes(selectors)
-}
-
-const normalizeSelectorsOnly = (rule: StyleRule): StyleRule => {
-	const out: Record<string, unknown> = {}
-	for (const [key, val] of Object.entries(rule as Record<string, unknown>)) {
-		if (key === "selectors") {
-			const nested: Record<string, unknown> = {}
-			for (const [rawSel, child] of Object.entries(
-				val as Record<string, unknown>,
-			)) {
-				let sel = String(rawSel).trim()
-				if (sel.startsWith(":")) sel = `&${sel}`
-				sel = sel.replace(/&\s*([>+~])\s*/g, "& $1 ")
-				nested[sel] = normalizeSelectorsOnly(child as StyleRule)
-			}
-			out.selectors = nested
-			continue
-		}
-		if (
-			key === "@media" ||
-			key === "@supports" ||
-			key === "@container" ||
-			key === "@layer"
-		) {
-			const nested: Record<string, unknown> = {}
-			for (const [k, child] of Object.entries(val as Record<string, unknown>)) {
-				nested[k] = normalizeSelectorsOnly(child as StyleRule)
-			}
-			out[key] = nested
-			continue
-		}
-		if (typeof val === "object" && val) {
-			out[key] = normalizeSelectorsOnly(val as StyleRule)
-		} else {
-			out[key] = val
-		}
-	}
-	return out as StyleRule
-}
-
-const VW_PRECISION = 3
-const PIXEL_PRECISION = 2
-const pxRegex = /(-?\d*\.?\d+)px\b/g
-
-const toVw = (px: number, design: number) =>
-	`${((px / design) * 100).toFixed(VW_PRECISION)}vw`
-const toPxString = (val: number) => {
-	const out = val.toFixed(PIXEL_PRECISION)
-	return `${out}px`.replace(".00px", "px")
-}
-const toFull = (
-	px: number,
-	desktopSize: number,
-	overrideScaleFully?: boolean,
-) => {
-	const useScale = overrideScaleFully ?? config.scaleFully
-	if (useScale) return toVw(px, desktopSize)
-	const val = (px * desktopBreakpoint) / desktopSize
-	return toPxString(val)
-}
-
-const toLargeMobilePx = (px: number, mobileSize: number) => {
-	const val = (px / mobileSize) * mobileBreakpoint
-	return toPxString(val)
-}
-
-type FMode =
-	| "responsive"
-	| "scaledResponsive"
-	| "large"
-	| "small"
-	| "fullWidth"
-	| "desktop"
-	| "tablet"
-	| "mobile"
-	| "allFullWidth"
-	| "allDesktop"
-	| "allTablet"
-	| "allMobile"
 
 type FOptions = {
-	only?: "mobile" | "tablet" | "desktop" | "fullWidth"
+	engine?: ResponsiveEngine
 	scaleFully?: boolean
-	applyStylesToAllBreakpoints?: boolean
 	designSizeOverride?: {
 		desktop?: number
 		tablet?: number
@@ -260,362 +49,381 @@ type FOptions = {
 	}
 }
 
-const computeTerms = (px: number, mode: FMode, options?: FOptions) => {
-	const original = `${px}px`
-	const mobileSize = options?.designSizeOverride?.mobile ?? mobileDesignSize
-	const tabletSize = options?.designSizeOverride?.tablet ?? tabletDesignSize
-	const desktopSize = options?.designSizeOverride?.desktop ?? desktopDesignSize
-	const forceScaleFully = options?.scaleFully ?? mode === "scaledResponsive"
+type PxTransform = (px: number) => string
 
-	const m = toVw(px, mobileSize)
-	const t =
-		config.tabletBreakpoint === "tablet"
-			? toVw(px, tabletSize)
-			: toLargeMobilePx(px, mobileSize)
-	const d = toVw(px, desktopSize)
-	const f = toFull(px, desktopSize, forceScaleFully)
-	return { original, m, t, d, f }
+// =============================================================================
+// Utilities Config
+// =============================================================================
+
+const TABLET_RULE: BreakpointRule =
+	config.tabletBreakpoint === "tablet"
+		? { breakpoint: "tablet", designSize: "tablet", output: "fluid" }
+		: { breakpoint: "tablet", designSize: "mobile", output: "pixel" }
+
+const UTILITIES = {
+	responsive: [
+		{ breakpoint: "mobile", designSize: "mobile", output: "fluid" },
+		TABLET_RULE,
+		{ breakpoint: "desktop", designSize: "desktop", output: "fluid" },
+		{
+			breakpoint: "fullWidth",
+			designSize: "desktop",
+			output: "scaleFullyConfig",
+		},
+	],
+
+	scaledResponsive: [
+		{ breakpoint: "mobile", designSize: "mobile", output: "fluid" },
+		TABLET_RULE,
+		{ breakpoint: "desktop", designSize: "desktop", output: "fluid" },
+		{ breakpoint: "fullWidth", designSize: "desktop", output: "fluid" },
+	],
+
+	large: [
+		{ breakpoint: "desktop", designSize: "desktop", output: "fluid" },
+		{
+			breakpoint: "fullWidth",
+			designSize: "desktop",
+			output: "scaleFullyConfig",
+		},
+	],
+
+	small: [
+		{ breakpoint: "mobile", designSize: "mobile", output: "fluid" },
+		TABLET_RULE,
+	],
+
+	fullWidth: [
+		{
+			breakpoint: "fullWidth",
+			designSize: "desktop",
+			output: "scaleFullyConfig",
+		},
+	],
+
+	desktop: [{ breakpoint: "desktop", designSize: "desktop", output: "fluid" }],
+
+	tablet: [TABLET_RULE],
+
+	mobile: [{ breakpoint: "mobile", designSize: "mobile", output: "fluid" }],
+
+	allFullWidth: [
+		{ breakpoint: "mobile", designSize: "desktop", output: "scaleFullyConfig" },
+		{ breakpoint: "tablet", designSize: "desktop", output: "scaleFullyConfig" },
+		{
+			breakpoint: "desktop",
+			designSize: "desktop",
+			output: "scaleFullyConfig",
+		},
+		{
+			breakpoint: "fullWidth",
+			designSize: "desktop",
+			output: "scaleFullyConfig",
+		},
+	],
+
+	allDesktop: [
+		{ breakpoint: "mobile", designSize: "desktop", output: "fluid" },
+		{ breakpoint: "tablet", designSize: "desktop", output: "fluid" },
+		{ breakpoint: "desktop", designSize: "desktop", output: "fluid" },
+		{ breakpoint: "fullWidth", designSize: "desktop", output: "fluid" },
+	],
+
+	allTablet: [
+		{ ...TABLET_RULE, breakpoint: "mobile" },
+		{ ...TABLET_RULE, breakpoint: "tablet" },
+		{ ...TABLET_RULE, breakpoint: "desktop" },
+		{ ...TABLET_RULE, breakpoint: "fullWidth" },
+	],
+
+	allMobile: [
+		{ breakpoint: "mobile", designSize: "mobile", output: "fluid" },
+		{ breakpoint: "tablet", designSize: "mobile", output: "fluid" },
+		{ breakpoint: "desktop", designSize: "mobile", output: "fluid" },
+		{ breakpoint: "fullWidth", designSize: "mobile", output: "fluid" },
+	],
+} satisfies Record<string, BreakpointRule[]>
+
+// =============================================================================
+// Config
+// =============================================================================
+
+/**
+ * decimal precision for generated vw values
+ */
+const VW_PRECISION = 3
+/**
+ * decimal precision for generated px values
+ */
+const PIXEL_PRECISION = 2
+/**
+ * responsive engine to use
+ */
+const DEFAULT_ENGINE: ResponsiveEngine = config.vanillaExtractEngine
+
+// =============================================================================
+// Internal Constants
+// =============================================================================
+
+let hash = 0
+const getInjectionKey = () => `--s-${hash++}`
+
+const DESIGN_SIZE: Record<DesignSize, number> = {
+	mobile: mobileDesignSize,
+	tablet: tabletDesignSize,
+	desktop: desktopDesignSize,
 }
 
-const replacePxWithSwitchers = (
-	value: string,
-	mode: FMode,
-	options?: FOptions,
-): string =>
-	value.replace(pxRegex, (_, n: string) => {
-		const num = Number.parseFloat(n)
-		const { original, m, t, d, f } = computeTerms(num, mode, options)
-		switch (mode) {
-			case "responsive":
-			case "scaledResponsive":
-				return switchValue4(m, t, d, f)
-			case "large":
-				return switchValue4(original, original, d, f)
-			case "small":
-				return switchValue4(m, t, original, original)
-			case "fullWidth":
-				// single-target bucket: direct value, no switching
-				return f
-			case "desktop":
-				return d
-			case "tablet":
-				return t
-			case "mobile":
-				return m
-			case "allFullWidth":
-				// same value for all breakpoints: avoid switcher
-				return f
-			case "allDesktop":
-				return d
-			case "allTablet":
-				return t
-			case "allMobile":
-				return m
-		}
-	})
+const BREAKPOINT_MIN: Record<Breakpoint, number> = {
+	mobile: mobileBreakpoint,
+	tablet: mobileBreakpoint + 1,
+	desktop: tabletBreakpoint + 1,
+	fullWidth: desktopBreakpoint + 1,
+}
 
-const transformStyleRule = (
-	rule: StyleRule,
-	mode: FMode,
+const MEDIA_QUERIES: Record<Breakpoint, string> = {
+	mobile: `screen and (max-width: ${mobileBreakpoint}px)`,
+	tablet: `screen and (min-width: ${BREAKPOINT_MIN.tablet}px) and (max-width: ${tabletBreakpoint}px)`,
+	desktop: `screen and (min-width: ${BREAKPOINT_MIN.desktop}px) and (max-width: ${desktopBreakpoint}px)`,
+	fullWidth: `screen and (min-width: ${BREAKPOINT_MIN.fullWidth}px)`,
+}
+
+const COMBO_MEDIA_QUERIES: Record<"small" | "large", string> = {
+	small: `screen and (max-width: ${tabletBreakpoint}px)`,
+	large: `screen and (min-width: ${BREAKPOINT_MIN.desktop}px)`,
+}
+
+const CSS_VARS: Record<Breakpoint, string> = {
+	mobile: isMobile,
+	tablet: isTablet,
+	desktop: isDesktop,
+	fullWidth: isFull,
+}
+
+// =============================================================================
+// Shared Helpers
+// =============================================================================
+
+const getDesignSize = (size: DesignSize, options?: FOptions): number =>
+	options?.designSizeOverride?.[size] ?? DESIGN_SIZE[size]
+
+const toVw = (px: number, designSize: number): string =>
+	`${((px / designSize) * 100).toFixed(VW_PRECISION)}vw`
+
+const toPx = (
+	px: number,
+	designSize: number,
+	breakpoint: Breakpoint,
+): string => {
+	const minWidth = BREAKPOINT_MIN[breakpoint]
+	const scaled = (px / designSize) * minWidth
+	const str = scaled.toFixed(PIXEL_PRECISION)
+	return `${str}px`.replace(".00px", "px")
+}
+
+const computeResponsiveValue = (
+	px: number,
+	rule: BreakpointRule,
+	options?: FOptions,
+): string => {
+	const designSize = getDesignSize(rule.designSize, options)
+
+	switch (rule.output) {
+		case "fluid":
+			return toVw(px, designSize)
+		case "pixel":
+			return toPx(px, designSize, rule.breakpoint)
+		case "scaleFullyConfig": {
+			const shouldScale = options?.scaleFully ?? config.scaleFully
+			return shouldScale
+				? toVw(px, designSize)
+				: toPx(px, designSize, rule.breakpoint)
+		}
+	}
+}
+
+const getBreakpointCombo = (
+	rules: BreakpointRule[],
+): BreakpointCombo | null => {
+	const breakpoints = new Set(rules.map((r) => r.breakpoint))
+	if (breakpoints.size === 4) return "all"
+	if (breakpoints.size === 2) {
+		if (breakpoints.has("mobile") && breakpoints.has("tablet")) return "small"
+		if (breakpoints.has("desktop") && breakpoints.has("fullWidth"))
+			return "large"
+	}
+	return null
+}
+
+const hasUniformOutput = (rules: BreakpointRule[]): boolean =>
+	rules.every(
+		(r) =>
+			r.designSize === rules[0]?.designSize && r.output === rules[0]?.output,
+	)
+
+const replacePxInAst = (
+	root: csstree.CssNode,
+	transform: PxTransform,
+): void => {
+	csstree.walk(root, {
+		visit: "Dimension",
+		enter(node, item, list) {
+			if (node.type !== "Dimension" || node.unit !== "px" || !list) return
+			list.replace(
+				item,
+				list.createItem({
+					type: "Raw",
+					value: transform(Number.parseFloat(node.value)),
+				}),
+			)
+		},
+	})
+}
+
+const parseWrappedCss = (cssText: string): csstree.CssNode | null => {
+	try {
+		return csstree.parse(`x{${cssText}}`)
+	} catch (error) {
+		console.error("error parsing css:", error)
+		return null
+	}
+}
+
+const unwrapGeneratedCss = (generated: string): string => generated.slice(2, -1)
+
+const toInjectedStyleRule = (cssText: string) =>
+	({
+		[getInjectionKey()]: `ignored;${cssText}`,
+	}) as unknown as StyleRule
+
+// =============================================================================
+// Calc Engine
+// =============================================================================
+
+const getCalcExpression = (
+	px: number,
+	rules: BreakpointRule[],
+	options?: FOptions,
+): string => {
+	const uniform = hasUniformOutput(rules)
+
+	if (uniform && rules[0]) {
+		return computeResponsiveValue(px, rules[0], options)
+	}
+
+	const terms = rules.map((rule) => {
+		const value = computeResponsiveValue(px, rule, options)
+		return `(${value}) * ${CSS_VARS[rule.breakpoint]}`
+	})
+	return `calc(${terms.join(" + ")})`
+}
+
+const wrapWithMediaQueries = (
+	cssText: string,
+	rules: BreakpointRule[],
+): string => {
+	const combo = getBreakpointCombo(rules)
+
+	if (combo === "all") return cssText
+
+	if (combo === "small" || combo === "large") {
+		return `@media ${COMBO_MEDIA_QUERIES[combo]}{${cssText}}`
+	}
+
+	const uniqueBreakpoints = [...new Set(rules.map((r) => r.breakpoint))]
+	return uniqueBreakpoints
+		.map((bp) => `@media ${MEDIA_QUERIES[bp]}{${cssText}}`)
+		.join("")
+}
+
+const calcEngine = (
+	cssText: string,
+	rules: BreakpointRule[],
+	options?: FOptions,
+): string => {
+	const ast = parseWrappedCss(cssText)
+	if (!ast) return cssText
+
+	replacePxInAst(ast, (px) => getCalcExpression(px, rules, options))
+	const processed = unwrapGeneratedCss(csstree.generate(ast))
+	return wrapWithMediaQueries(processed, rules)
+}
+
+// =============================================================================
+// Media Engine
+// =============================================================================
+
+const mediaEngine = (
+	cssText: string,
+	rules: BreakpointRule[],
+	options?: FOptions,
+): string => {
+	const ast = parseWrappedCss(cssText)
+	if (!ast) return cssText
+
+	const contents: string[] = []
+	for (const rule of rules) {
+		const cloned = csstree.clone(ast)
+		replacePxInAst(cloned, (px) => computeResponsiveValue(px, rule, options))
+		contents.push(unwrapGeneratedCss(csstree.generate(cloned)))
+	}
+
+	const allIdentical =
+		contents.length > 0 && contents.every((c) => c === contents[0])
+	if (allIdentical && getBreakpointCombo(rules) === "all") {
+		return contents[0] ?? ""
+	}
+
+	return rules
+		.map(
+			(rule, i) => `@media ${MEDIA_QUERIES[rule.breakpoint]}{${contents[i]}}`,
+		)
+		.join("")
+}
+
+// =============================================================================
+// Style Generation
+// =============================================================================
+
+const generateStyle = (
+	cssText: string,
+	rules: BreakpointRule[],
 	options?: FOptions,
 ): StyleRule => {
-	const out: Record<string, unknown> = {}
-	for (const [key, val] of Object.entries(rule as Record<string, unknown>)) {
-		if (key === "selectors") {
-			const nested: Record<string, unknown> = {}
-			for (const [rawSel, child] of Object.entries(
-				val as Record<string, unknown>,
-			)) {
-				let sel = String(rawSel).trim()
-				// ensure self-targeting pseudos/elements are anchored
-				if (sel.startsWith(":")) sel = `&${sel}`
-				// normalize awkward child/sibling combinator spacing like "&>*" → "& > *"
-				sel = sel.replace(/&\s*([>+~])\s*/g, "& $1 ")
-				nested[sel] = transformStyleRule(child as StyleRule, mode, options)
-			}
-			out.selectors = nested
-			continue
-		}
-		if (
-			key === "@media" ||
-			key === "@supports" ||
-			key === "@container" ||
-			key === "@layer"
-		) {
-			const nested: Record<string, unknown> = {}
-			for (const [k, child] of Object.entries(val as Record<string, unknown>)) {
-				nested[k] = transformStyleRule(child as StyleRule, mode, options)
-			}
-			out[key] = nested
-			continue
-		}
-		if (Array.isArray(val)) {
-			out[key] = (val as Array<string | number>).map((v) =>
-				typeof v === "string" ? replacePxWithSwitchers(v, mode, options) : v,
-			)
-		} else if (typeof val === "object" && val) {
-			out[key] = transformStyleRule(val as StyleRule, mode, options)
-		} else if (typeof val === "string") {
-			out[key] = replacePxWithSwitchers(val, mode, options)
-		} else {
-			out[key] = val
-		}
-	}
-	return out as StyleRule
+	const engine = options?.engine ?? DEFAULT_ENGINE
+	const processed =
+		engine === "calc"
+			? calcEngine(cssText, rules, options)
+			: mediaEngine(cssText, rules, options)
+	return toInjectedStyleRule(processed)
 }
 
-const resolveMode = (base: FMode, options?: FOptions): FMode => {
-	if (!options) return base
-	let mode = base
-	if (options.only) {
-		switch (options.only) {
-			case "mobile":
-				mode = "mobile"
-				break
-			case "tablet":
-				mode = "tablet"
-				break
-			case "desktop":
-				mode = "desktop"
-				break
-			case "fullWidth":
-				mode = "fullWidth"
-				break
-		}
-	}
-	if (options.applyStylesToAllBreakpoints && options.only) {
-		switch (options.only) {
-			case "mobile":
-				mode = "allMobile"
-				break
-			case "tablet":
-				mode = "allTablet"
-				break
-			case "desktop":
-				mode = "allDesktop"
-				break
-			case "fullWidth":
-				mode = "allFullWidth"
-				break
-		}
-	}
-	return mode
+const unresponsive = (cssText: string): StyleRule =>
+	toInjectedStyleRule(cssText)
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+type UtilityFn = (cssText: string, options?: FOptions) => StyleRule
+
+type FApi = {
+	[K in keyof typeof UTILITIES]: UtilityFn
+} & {
+	unresponsive: (cssText: string) => StyleRule
 }
 
-const getMediaQueryForMode = (mode: FMode): string | null => {
-	// gate modes that target a subset of breakpoints
-	switch (mode) {
-		case "mobile":
-			return `screen and (max-width: ${mobileBreakpoint}px)`
-		case "tablet":
-			return `screen and (min-width: ${mobileBreakpoint + 1}px) and (max-width: ${tabletBreakpoint}px)`
-		case "desktop":
-			return `screen and (min-width: ${tabletBreakpoint + 1}px) and (max-width: ${desktopBreakpoint}px)`
-		case "fullWidth":
-			return `screen and (min-width: ${desktopBreakpoint + 1}px)`
-		case "small":
-			// mobile + tablet combined
-			return `screen and (max-width: ${tabletBreakpoint}px)`
-		case "large":
-			// desktop + fullWidth combined
-			return `screen and (min-width: ${tabletBreakpoint + 1}px)`
-		default:
-			return null
-	}
-}
+export const f = Object.fromEntries(
+	Object.entries(UTILITIES).map(([name, rules]) => [
+		name,
+		(cssText: string, options?: FOptions) =>
+			generateStyle(cssText, rules, options),
+	]),
+) as FApi
 
-const wrapWithMedia = (rule: StyleRule, query: string | null): StyleRule => {
-	if (!query) return rule
-	return { "@media": { [query]: rule } } as StyleRule
-}
-
-export const f = {
-	responsive: (
-		tplOrRule: TemplateStringsArray | string | StyleRule,
-		optionsOrExpr?: FOptions | string | number,
-		...expr: Array<string | number>
-	): StyleRule => {
-		const hasOptions =
-			typeof optionsOrExpr === "object" &&
-			optionsOrExpr !== null &&
-			!Array.isArray(optionsOrExpr)
-		const options = hasOptions ? (optionsOrExpr as FOptions) : undefined
-		const base = resolveStyleRule(tplOrRule, optionsOrExpr, expr, hasOptions)
-		const mode = resolveMode("responsive", options)
-		const transformed = transformStyleRule(base, mode, options)
-		return wrapWithMedia(transformed, getMediaQueryForMode(mode))
-	},
-	scaledResponsive: (
-		tplOrRule: TemplateStringsArray | string | StyleRule,
-		optionsOrExpr?: FOptions | string | number,
-		...expr: Array<string | number>
-	): StyleRule => {
-		const hasOptions =
-			typeof optionsOrExpr === "object" &&
-			optionsOrExpr !== null &&
-			!Array.isArray(optionsOrExpr)
-		const options = hasOptions ? (optionsOrExpr as FOptions) : undefined
-		const base = resolveStyleRule(tplOrRule, optionsOrExpr, expr, hasOptions)
-		const mode = resolveMode("scaledResponsive", options)
-		const transformed = transformStyleRule(base, mode, options)
-		return wrapWithMedia(transformed, getMediaQueryForMode(mode))
-	},
-	large: (
-		tplOrRule: TemplateStringsArray | string | StyleRule,
-		optionsOrExpr?: FOptions | string | number,
-		...expr: Array<string | number>
-	): StyleRule => {
-		const hasOptions =
-			typeof optionsOrExpr === "object" &&
-			optionsOrExpr !== null &&
-			!Array.isArray(optionsOrExpr)
-		const options = hasOptions ? (optionsOrExpr as FOptions) : undefined
-		const base = resolveStyleRule(tplOrRule, optionsOrExpr, expr, hasOptions)
-		const mode = resolveMode("large", options)
-		const transformed = transformStyleRule(base, mode, options)
-		return wrapWithMedia(transformed, getMediaQueryForMode(mode))
-	},
-	small: (
-		tplOrRule: TemplateStringsArray | string | StyleRule,
-		optionsOrExpr?: FOptions | string | number,
-		...expr: Array<string | number>
-	): StyleRule => {
-		const hasOptions =
-			typeof optionsOrExpr === "object" &&
-			optionsOrExpr !== null &&
-			!Array.isArray(optionsOrExpr)
-		const options = hasOptions ? (optionsOrExpr as FOptions) : undefined
-		const base = resolveStyleRule(tplOrRule, optionsOrExpr, expr, hasOptions)
-		const mode = resolveMode("small", options)
-		const transformed = transformStyleRule(base, mode, options)
-		return wrapWithMedia(transformed, getMediaQueryForMode(mode))
-	},
-	fullWidth: (
-		tplOrRule: TemplateStringsArray | string | StyleRule,
-		optionsOrExpr?: FOptions | string | number,
-		...expr: Array<string | number>
-	): StyleRule => {
-		const hasOptions =
-			typeof optionsOrExpr === "object" &&
-			optionsOrExpr !== null &&
-			!Array.isArray(optionsOrExpr)
-		const options = hasOptions ? (optionsOrExpr as FOptions) : undefined
-		const base = resolveStyleRule(tplOrRule, optionsOrExpr, expr, hasOptions)
-		const mode = resolveMode("fullWidth", options)
-		const transformed = transformStyleRule(base, mode, options)
-		return wrapWithMedia(transformed, getMediaQueryForMode(mode))
-	},
-	desktop: (
-		tplOrRule: TemplateStringsArray | string | StyleRule,
-		optionsOrExpr?: FOptions | string | number,
-		...expr: Array<string | number>
-	): StyleRule => {
-		const hasOptions =
-			typeof optionsOrExpr === "object" &&
-			optionsOrExpr !== null &&
-			!Array.isArray(optionsOrExpr)
-		const options = hasOptions ? (optionsOrExpr as FOptions) : undefined
-		const base = resolveStyleRule(tplOrRule, optionsOrExpr, expr, hasOptions)
-		const mode = resolveMode("desktop", options)
-		const transformed = transformStyleRule(base, mode, options)
-		return wrapWithMedia(transformed, getMediaQueryForMode(mode))
-	},
-	tablet: (
-		tplOrRule: TemplateStringsArray | string | StyleRule,
-		optionsOrExpr?: FOptions | string | number,
-		...expr: Array<string | number>
-	): StyleRule => {
-		const hasOptions =
-			typeof optionsOrExpr === "object" &&
-			optionsOrExpr !== null &&
-			!Array.isArray(optionsOrExpr)
-		const options = hasOptions ? (optionsOrExpr as FOptions) : undefined
-		const base = resolveStyleRule(tplOrRule, optionsOrExpr, expr, hasOptions)
-		const mode = resolveMode("tablet", options)
-		const transformed = transformStyleRule(base, mode, options)
-		return wrapWithMedia(transformed, getMediaQueryForMode(mode))
-	},
-	mobile: (
-		tplOrRule: TemplateStringsArray | string | StyleRule,
-		optionsOrExpr?: FOptions | string | number,
-		...expr: Array<string | number>
-	): StyleRule => {
-		const hasOptions =
-			typeof optionsOrExpr === "object" &&
-			optionsOrExpr !== null &&
-			!Array.isArray(optionsOrExpr)
-		const options = hasOptions ? (optionsOrExpr as FOptions) : undefined
-		const base = resolveStyleRule(tplOrRule, optionsOrExpr, expr, hasOptions)
-		const mode = resolveMode("mobile", options)
-		const transformed = transformStyleRule(base, mode, options)
-		return wrapWithMedia(transformed, getMediaQueryForMode(mode))
-	},
-	allFullWidth: (
-		tplOrRule: TemplateStringsArray | string | StyleRule,
-		optionsOrExpr?: FOptions | string | number,
-		...expr: Array<string | number>
-	): StyleRule => {
-		const hasOptions =
-			typeof optionsOrExpr === "object" &&
-			optionsOrExpr !== null &&
-			!Array.isArray(optionsOrExpr)
-		const options = hasOptions ? (optionsOrExpr as FOptions) : undefined
-		const base = resolveStyleRule(tplOrRule, optionsOrExpr, expr, hasOptions)
-		const mode = resolveMode("allFullWidth", options)
-		const transformed = transformStyleRule(base, mode, options)
-		return wrapWithMedia(transformed, getMediaQueryForMode(mode))
-	},
-	allDesktop: (
-		tplOrRule: TemplateStringsArray | string | StyleRule,
-		optionsOrExpr?: FOptions | string | number,
-		...expr: Array<string | number>
-	): StyleRule => {
-		const hasOptions =
-			typeof optionsOrExpr === "object" &&
-			optionsOrExpr !== null &&
-			!Array.isArray(optionsOrExpr)
-		const options = hasOptions ? (optionsOrExpr as FOptions) : undefined
-		const base = resolveStyleRule(tplOrRule, optionsOrExpr, expr, hasOptions)
-		const mode = resolveMode("allDesktop", options)
-		const transformed = transformStyleRule(base, mode, options)
-		return wrapWithMedia(transformed, getMediaQueryForMode(mode))
-	},
-	allTablet: (
-		tplOrRule: TemplateStringsArray | string | StyleRule,
-		optionsOrExpr?: FOptions | string | number,
-		...expr: Array<string | number>
-	): StyleRule => {
-		const hasOptions =
-			typeof optionsOrExpr === "object" &&
-			optionsOrExpr !== null &&
-			!Array.isArray(optionsOrExpr)
-		const options = hasOptions ? (optionsOrExpr as FOptions) : undefined
-		const base = resolveStyleRule(tplOrRule, optionsOrExpr, expr, hasOptions)
-		const mode = resolveMode("allTablet", options)
-		const transformed = transformStyleRule(base, mode, options)
-		return wrapWithMedia(transformed, getMediaQueryForMode(mode))
-	},
-	allMobile: (
-		tplOrRule: TemplateStringsArray | string | StyleRule,
-		optionsOrExpr?: FOptions | string | number,
-		...expr: Array<string | number>
-	): StyleRule => {
-		const hasOptions =
-			typeof optionsOrExpr === "object" &&
-			optionsOrExpr !== null &&
-			!Array.isArray(optionsOrExpr)
-		const options = hasOptions ? (optionsOrExpr as FOptions) : undefined
-		const base = resolveStyleRule(tplOrRule, optionsOrExpr, expr, hasOptions)
-		const mode = resolveMode("allMobile", options)
-		const transformed = transformStyleRule(base, mode, options)
-		return wrapWithMedia(transformed, getMediaQueryForMode(mode))
-	},
-	unresponsive: (
-		tplOrRule: TemplateStringsArray | string | StyleRule,
-		...expr: Array<string | number>
-	): StyleRule => unresponsive(tplOrRule, ...expr),
-}
+f.unresponsive = unresponsive
 
 export const fresponsive = f.responsive
 export const ftablet = f.tablet
 export const fmobile = f.mobile
+export { unresponsive }

--- a/styled/vanilla.ts
+++ b/styled/vanilla.ts
@@ -1,6 +1,6 @@
-import type { StyleRule } from "@vanilla-extract/css"
-import * as csstree from "@eslint/css-tree"
 import config from "libraryConfig"
+import * as csstree from "@eslint/css-tree"
+import type { StyleRule } from "@vanilla-extract/css"
 import {
 	desktopBreakpoint,
 	desktopDesignSize,

--- a/styled/vanilla.ts
+++ b/styled/vanilla.ts
@@ -15,6 +15,7 @@ import {
 } from "styles/media"
 import { COMMENT, compile, DECLARATION, type Element, RULESET } from "stylis"
 import { isDesktop, isFull, isMobile, isTablet } from "./breakpoints.css"
+import { isBrowser } from "../deviceDetection"
 
 export type CSSObject = StyleRule
 export type CSSValue = string | number | StyleRule
@@ -23,6 +24,12 @@ if (libraryConfig.stylingSystem === "restyle")
 	throw new Error(
 		"this project is only configured to use the restyle styling system",
 	)
+
+if (isBrowser) {
+	throw new Error(
+		"style system was loaded in the browser! this will explode your bundle size!",
+	)
+}
 
 export function attrs<Props>(
 	Component: ComponentType<Props>,

--- a/vanilla/css-loader.ts
+++ b/vanilla/css-loader.ts
@@ -1,0 +1,10 @@
+// matches expressions like:
+// --s-1: ignored;
+// --s-930: ignored;
+// --s-99999999: ignored;
+// etc
+const ignoredRegex = /--s-\d+: ignored;/g
+
+export default function cssLoader(css: string) {
+	return css.replaceAll(ignoredRegex, "")
+}

--- a/vanilla/dependency-graph.ts
+++ b/vanilla/dependency-graph.ts
@@ -1,0 +1,456 @@
+import ts from "typescript"
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type NodeKind =
+	| "import"
+	| "variable"
+	| "function"
+	| "class"
+	| "expression"
+	| "statement"
+	| "type"
+	| "export"
+
+export interface ImportInfo {
+	/** The module specifier (e.g., "@vanilla-extract/css") */
+	module: string
+	/** The imported name ("default", "*", or the specific named import) */
+	importedName: string
+	/** Whether this is a type-only import */
+	isTypeOnly: boolean
+}
+
+export interface ExportInfo {
+	/** The exported name */
+	name: string
+	/** Whether this is a default export */
+	isDefault: boolean
+}
+
+export interface DependencyNode {
+	/** Unique id for ordering and deduplication */
+	id: number
+	/** The kind of top-level construct */
+	kind: NodeKind
+	/** The name of the binding (undefined for expression statements) */
+	name?: string
+	/** The original AST statement node */
+	statement: ts.Statement
+	/** Names of other bindings this node depends on */
+	dependsOn: string[]
+	/** Import metadata (only for kind: "import") */
+	importInfo?: ImportInfo
+	/** Export metadata (if this node is exported) */
+	exportInfo?: ExportInfo
+}
+
+export interface DependencyGraph {
+	/** The parsed source file */
+	sourceFile: ts.SourceFile
+	/** All nodes keyed by name (or internal key for expressions) */
+	nodes: Map<string, DependencyNode>
+	/** All nodes in original source order */
+	ordered: DependencyNode[]
+}
+
+// =============================================================================
+// Analysis
+// =============================================================================
+
+export interface AnalyzeOptions {
+	isTsx?: boolean
+}
+
+/**
+ * Parses source code and builds a typed dependency graph.
+ */
+export function analyzeDependencies(
+	sourceCode: string,
+	options: AnalyzeOptions = {},
+): DependencyGraph {
+	const { isTsx = true } = options
+
+	const sourceFile = ts.createSourceFile(
+		isTsx ? "file.tsx" : "file.ts",
+		sourceCode,
+		ts.ScriptTarget.Latest,
+		true,
+		isTsx ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+	)
+
+	const definedNames = new Set<string>()
+	const nodes = new Map<string, DependencyNode>()
+	const ordered: DependencyNode[] = []
+
+	let statementId = 0
+
+	// --- Helper: check if identifier is a lowercase JSX tag name ---
+	const isIntrinsicJsxTag = (id: ts.Identifier): boolean => {
+		const parent = id.parent
+		if (!parent) return false
+		const firstChar = id.text[0]
+		if (!firstChar || firstChar !== firstChar.toLowerCase()) return false
+		return (
+			ts.isJsxOpeningElement(parent) ||
+			ts.isJsxClosingElement(parent) ||
+			ts.isJsxSelfClosingElement(parent)
+		)
+	}
+
+	// --- Helper: collect all identifier references in a node ---
+	const collectDependencies = (
+		node: ts.Node,
+		excludeName?: string,
+	): string[] => {
+		const deps = new Set<string>()
+		const visit = (n: ts.Node) => {
+			if (ts.isIdentifier(n)) {
+				if (definedNames.has(n.text) && n.text !== excludeName) {
+					if (!isIntrinsicJsxTag(n)) {
+						deps.add(n.text)
+					}
+				}
+			}
+			ts.forEachChild(n, visit)
+		}
+		visit(node)
+		return Array.from(deps)
+	}
+
+	// --- Pass 1: Inventory all defined names ---
+	for (const stmt of sourceFile.statements) {
+		if (ts.isVariableStatement(stmt)) {
+			for (const decl of stmt.declarationList.declarations) {
+				if (ts.isIdentifier(decl.name)) {
+					definedNames.add(decl.name.text)
+				}
+			}
+		} else if (ts.isFunctionDeclaration(stmt) || ts.isClassDeclaration(stmt)) {
+			if (stmt.name) {
+				definedNames.add(stmt.name.text)
+			}
+		} else if (ts.isImportDeclaration(stmt) && stmt.importClause) {
+			const clause = stmt.importClause
+			if (clause.name) {
+				definedNames.add(clause.name.text)
+			}
+			if (clause.namedBindings) {
+				if (ts.isNamedImports(clause.namedBindings)) {
+					for (const el of clause.namedBindings.elements) {
+						definedNames.add(el.name.text)
+					}
+				} else if (ts.isNamespaceImport(clause.namedBindings)) {
+					definedNames.add(clause.namedBindings.name.text)
+				}
+			}
+		}
+	}
+
+	// --- Pass 2: Build nodes ---
+	for (const stmt of sourceFile.statements) {
+		const id = statementId++
+
+		// 1. IMPORTS
+		if (ts.isImportDeclaration(stmt)) {
+			const moduleSpec = (stmt.moduleSpecifier as ts.StringLiteral).text
+			const clause = stmt.importClause
+			const isTypeOnlyImport = clause?.isTypeOnly ?? false
+
+			if (!clause) {
+				// Side-effect import: import 'foo'
+				const key = `__expr_${id}`
+				const node: DependencyNode = {
+					id,
+					kind: "import",
+					statement: stmt,
+					dependsOn: [],
+					importInfo: {
+						module: moduleSpec,
+						importedName: "*",
+						isTypeOnly: false,
+					},
+				}
+				nodes.set(key, node)
+				ordered.push(node)
+				continue
+			}
+
+			// Default import
+			if (clause.name) {
+				const name = clause.name.text
+				const node: DependencyNode = {
+					id,
+					kind: "import",
+					name,
+					statement: stmt,
+					dependsOn: [],
+					importInfo: {
+						module: moduleSpec,
+						importedName: "default",
+						isTypeOnly: isTypeOnlyImport,
+					},
+				}
+				nodes.set(name, node)
+				ordered.push(node)
+			}
+
+			// Named bindings
+			if (clause.namedBindings) {
+				if (ts.isNamedImports(clause.namedBindings)) {
+					for (const el of clause.namedBindings.elements) {
+						const localName = el.name.text
+						const importedName = el.propertyName?.text ?? localName
+						const isElementTypeOnly = el.isTypeOnly || isTypeOnlyImport
+
+						const node: DependencyNode = {
+							id,
+							kind: "import",
+							name: localName,
+							statement: stmt,
+							dependsOn: [],
+							importInfo: {
+								module: moduleSpec,
+								importedName,
+								isTypeOnly: isElementTypeOnly,
+							},
+						}
+						nodes.set(localName, node)
+						ordered.push(node)
+					}
+				} else if (ts.isNamespaceImport(clause.namedBindings)) {
+					const name = clause.namedBindings.name.text
+					const node: DependencyNode = {
+						id,
+						kind: "import",
+						name,
+						statement: stmt,
+						dependsOn: [],
+						importInfo: {
+							module: moduleSpec,
+							importedName: "*",
+							isTypeOnly: isTypeOnlyImport,
+						},
+					}
+					nodes.set(name, node)
+					ordered.push(node)
+				}
+			}
+			continue
+		}
+
+		// 2. VARIABLES
+		if (ts.isVariableStatement(stmt)) {
+			const isExported = stmt.modifiers?.some(
+				(m) => m.kind === ts.SyntaxKind.ExportKeyword,
+			) ?? false
+
+			for (const decl of stmt.declarationList.declarations) {
+				if (!ts.isIdentifier(decl.name)) continue
+
+				const name = decl.name.text
+				const deps = collectDependencies(decl.initializer ?? decl, name)
+
+				const node: DependencyNode = {
+					id,
+					kind: "variable",
+					name,
+					statement: stmt,
+					dependsOn: deps,
+				}
+
+				if (isExported) {
+					node.exportInfo = { name, isDefault: false }
+				}
+
+				nodes.set(name, node)
+				ordered.push(node)
+			}
+			continue
+		}
+
+		// 3. FUNCTIONS
+		if (ts.isFunctionDeclaration(stmt)) {
+			const isExported =
+				(ts.getCombinedModifierFlags(stmt) & ts.ModifierFlags.Export) !== 0
+			const isDefault =
+				(ts.getCombinedModifierFlags(stmt) & ts.ModifierFlags.Default) !== 0
+			const name = stmt.name?.text ?? (isDefault ? "default" : undefined)
+
+			if (name) {
+				const deps = collectDependencies(stmt, name)
+				const node: DependencyNode = {
+					id,
+					kind: "function",
+					name,
+					statement: stmt,
+					dependsOn: deps,
+				}
+
+				if (isExported) {
+					node.exportInfo = { name: isDefault ? "default" : name, isDefault }
+				}
+
+				nodes.set(name, node)
+				ordered.push(node)
+			}
+			continue
+		}
+
+		// 4. CLASSES
+		if (ts.isClassDeclaration(stmt)) {
+			const isExported =
+				(ts.getCombinedModifierFlags(stmt) & ts.ModifierFlags.Export) !== 0
+			const isDefault =
+				(ts.getCombinedModifierFlags(stmt) & ts.ModifierFlags.Default) !== 0
+			const name = stmt.name?.text ?? (isDefault ? "default" : undefined)
+
+			if (name) {
+				const deps = collectDependencies(stmt, name)
+				const node: DependencyNode = {
+					id,
+					kind: "class",
+					name,
+					statement: stmt,
+					dependsOn: deps,
+				}
+
+				if (isExported) {
+					node.exportInfo = { name: isDefault ? "default" : name, isDefault }
+				}
+
+				nodes.set(name, node)
+				ordered.push(node)
+			}
+			continue
+		}
+
+		// 5. EXPRESSION STATEMENTS
+		if (ts.isExpressionStatement(stmt)) {
+			const key = `__expr_${id}`
+			const deps = collectDependencies(stmt)
+			const node: DependencyNode = {
+				id,
+				kind: "expression",
+				statement: stmt,
+				dependsOn: deps,
+			}
+			nodes.set(key, node)
+			ordered.push(node)
+			continue
+		}
+
+		// 6. BLOCK STATEMENTS (if, for, while, try, etc.) - treated like expressions
+		if (
+			ts.isIfStatement(stmt) ||
+			ts.isForStatement(stmt) ||
+			ts.isForInStatement(stmt) ||
+			ts.isForOfStatement(stmt) ||
+			ts.isWhileStatement(stmt) ||
+			ts.isDoStatement(stmt) ||
+			ts.isTryStatement(stmt) ||
+			ts.isSwitchStatement(stmt) ||
+			ts.isBlock(stmt)
+		) {
+			const key = `__stmt_${id}`
+			const deps = collectDependencies(stmt)
+			const node: DependencyNode = {
+				id,
+				kind: "statement",
+				statement: stmt,
+				dependsOn: deps,
+			}
+			nodes.set(key, node)
+			ordered.push(node)
+			continue
+		}
+
+		// 7. TYPE DECLARATIONS (type aliases, interfaces, enums)
+		// These don't produce runtime code but should be preserved
+		if (
+			ts.isTypeAliasDeclaration(stmt) ||
+			ts.isInterfaceDeclaration(stmt) ||
+			ts.isEnumDeclaration(stmt)
+		) {
+			const name = stmt.name.text
+			const node: DependencyNode = {
+				id,
+				kind: "type",
+				name,
+				statement: stmt,
+				dependsOn: [], // Type declarations have no runtime dependencies
+			}
+
+			const isExported =
+				(ts.getCombinedModifierFlags(stmt) & ts.ModifierFlags.Export) !== 0
+			if (isExported) {
+				node.exportInfo = { name, isDefault: false }
+			}
+
+			nodes.set(name, node)
+			ordered.push(node)
+			continue
+		}
+
+		// 8. EXPORT DECLARATIONS (re-exports, export { }, export default)
+		if (ts.isExportDeclaration(stmt)) {
+			const key = `__export_${id}`
+			const deps = stmt.exportClause
+				? collectDependencies(stmt.exportClause)
+				: []
+			const node: DependencyNode = {
+				id,
+				kind: "export",
+				statement: stmt,
+				dependsOn: deps,
+			}
+			nodes.set(key, node)
+			ordered.push(node)
+			continue
+		}
+
+		// 9. EXPORT ASSIGNMENT (export = something or export default expression)
+		if (ts.isExportAssignment(stmt)) {
+			const key = `__export_${id}`
+			const deps = collectDependencies(stmt.expression)
+			const node: DependencyNode = {
+				id,
+				kind: "export",
+				statement: stmt,
+				dependsOn: deps,
+				exportInfo: { name: "default", isDefault: true },
+			}
+			nodes.set(key, node)
+			ordered.push(node)
+			continue
+		}
+
+		// 10. MODULE DECLARATIONS (declare module, namespace)
+		if (ts.isModuleDeclaration(stmt)) {
+			const key = `__module_${id}`
+			const node: DependencyNode = {
+				id,
+				kind: "type",
+				name: stmt.name.getText(),
+				statement: stmt,
+				dependsOn: [],
+			}
+			nodes.set(key, node)
+			ordered.push(node)
+			continue
+		}
+
+		// UNKNOWN STATEMENTS - throw error to alert developer
+		const stmtText = stmt.getText(sourceFile).slice(0, 100)
+		const stmtKind = ts.SyntaxKind[stmt.kind]
+		throw new Error(
+			`[vanilla-split-loader] Unhandled top-level statement type: ${stmtKind}\n` +
+				`Preview: ${stmtText}${stmtText.length >= 100 ? "..." : ""}\n\n` +
+				`This is a bug in the split loader. Please report it with the above information.`,
+		)
+	}
+
+	return { sourceFile, nodes, ordered }
+}

--- a/vanilla/dependency-graph.ts
+++ b/vanilla/dependency-graph.ts
@@ -243,9 +243,9 @@ export function analyzeDependencies(
 
 		// 2. VARIABLES
 		if (ts.isVariableStatement(stmt)) {
-			const isExported = stmt.modifiers?.some(
-				(m) => m.kind === ts.SyntaxKind.ExportKeyword,
-			) ?? false
+			const isExported =
+				stmt.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) ??
+				false
 
 			for (const decl of stmt.declarationList.declarations) {
 				if (!ts.isIdentifier(decl.name)) continue

--- a/vanilla/source-builder.ts
+++ b/vanilla/source-builder.ts
@@ -26,7 +26,11 @@ export function reconstructSource(
 	nodes: DependencyNode[],
 	options: ReconstructOptions = {},
 ): string {
-	const { exportNames = new Set(), transforms = new Map(), append = [] } = options
+	const {
+		exportNames = new Set(),
+		transforms = new Map(),
+		append = [],
+	} = options
 
 	const seenIds = new Set<number>()
 	const parts: string[] = []
@@ -52,7 +56,11 @@ export function reconstructSource(
 		// Add export if needed and not already exported
 		if (node.name && exportNames.has(node.name) && !node.exportInfo) {
 			// Only add export to variable/function/class declarations
-			if (node.kind === "variable" || node.kind === "function" || node.kind === "class") {
+			if (
+				node.kind === "variable" ||
+				node.kind === "function" ||
+				node.kind === "class"
+			) {
 				src = `export ${src}`
 			}
 		}
@@ -123,7 +131,11 @@ export function createImportDeclaration(
 			undefined,
 			ts.factory.createNamedImports(
 				names.map((n) =>
-					ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier(n)),
+					ts.factory.createImportSpecifier(
+						false,
+						undefined,
+						ts.factory.createIdentifier(n),
+					),
 				),
 			),
 		),
@@ -143,7 +155,11 @@ export function createReExportDeclaration(
 		false,
 		ts.factory.createNamedExports(
 			names.map((n) =>
-				ts.factory.createExportSpecifier(false, undefined, ts.factory.createIdentifier(n)),
+				ts.factory.createExportSpecifier(
+					false,
+					undefined,
+					ts.factory.createIdentifier(n),
+				),
 			),
 		),
 		ts.factory.createStringLiteral(fromPath),

--- a/vanilla/source-builder.ts
+++ b/vanilla/source-builder.ts
@@ -1,0 +1,168 @@
+import ts from "typescript"
+import type { DependencyNode } from "./dependency-graph.ts"
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ReconstructOptions {
+	/** Names to add 'export' keyword to */
+	exportNames?: Set<string>
+	/** Name -> replacement source code (replaces the entire statement) */
+	transforms?: Map<string, string>
+	/** Extra source strings to append at the end */
+	append?: string[]
+}
+
+// =============================================================================
+// Source reconstruction
+// =============================================================================
+
+/**
+ * Reconstructs source code from a list of dependency nodes.
+ * Handles deduplication, export addition, and source transforms.
+ */
+export function reconstructSource(
+	nodes: DependencyNode[],
+	options: ReconstructOptions = {},
+): string {
+	const { exportNames = new Set(), transforms = new Map(), append = [] } = options
+
+	const seenIds = new Set<number>()
+	const parts: string[] = []
+
+	// Sort by id to preserve original source order
+	const sorted = [...nodes].sort((a, b) => a.id - b.id)
+
+	for (const node of sorted) {
+		// Skip duplicates (same statement can create multiple nodes, e.g., multi-import)
+		if (seenIds.has(node.id)) continue
+		seenIds.add(node.id)
+
+		// Check for a transform
+		if (node.name && transforms.has(node.name)) {
+			parts.push(transforms.get(node.name)!)
+			continue
+		}
+
+		// Get the source text
+		const sourceFile = node.statement.getSourceFile()
+		let src = node.statement.getText(sourceFile)
+
+		// Add export if needed and not already exported
+		if (node.name && exportNames.has(node.name) && !node.exportInfo) {
+			// Only add export to variable/function/class declarations
+			if (node.kind === "variable" || node.kind === "function" || node.kind === "class") {
+				src = `export ${src}`
+			}
+		}
+
+		parts.push(src)
+	}
+
+	// Append any extra statements
+	for (const extra of append) {
+		parts.push(extra)
+	}
+
+	return `${parts.join("\n")}\n`
+}
+
+// =============================================================================
+// Import reconstruction helpers
+// =============================================================================
+
+/**
+ * Builds a minimal import statement for the given nodes.
+ * Groups imports by module and reconstructs them.
+ */
+export function reconstructImports(
+	nodes: DependencyNode[],
+	sourceFile: ts.SourceFile,
+): string {
+	// Group import nodes by their statement id (same import statement)
+	const byStatementId = new Map<number, DependencyNode[]>()
+
+	for (const node of nodes) {
+		if (node.kind !== "import") continue
+		const existing = byStatementId.get(node.id) ?? []
+		existing.push(node)
+		byStatementId.set(node.id, existing)
+	}
+
+	const parts: string[] = []
+
+	// For each unique import statement, print it once
+	const seenIds = new Set<number>()
+	for (const node of nodes) {
+		if (node.kind !== "import") continue
+		if (seenIds.has(node.id)) continue
+		seenIds.add(node.id)
+
+		parts.push(node.statement.getText(sourceFile))
+	}
+
+	return parts.join("\n")
+}
+
+// =============================================================================
+// Statement creation helpers
+// =============================================================================
+
+/**
+ * Creates an import declaration AST node.
+ */
+export function createImportDeclaration(
+	names: string[],
+	fromPath: string,
+): ts.ImportDeclaration {
+	return ts.factory.createImportDeclaration(
+		undefined,
+		ts.factory.createImportClause(
+			false,
+			undefined,
+			ts.factory.createNamedImports(
+				names.map((n) =>
+					ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier(n)),
+				),
+			),
+		),
+		ts.factory.createStringLiteral(fromPath),
+	)
+}
+
+/**
+ * Creates a re-export declaration AST node.
+ */
+export function createReExportDeclaration(
+	names: string[],
+	fromPath: string,
+): ts.ExportDeclaration {
+	return ts.factory.createExportDeclaration(
+		undefined,
+		false,
+		ts.factory.createNamedExports(
+			names.map((n) =>
+				ts.factory.createExportSpecifier(false, undefined, ts.factory.createIdentifier(n)),
+			),
+		),
+		ts.factory.createStringLiteral(fromPath),
+	)
+}
+
+/**
+ * Prints an AST node to a string.
+ */
+export function printNode(node: ts.Node): string {
+	const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed })
+	const sourceFile = ts.createSourceFile("temp.ts", "", ts.ScriptTarget.Latest)
+	return printer.printNode(ts.EmitHint.Unspecified, node, sourceFile)
+}
+
+/**
+ * Prints a source file to a string.
+ */
+export function printSourceFile(sourceFile: ts.SourceFile): string {
+	const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed })
+	return printer.printFile(sourceFile)
+}

--- a/vanilla/vanilla-split-loader.ts
+++ b/vanilla/vanilla-split-loader.ts
@@ -621,10 +621,7 @@ function buildOriginalStatements(
 		statements.push(node.statement)
 		if (node.kind === "import") {
 			lastImportIdx = statements.length - 1
-		} else if (
-			isDirectivePrologue(node.statement) &&
-			lastImportIdx === -1
-		) {
+		} else if (isDirectivePrologue(node.statement) && lastImportIdx === -1) {
 			// Track directive prologues that come before any imports
 			lastDirectiveIdx = statements.length - 1
 		}

--- a/vanilla/vanilla-split-loader.ts
+++ b/vanilla/vanilla-split-loader.ts
@@ -6,13 +6,24 @@ import turboLoaderRAW, {
 	type TurboLoaderOptions,
 } from "@vanilla-extract/turbopack-plugin"
 import ts from "typescript"
+import {
+	analyzeDependencies,
+	type DependencyGraph,
+	type DependencyNode,
+} from "./dependency-graph.ts"
+import {
+	createImportDeclaration,
+	createReExportDeclaration,
+	printSourceFile,
+	reconstructSource,
+} from "./source-builder.ts"
+
+// =============================================================================
+// Configuration
+// =============================================================================
 
 type ModulesConfig = Record<string, string[]>
 
-// @ts-expect-error turbopack loader shape has default export in some builds
-const turboLoader = turboLoaderRAW.default as typeof turboLoaderRAW
-
-// tracked functions that should be extracted to virtual .css.ts modules
 const TRACKED_MODULES: ModulesConfig = {
 	"@vanilla-extract/css": [
 		"style",
@@ -35,640 +46,82 @@ const TRACKED_MODULES: ModulesConfig = {
 		"globalKeyframes",
 		"globalLayer",
 	],
-	"library/styled/alpha": ["styled", "keyframes"],
+	"library/styled/alpha": ["styled", "keyframes", "compileTime"],
 }
 
-const SPLIT_STYLED_MODULE = "library/styled/alpha"
-const SPLIT_STYLED_IMPORT = "styled"
+const STYLED_MODULE = "library/styled/alpha"
+const STYLED_IMPORT = "styled"
 
-type ImportRegistry = {
-	trackedLocalNames: Set<string>
-	trackedLocalToModule: Map<string, string>
-	trackedLocalToImported: Map<string, string>
-	allImports: ts.ImportDeclaration[]
-}
-
-type MovedDeclaration = {
-	name: string
-	initializerText: string
-	initializer: ts.Expression
-	kind: "const" | "let"
-}
-
-type MovedExpression = {
-	text: string
-	expression: ts.Expression
-}
-
-type SplitResult = {
-	statements: ts.Statement[]
-	movedNames: string[]
-	reexportNames: string[]
-	movedDecls: MovedDeclaration[]
-	movedExprs: MovedExpression[]
-	supportingStatements: ts.Statement[]
-	needsWithComponentHelper: boolean
-}
+// @ts-expect-error turbopack loader shape has default export in some builds
+const turboLoader = turboLoaderRAW.default as typeof turboLoaderRAW
 
 // =============================================================================
-// TS factory helpers
+// Tracked import registry
 // =============================================================================
 
-const createNamedImport = (
-	names: string[],
-	fromPath: string,
-): ts.ImportDeclaration => {
-	const code = `import { ${names.join(", ")} } from ${JSON.stringify(fromPath)};`
-	const sf = ts.createSourceFile(
-		"i.ts",
-		code,
-		ts.ScriptTarget.ES2020,
-		false,
-		ts.ScriptKind.TS,
-	)
-	return sf.statements[0] as ts.ImportDeclaration
+interface TrackedRegistry {
+	/** Local names that are tracked imports (e.g., "style", "styled") */
+	trackedNames: Set<string>
+	/** Local name -> module specifier */
+	localToModule: Map<string, string>
+	/** Local name -> original imported name */
+	localToImported: Map<string, string>
 }
-
-const createReExport = (
-	names: string[],
-	fromPath: string,
-): ts.ExportDeclaration => {
-	return ts.factory.createExportDeclaration(
-		undefined,
-		false,
-		ts.factory.createNamedExports(
-			names.map((n) => ts.factory.createExportSpecifier(false, undefined, n)),
-		),
-		ts.factory.createStringLiteral(fromPath),
-		undefined,
-	)
-}
-
-// =============================================================================
-// Import registry
-// =============================================================================
 
 /**
- * Scans the source file for imports of tracked functions and builds a registry
- * mapping local names to their module/import names.
+ * Builds a registry of tracked imports from the dependency graph.
  */
-const buildImportRegistry = (sourceFile: ts.SourceFile): ImportRegistry => {
-	const trackedLocalNames = new Set<string>()
-	const trackedLocalToModule = new Map<string, string>()
-	const trackedLocalToImported = new Map<string, string>()
-	const allImports: ts.ImportDeclaration[] = []
+function buildTrackedRegistry(graph: DependencyGraph): TrackedRegistry {
+	const trackedNames = new Set<string>()
+	const localToModule = new Map<string, string>()
+	const localToImported = new Map<string, string>()
 
-	for (const stmt of sourceFile.statements) {
-		if (!ts.isImportDeclaration(stmt)) continue
+	for (const [name, node] of graph.nodes) {
+		if (node.kind !== "import" || !node.importInfo) continue
+		if (node.importInfo.isTypeOnly) continue
 
-		allImports.push(stmt)
+		const tracked = TRACKED_MODULES[node.importInfo.module]
+		if (!tracked) continue
 
-		const moduleSpecifier = (stmt.moduleSpecifier as ts.StringLiteral).text
-		const tracked = TRACKED_MODULES[moduleSpecifier]
-
-		if (!tracked || !stmt.importClause) continue
-
-		const { name: defaultImport, namedBindings } = stmt.importClause
-
-		// track default import if explicitly included
-		if (defaultImport && tracked.includes("default")) {
-			trackedLocalNames.add(defaultImport.text)
-			trackedLocalToModule.set(defaultImport.text, moduleSpecifier)
-			trackedLocalToImported.set(defaultImport.text, "default")
-		}
-
-		// track named imports
-		if (namedBindings && ts.isNamedImports(namedBindings)) {
-			for (const el of namedBindings.elements) {
-				const imported = (el.propertyName ?? el.name).text
-				const local = el.name.text
-				if (tracked.includes(imported)) {
-					trackedLocalNames.add(local)
-					trackedLocalToModule.set(local, moduleSpecifier)
-					trackedLocalToImported.set(local, imported)
-				}
-			}
+		if (tracked.includes(node.importInfo.importedName)) {
+			trackedNames.add(name)
+			localToModule.set(name, node.importInfo.module)
+			localToImported.set(name, node.importInfo.importedName)
 		}
 	}
 
-	return {
-		trackedLocalNames,
-		trackedLocalToModule,
-		trackedLocalToImported,
-		allImports,
-	}
+	return { trackedNames, localToModule, localToImported }
 }
 
 // =============================================================================
-// Styled component handling
+// Taint analysis
 // =============================================================================
+
+interface TaintResult {
+	/** All tainted node names (directly or transitively use tracked functions) */
+	tainted: Set<string>
+	/** Tainted functions/classes that can't be moved (should error) */
+	invalidTainted: DependencyNode[]
+}
 
 /**
- * Handles styled(Component, config) by splitting it into:
- * - Virtual module: Component___raw = styled('div', config)
- * - Original file: Component = withComponent(FirstArg, Component___raw)
+ * Computes which nodes are "tainted" by tracked function usage.
+ * A node is tainted if it directly calls a tracked function.
+ * Functions/classes that are tainted are invalid (can't move to .css.ts).
  */
-const handleStyledComponent = (
-	decl: ts.VariableDeclaration,
-	call: ts.CallExpression,
-	sourceFile: ts.SourceFile,
-	isConstList: boolean,
-): {
-	shouldMove: boolean
-	movedName?: string
-	movedInitializer?: string
-	kind?: "const" | "let"
-	newDecl?: ts.VariableDeclaration
-} => {
-	const args = call.arguments
-	const firstArg = args[0]
-	const baseName = (decl.name as ts.Identifier).text
-
-	// styled('tag', ...) -> move entirely to virtual module
-	const isStringTag =
-		firstArg &&
-		(ts.isStringLiteral(firstArg) ||
-			ts.isNoSubstitutionTemplateLiteral(firstArg))
-
-	if (isStringTag) {
-		// styled('tag', ...rest) -> include debugId as third arg when rest exists
-		const firstArgText = firstArg.getText(sourceFile)
-		const restArgs = args.slice(1)
-		const restArgsText = restArgs.map((a) => a.getText(sourceFile)).join(", ")
-		const movedInitializer =
-			restArgs.length > 0
-				? `styled(${firstArgText}, ${restArgsText}, ${JSON.stringify(baseName)})`
-				: `styled(${firstArgText})`
-
-		return {
-			shouldMove: true,
-			movedName: baseName,
-			movedInitializer,
-			kind: isConstList ? "const" : "let",
-		}
-	}
-
-	// styled(Component, ...) -> split into raw + wrapper
-	const rawName = `${baseName}___raw`
-	const restArgs = args.slice(1)
-
-	// build: styled('div', ...restArgs)
-	const restArgsText = restArgs.map((a) => a.getText(sourceFile)).join(", ")
-	const rawInitializer = restArgsText
-		? `styled("div", ${restArgsText}, ${JSON.stringify(baseName)})`
-		: `styled("div")`
-
-	// build: withComponent(FirstArg, rawName)
-	const newInit = ts.factory.createCallExpression(
-		ts.factory.createIdentifier("withComponent"),
-		undefined,
-		[
-			firstArg ?? ts.factory.createIdentifier("undefined"),
-			ts.factory.createIdentifier(rawName),
-		],
-	)
-
-	const newDecl = ts.factory.updateVariableDeclaration(
-		decl,
-		decl.name,
-		decl.exclamationToken,
-		decl.type,
-		newInit,
-	)
-
-	return {
-		shouldMove: true,
-		movedName: rawName,
-		movedInitializer: rawInitializer,
-		kind: isConstList ? "const" : "let",
-		newDecl,
-	}
-}
-
-// =============================================================================
-// Statement splitting
-// =============================================================================
-
-/**
- * Walks all statements in the source file and splits out tracked function calls
- * into declarations/expressions to be moved to the virtual module.
- */
-const splitDeclarations = (
-	sourceFile: ts.SourceFile,
-	registry: ImportRegistry,
-): SplitResult => {
-	const statements: ts.Statement[] = []
-	const movedNames: string[] = []
-	const reexportNames: string[] = []
-	const movedDecls: MovedDeclaration[] = []
-	const movedExprs: MovedExpression[] = []
-	let needsWithComponentHelper = false
-
-	for (const stmt of sourceFile.statements) {
-		// handle top-level expression statements (e.g., globalStyle(...))
-		if (ts.isExpressionStatement(stmt)) {
-			const expr = stmt.expression
-			// handle both call expressions and tagged template expressions
-			let ident: ts.Identifier | undefined
-			if (ts.isCallExpression(expr) && ts.isIdentifier(expr.expression)) {
-				ident = expr.expression
-			} else if (
-				ts.isTaggedTemplateExpression(expr) &&
-				ts.isIdentifier(expr.tag)
-			) {
-				ident = expr.tag
-			}
-			if (ident && registry.trackedLocalNames.has(ident.text)) {
-				movedExprs.push({
-					text: expr.getText(sourceFile),
-					expression: expr,
-				})
-				continue
-			}
-			statements.push(stmt)
-			continue
-		}
-
-		// only interested in variable statements from here
-		if (!ts.isVariableStatement(stmt)) {
-			statements.push(stmt)
-			continue
-		}
-
-		const isExported = (stmt.modifiers ?? []).some(
-			(m) => m.kind === ts.SyntaxKind.ExportKeyword,
-		)
-		const isConstList = (stmt.declarationList.flags & ts.NodeFlags.Const) !== 0
-		const keptDecls: ts.VariableDeclaration[] = []
-
-		for (const decl of stmt.declarationList.declarations) {
-			// skip non-identifier or uninitialized declarations
-			if (!ts.isIdentifier(decl.name) || !decl.initializer) {
-				keptDecls.push(decl)
-				continue
-			}
-
-			// check if initializer is a tracked function call
-			let trackedIdent: ts.Identifier | undefined
-			if (
-				ts.isCallExpression(decl.initializer) &&
-				ts.isIdentifier(decl.initializer.expression)
-			) {
-				trackedIdent = decl.initializer.expression
-			} else if (
-				ts.isTaggedTemplateExpression(decl.initializer) &&
-				ts.isIdentifier(decl.initializer.tag)
-			) {
-				trackedIdent = decl.initializer.tag
-			}
-			if (!trackedIdent || !registry.trackedLocalNames.has(trackedIdent.text)) {
-				keptDecls.push(decl)
-				continue
-			}
-
-			const calleeLocal = trackedIdent.text
-			const calleeModule = registry.trackedLocalToModule.get(calleeLocal)
-			const calleeImported = registry.trackedLocalToImported.get(calleeLocal)
-
-			const isStyledFromLib =
-				calleeModule === SPLIT_STYLED_MODULE &&
-				calleeImported === SPLIT_STYLED_IMPORT
-			const callExpr = ts.isCallExpression(decl.initializer)
-				? decl.initializer
-				: undefined
-
-			if (isStyledFromLib && callExpr) {
-				const result = handleStyledComponent(
-					decl,
-					callExpr,
-					sourceFile,
-					isConstList,
-				)
-				if (
-					result.shouldMove &&
-					result.movedName &&
-					result.movedInitializer &&
-					result.kind
-				) {
-					movedNames.push(result.movedName)
-					movedDecls.push({
-						name: result.movedName,
-						initializerText: result.movedInitializer,
-						initializer: callExpr,
-						kind: result.kind,
-					})
-					if (result.newDecl) {
-						keptDecls.push(result.newDecl)
-						needsWithComponentHelper = true
-					} else if (isExported) {
-						// styled('tag') was moved entirely, re-export it
-						reexportNames.push(decl.name.text)
-					}
-				}
-				continue
-			}
-
-			// non-styled tracked calls (style, keyframes, etc.) -> move to virtual module
-			movedNames.push(decl.name.text)
-			if (isExported) reexportNames.push(decl.name.text)
-			movedDecls.push({
-				name: decl.name.text,
-				initializerText: decl.initializer.getText(sourceFile),
-				initializer: decl.initializer,
-				kind: isConstList ? "const" : "let",
-			})
-		}
-
-		// if any declarations remain, keep the statement
-		if (keptDecls.length > 0) {
-			statements.push(
-				ts.factory.updateVariableStatement(
-					stmt,
-					stmt.modifiers,
-					ts.factory.updateVariableDeclarationList(
-						stmt.declarationList,
-						keptDecls,
-					),
-				),
-			)
-		}
-	}
-
-	return {
-		statements,
-		movedNames,
-		reexportNames,
-		movedDecls,
-		movedExprs,
-		supportingStatements: [],
-		needsWithComponentHelper,
-	}
-}
-
-// =============================================================================
-// Dependency analysis helpers
-// =============================================================================
-
-const GLOBAL_IDENTIFIERS = new Set<string>([
-	"Math",
-	"Number",
-	"String",
-	"Boolean",
-	"Object",
-	"Array",
-	"Set",
-	"Map",
-	"WeakMap",
-	"WeakSet",
-	"Date",
-	"BigInt",
-	"Symbol",
-	"Promise",
-	"RegExp",
-	"Intl",
-	"JSON",
-	"Reflect",
-	"Proxy",
-	"console",
-	"window",
-	"document",
-	"navigator",
-	"location",
-	"globalThis",
-	"self",
-])
-
-const extractBindingNames = (
-	binding: ts.BindingName,
-	names: string[],
-): void => {
-	if (ts.isIdentifier(binding)) {
-		names.push(binding.text)
-		return
-	}
-
-	for (const element of binding.elements) {
-		if (ts.isOmittedExpression(element)) continue
-		extractBindingNames(element.name, names)
-	}
-}
-
-const collectLocalNames = (
-	node: ts.Node | undefined,
-	locals: Set<string>,
-): void => {
-	if (!node) return
-
-	const visit = (current: ts.Node) => {
-		if (ts.isFunctionLike(current)) {
-			if (current.name && ts.isIdentifier(current.name)) {
-				locals.add(current.name.text)
-			}
-			for (const param of current.parameters) {
-				const paramNames: string[] = []
-				extractBindingNames(param.name, paramNames)
-				paramNames.forEach((name) => {
-					locals.add(name)
-				})
-			}
-		}
-
-		if (ts.isVariableDeclaration(current)) {
-			const declNames: string[] = []
-			extractBindingNames(current.name, declNames)
-			declNames.forEach((name) => {
-				locals.add(name)
-			})
-		}
-
-		if (ts.isCatchClause(current) && current.variableDeclaration) {
-			const catchNames: string[] = []
-			extractBindingNames(current.variableDeclaration.name, catchNames)
-			catchNames.forEach((name) => {
-				locals.add(name)
-			})
-		}
-
-		current.forEachChild(visit)
-	}
-
-	visit(node)
-}
-
-const isIdentifierInTypePosition = (identifier: ts.Identifier): boolean => {
-	let current: ts.Node | undefined = identifier
-	while (current) {
-		switch (current.kind) {
-			case ts.SyntaxKind.TypeReference:
-			case ts.SyntaxKind.TypeAliasDeclaration:
-			case ts.SyntaxKind.InterfaceDeclaration:
-			case ts.SyntaxKind.TypeLiteral:
-			case ts.SyntaxKind.MappedType:
-			case ts.SyntaxKind.TypePredicate:
-			case ts.SyntaxKind.TypeQuery:
-			case ts.SyntaxKind.TypeParameter:
-			case ts.SyntaxKind.ImportType:
-			case ts.SyntaxKind.ExpressionWithTypeArguments:
-				return true
-		}
-
-		if (ts.isImportClause(current) && current.isTypeOnly) return true
-		if (ts.isImportSpecifier(current) && current.isTypeOnly) return true
-
-		current = current.parent
-	}
-	return false
-}
-
-const shouldIncludeIdentifier = (identifier: ts.Identifier): boolean => {
-	const text = identifier.text
-	if (!text) return false
-	if (text === "undefined" || text === "NaN" || text === "Infinity")
-		return false
-
-	const parent = identifier.parent
-	if (!parent) return true
-
-	if (ts.isPropertyAccessExpression(parent) && parent.name === identifier) {
-		return false
-	}
-
-	if (
-		ts.isPropertyAssignment(parent) &&
-		parent.name === identifier &&
-		!ts.isComputedPropertyName(parent.name)
-	) {
-		return false
-	}
-
-	if (ts.isBindingElement(parent) && parent.name === identifier) {
-		return false
-	}
-
-	if (ts.isImportSpecifier(parent) && parent.name === identifier) {
-		return false
-	}
-
-	if (isIdentifierInTypePosition(identifier)) return false
-
-	return true
-}
-
-const collectDependenciesForNode = (node: ts.Node | undefined): Set<string> => {
-	const deps = new Set<string>()
-	if (!node) return deps
-
-	const locals = new Set<string>()
-	collectLocalNames(node, locals)
-
-	const visit = (current: ts.Node) => {
-		if (ts.isIdentifier(current)) {
-			if (!locals.has(current.text) && shouldIncludeIdentifier(current)) {
-				deps.add(current.text)
-			}
-			return
-		}
-
-		current.forEachChild(visit)
-	}
-
-	visit(node)
-	return deps
-}
-
-const _collectDependenciesFromSplitResult = (
-	result: SplitResult,
-): Set<string> => {
-	const deps = new Set<string>()
-	for (const md of result.movedDecls) {
-		for (const dep of collectDependenciesForNode(md.initializer)) {
-			deps.add(dep)
-		}
-	}
-	for (const expr of result.movedExprs) {
-		for (const dep of collectDependenciesForNode(expr.expression)) {
-			deps.add(dep)
-		}
-	}
-	return deps
-}
-
-const collectImportLocalNames = (
-	imports: ts.ImportDeclaration[],
-): Set<string> => {
-	const names = new Set<string>()
-	for (const decl of imports) {
-		const clause = decl.importClause
-		if (!clause) continue
-		if (clause.name) {
-			names.add(clause.name.text)
-		}
-		if (clause.namedBindings) {
-			if (ts.isNamespaceImport(clause.namedBindings)) {
-				names.add(clause.namedBindings.name.text)
-			} else if (ts.isNamedImports(clause.namedBindings)) {
-				for (const element of clause.namedBindings.elements) {
-					names.add(element.name.text)
-				}
-			}
-		}
-	}
-	return names
-}
-
-const getDeclaredNamesFromStatement = (stmt: ts.Statement): string[] => {
-	const names: string[] = []
-	if (ts.isVariableStatement(stmt)) {
-		for (const decl of stmt.declarationList.declarations) {
-			extractBindingNames(decl.name, names)
-		}
-	} else if (ts.isFunctionDeclaration(stmt) && stmt.name) {
-		names.push(stmt.name.text)
-	} else if (ts.isClassDeclaration(stmt) && stmt.name) {
-		names.push(stmt.name.text)
-	} else if (ts.isEnumDeclaration(stmt)) {
-		names.push(stmt.name.text)
-	}
-	return names
-}
-
-const findSupportingStatements = (
-	sourceFile: ts.SourceFile,
-	unresolvedNames: Set<string>,
-): ts.Statement[] => {
-	const supporting: ts.Statement[] = []
-	if (unresolvedNames.size === 0) return supporting
-
-	for (const stmt of sourceFile.statements) {
-		if (unresolvedNames.size === 0) break
-		const declared = getDeclaredNamesFromStatement(stmt)
-		if (declared.length === 0) continue
-		const matches = declared.filter((name) => unresolvedNames.has(name))
-		if (matches.length === 0) continue
-		supporting.push(stmt)
-		matches.forEach((name) => {
-			unresolvedNames.delete(name)
-		})
-	}
-
-	return supporting
-}
-
-const isTrackedStyledCall = (
-	stmt: ts.Statement,
-	registry: ImportRegistry,
-): boolean => {
+function isVariableFunctionLike(node: DependencyNode): boolean {
+	if (node.kind !== "variable") return false
+	const stmt = node.statement
 	if (!ts.isVariableStatement(stmt)) return false
+
 	for (const decl of stmt.declarationList.declarations) {
-		if (!decl.initializer) continue
+		if (!ts.isIdentifier(decl.name) || decl.name.text !== node.name) continue
+		const init = decl.initializer
+		if (!init) continue
 		if (
-			ts.isCallExpression(decl.initializer) &&
-			ts.isIdentifier(decl.initializer.expression) &&
-			registry.trackedLocalNames.has(decl.initializer.expression.text) &&
-			registry.trackedLocalToModule.get(decl.initializer.expression.text) ===
-				SPLIT_STYLED_MODULE &&
-			registry.trackedLocalToImported.get(decl.initializer.expression.text) ===
-				SPLIT_STYLED_IMPORT
+			ts.isArrowFunction(init) ||
+			ts.isFunctionExpression(init) ||
+			ts.isClassExpression(init)
 		) {
 			return true
 		}
@@ -676,215 +129,614 @@ const isTrackedStyledCall = (
 	return false
 }
 
-const containsJsx = (node: ts.Node): boolean => {
-	let found = false
-	const visit = (n: ts.Node) => {
-		if (
-			ts.isJsxElement(n) ||
-			ts.isJsxSelfClosingElement(n) ||
-			ts.isJsxFragment(n)
-		) {
-			found = true
-			return
+function computeTaintedNodes(
+	graph: DependencyGraph,
+	registry: TrackedRegistry,
+): TaintResult {
+	const tainted = new Set<string>()
+	const invalidTainted: DependencyNode[] = []
+
+	for (const [name, node] of graph.nodes) {
+		if (node.kind === "import") continue
+
+		// Check if this node directly depends on a tracked function
+		const usesTracked = node.dependsOn.some((dep) =>
+			registry.trackedNames.has(dep),
+		)
+
+		if (usesTracked) {
+			if (node.name) tainted.add(node.name)
+			else tainted.add(name) // expression statement key
+
+			// Functions and classes can't be moved to .css.ts
+			// Also catch arrow functions/function expressions assigned to variables
+			if (
+				node.kind === "function" ||
+				node.kind === "class" ||
+				isVariableFunctionLike(node)
+			) {
+				invalidTainted.push(node)
+			}
 		}
-		n.forEachChild(visit)
 	}
-	visit(node)
-	return found
+
+	return { tainted, invalidTainted }
 }
 
 // =============================================================================
-// Virtual module construction
+// Styled component handling
+// =============================================================================
+
+interface StyledTransform {
+	/** Original variable name */
+	originalName: string
+	/** Name for the raw component (e.g., "Button___raw") */
+	rawName: string
+	/** Source for the raw component in virtual module */
+	rawSource: string
+	/** The first argument to styled() that should be excluded from virtual deps */
+	excludedDep?: string
+	/** Whether this is a styled(Component) vs styled('tag') call */
+	needsWrapper: boolean
+}
+
+/**
+ * Analyzes styled() calls and produces transforms.
+ */
+function analyzeStyledCalls(
+	graph: DependencyGraph,
+	registry: TrackedRegistry,
+	tainted: Set<string>,
+): StyledTransform[] {
+	const transforms: StyledTransform[] = []
+
+	for (const name of tainted) {
+		const node = graph.nodes.get(name)
+		if (!node || node.kind !== "variable" || !node.name) continue
+
+		// Check if this is a styled() call
+		const styledLocal = Array.from(registry.trackedNames).find((local) => {
+			const mod = registry.localToModule.get(local)
+			const imp = registry.localToImported.get(local)
+			return mod === STYLED_MODULE && imp === STYLED_IMPORT
+		})
+
+		if (!styledLocal || !node.dependsOn.includes(styledLocal)) continue
+
+		// Parse the initializer to understand the call
+		const stmt = node.statement
+		if (!ts.isVariableStatement(stmt)) continue
+
+		const decl = stmt.declarationList.declarations.find(
+			(d) => ts.isIdentifier(d.name) && d.name.text === node.name,
+		)
+		if (!decl?.initializer || !ts.isCallExpression(decl.initializer)) continue
+
+		const call = decl.initializer
+		const args = call.arguments
+		const firstArg = args[0]
+
+		const isStringTag =
+			firstArg &&
+			(ts.isStringLiteral(firstArg) ||
+				ts.isNoSubstitutionTemplateLiteral(firstArg))
+
+		if (isStringTag) {
+			// styled('tag', config) -> move entirely, add debugId
+			const firstArgText = firstArg.getText(graph.sourceFile)
+			const restArgs = args.slice(1)
+			const restArgsText = restArgs
+				.map((a) => a.getText(graph.sourceFile))
+				.join(", ")
+
+			const rawSource =
+				restArgs.length > 0
+					? `export const ${node.name} = styled(${firstArgText}, ${restArgsText}, ${JSON.stringify(node.name)});`
+					: `export const ${node.name} = styled(${firstArgText});`
+
+			transforms.push({
+				originalName: node.name,
+				rawName: node.name,
+				rawSource,
+				needsWrapper: false,
+			})
+		} else {
+			// styled(Component, config) -> split into raw + wrapper
+			const rawName = `${node.name}___raw`
+			const restArgs = args.slice(1)
+			const restArgsText = restArgs
+				.map((a) => a.getText(graph.sourceFile))
+				.join(", ")
+
+			const rawSource = restArgsText
+				? `export const ${rawName} = styled("div", ${restArgsText}, ${JSON.stringify(node.name)});`
+				: `export const ${rawName} = styled("div");`
+
+			const excludedDep =
+				firstArg && ts.isIdentifier(firstArg) ? firstArg.text : undefined
+
+			transforms.push({
+				originalName: node.name,
+				rawName,
+				rawSource,
+				excludedDep,
+				needsWrapper: true,
+			})
+		}
+	}
+
+	return transforms
+}
+
+// =============================================================================
+// Partitioning
+// =============================================================================
+
+interface SplitPartition {
+	/** Nodes for the virtual .css.ts module */
+	virtual: DependencyNode[]
+	/** Nodes that stay in the original file */
+	original: DependencyNode[]
+	/** Names to re-export from original (tainted + exported) */
+	reexports: string[]
+	/** Names to import from virtual module */
+	imports: string[]
+}
+
+/**
+ * Computes the transitive closure of dependencies for a set of seeds.
+ */
+function getTransitiveClosure(
+	graph: DependencyGraph,
+	seeds: Set<string>,
+	exclude: Set<string> = new Set(),
+): Set<string> {
+	const closure = new Set<string>()
+	const queue = [...seeds]
+
+	while (queue.length > 0) {
+		const name = queue.pop()!
+		if (closure.has(name)) continue
+		// Only exclude non-seed dependencies (seeds themselves should always be included)
+		if (exclude.has(name) && !seeds.has(name)) continue
+
+		closure.add(name)
+
+		const node = graph.nodes.get(name)
+		if (!node) continue
+
+		for (const dep of node.dependsOn) {
+			// Exclude deps that aren't themselves seeds
+			const shouldExclude = exclude.has(dep) && !seeds.has(dep)
+			if (!closure.has(dep) && !shouldExclude) {
+				queue.push(dep)
+			}
+		}
+	}
+
+	return closure
+}
+
+/**
+ * Computes which nodes are used by nodes outside the virtual closure.
+ * Returns a set of names that need to stay in the original file.
+ */
+function computeOriginalDependencies(
+	graph: DependencyGraph,
+	virtualClosure: Set<string>,
+	wrappedNames: Set<string>,
+	excludedDeps: Set<string>,
+	tainted: Set<string>,
+): Set<string> {
+	const neededInOriginal = new Set<string>()
+
+	// Start with nodes that MUST be in original:
+	// 1. Nodes outside virtual closure (they're not moved)
+	// 2. Wrapped styled components (they stay with rewrite, but their ORIGINAL deps don't)
+	// 3. Excluded deps (first args of styled(Component) calls)
+	for (const node of graph.nodes.values()) {
+		const key = node.name ?? `__expr_${node.id}`
+		const inClosure = virtualClosure.has(key)
+
+		if (!inClosure || excludedDeps.has(key)) {
+			neededInOriginal.add(key)
+		}
+		// Wrapped names stay but their deps are handled specially below
+	}
+
+	// Now compute transitive closure of dependencies FROM original-only nodes
+	// Key insight: we should NOT follow deps of TAINTED nodes because their
+	// original declarations are being removed (replaced with imports from virtual)
+	const queue = [...neededInOriginal]
+	const visited = new Set<string>()
+
+	while (queue.length > 0) {
+		const name = queue.pop()!
+		if (visited.has(name)) continue
+		visited.add(name)
+
+		const node = graph.nodes.get(name)
+		if (!node) continue
+
+		// Don't follow deps of tainted nodes - their code is being replaced
+		// with imports from virtual, so their original deps aren't needed
+		const isTainted = tainted.has(name)
+		if (isTainted) {
+			continue
+		}
+
+		// Follow deps of non-tainted nodes
+		for (const dep of node.dependsOn) {
+			if (!visited.has(dep)) {
+				neededInOriginal.add(dep)
+				queue.push(dep)
+			}
+		}
+	}
+
+	// Wrapped components themselves need to stay (for the rewrite)
+	for (const name of wrappedNames) {
+		neededInOriginal.add(name)
+	}
+
+	return neededInOriginal
+}
+
+/**
+ * Partitions nodes between virtual and original modules.
+ */
+function partitionNodes(
+	graph: DependencyGraph,
+	tainted: Set<string>,
+	styledTransforms: StyledTransform[],
+): SplitPartition {
+	// Build exclusion set (first args of styled(Component) calls)
+	const excludedDeps = new Set<string>()
+	for (const t of styledTransforms) {
+		if (t.excludedDep) excludedDeps.add(t.excludedDep)
+	}
+
+	// Compute transitive closure for virtual module
+	const virtualClosure = getTransitiveClosure(graph, tainted, excludedDeps)
+
+	// Tainted names that have wrappers stay in original differently
+	const wrappedNames = new Set(
+		styledTransforms.filter((t) => t.needsWrapper).map((t) => t.originalName),
+	)
+
+	// Compute which nodes are actually needed in original
+	const neededInOriginal = computeOriginalDependencies(
+		graph,
+		virtualClosure,
+		wrappedNames,
+		excludedDeps,
+		tainted,
+	)
+
+	const virtual: DependencyNode[] = []
+	const original: DependencyNode[] = []
+	const reexports: string[] = []
+	const imports: string[] = []
+
+	for (const node of graph.ordered) {
+		const key = node.name ?? `__expr_${node.id}`
+		const inClosure = virtualClosure.has(key)
+		const isTainted = tainted.has(key)
+
+		if (inClosure) {
+			virtual.push(node)
+		}
+
+		// Original file keeps:
+		// - Nodes needed by other original nodes (computed above)
+		// - Wrapped styled components (they get rewritten)
+		// - But NOT tainted nodes (unless wrapped)
+		const isNeeded = neededInOriginal.has(key)
+		const isWrapped = wrappedNames.has(key)
+
+		if (isNeeded && (!isTainted || isWrapped)) {
+			original.push(node)
+		}
+
+		// Track what needs to be imported/re-exported
+		if (isTainted && node.name) {
+			// Only import runtime values (variables, functions, classes)
+			// Skip types, expressions, statements, exports
+			const isRuntimeValue =
+				node.kind === "variable" ||
+				node.kind === "function" ||
+				node.kind === "class"
+			if (isRuntimeValue) {
+				// For wrapped components, import the ___raw version
+				const transform = styledTransforms.find(
+					(t) => t.originalName === node.name,
+				)
+				if (transform?.needsWrapper) {
+					imports.push(transform.rawName)
+					// Also import the base component if it's tainted (moved to virtual)
+					if (transform.excludedDep && tainted.has(transform.excludedDep)) {
+						imports.push(transform.excludedDep)
+					}
+				} else {
+					imports.push(node.name)
+				}
+			}
+
+			if (node.exportInfo) {
+				reexports.push(node.name)
+			}
+		}
+	}
+
+	// Dedupe imports
+	return { virtual, original, reexports, imports: [...new Set(imports)] }
+}
+
+// =============================================================================
+// Source building
 // =============================================================================
 
 /**
- * Helper to parse a code snippet and find dependencies.
- * Wraps the text in a variable declaration to ensure it parses as valid TS.
+ * Builds the virtual module source code.
  */
-const getDependenciesFromText = (text: string): Set<string> => {
+function buildVirtualSource(
+	graph: DependencyGraph,
+	partition: SplitPartition,
+	tainted: Set<string>,
+	styledTransforms: StyledTransform[],
+): string {
+	// Build transforms map: tainted names get their raw source
+	const transforms = new Map<string, string>()
+	const append: string[] = []
+
+	for (const t of styledTransforms) {
+		if (t.needsWrapper) {
+			// Skip the original declaration, append the ___raw version
+			transforms.set(t.originalName, "") // empty = skip
+			append.push(t.rawSource)
+		} else {
+			// Replace with the transformed version
+			transforms.set(t.originalName, t.rawSource)
+		}
+	}
+
+	// Export names: all tainted variables (not expressions)
+	const exportNames = new Set<string>()
+	for (const name of tainted) {
+		const node = graph.nodes.get(name)
+		if (node && node.kind === "variable" && node.name) {
+			exportNames.add(node.name)
+		}
+	}
+
+	// Filter out empty transforms and reconstruct
+	const nodesToInclude = partition.virtual.filter((n) => {
+		if (n.name && transforms.get(n.name) === "") return false
+		return true
+	})
+
+	return reconstructSource(nodesToInclude, {
+		exportNames,
+		transforms,
+		append,
+	})
+}
+
+/**
+ * Checks if a statement is a directive prologue (e.g., "use client", "use strict")
+ */
+function isDirectivePrologue(stmt: ts.Statement): boolean {
+	if (!ts.isExpressionStatement(stmt)) return false
+	const expr = stmt.expression
+	return ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)
+}
+
+/**
+ * Builds the transformed original module statements.
+ */
+function buildOriginalStatements(
+	_graph: DependencyGraph,
+	partition: SplitPartition,
+	tainted: Set<string>,
+	styledTransforms: StyledTransform[],
+	importPath: string,
+): ts.Statement[] {
+	const statements: ts.Statement[] = []
+	const seenIds = new Set<number>()
+
+	// Maps for styled wrapper rewrites
+	const wrapperTransforms = new Map<string, StyledTransform>()
+	for (const t of styledTransforms) {
+		if (t.needsWrapper) {
+			wrapperTransforms.set(t.originalName, t)
+		}
+	}
+
+	// Track if we need withComponent helper
+	const needsWithComponent = wrapperTransforms.size > 0
+
+	// Find last import index for injection point (AFTER any directive prologues)
+	let lastImportIdx = -1
+	let lastDirectiveIdx = -1
+
+	for (const node of partition.original) {
+		if (seenIds.has(node.id)) continue
+		seenIds.add(node.id)
+
+		const key = node.name ?? `__expr_${node.id}`
+		const isTainted = tainted.has(key)
+
+		// Skip tainted nodes that aren't wrapped (they moved to virtual)
+		if (isTainted && !wrapperTransforms.has(key)) {
+			continue
+		}
+
+		// Handle wrapped styled components
+		if (node.name && wrapperTransforms.has(node.name)) {
+			const transform = wrapperTransforms.get(node.name)!
+			const stmt = node.statement as ts.VariableStatement
+
+			// Find the declaration
+			const decl = stmt.declarationList.declarations.find(
+				(d) => ts.isIdentifier(d.name) && d.name.text === node.name,
+			)
+			if (decl?.initializer && ts.isCallExpression(decl.initializer)) {
+				const firstArg = decl.initializer.arguments[0]
+
+				// Create: const Name = withComponent(FirstArg, Name___raw)
+				const newInit = ts.factory.createCallExpression(
+					ts.factory.createIdentifier("withComponent"),
+					undefined,
+					[
+						firstArg ?? ts.factory.createIdentifier("undefined"),
+						ts.factory.createIdentifier(transform.rawName),
+					],
+				)
+
+				const newDecl = ts.factory.updateVariableDeclaration(
+					decl,
+					decl.name,
+					decl.exclamationToken,
+					decl.type,
+					newInit,
+				)
+
+				const newDeclList = ts.factory.updateVariableDeclarationList(
+					stmt.declarationList,
+					[newDecl],
+				)
+
+				const newStmt = ts.factory.updateVariableStatement(
+					stmt,
+					stmt.modifiers,
+					newDeclList,
+				)
+
+				statements.push(newStmt)
+				if (node.kind === "import") lastImportIdx = statements.length - 1
+				continue
+			}
+		}
+
+		statements.push(node.statement)
+		if (node.kind === "import") {
+			lastImportIdx = statements.length - 1
+		} else if (
+			isDirectivePrologue(node.statement) &&
+			lastImportIdx === -1
+		) {
+			// Track directive prologues that come before any imports
+			lastDirectiveIdx = statements.length - 1
+		}
+	}
+
+	// Inject imports after last import, or after directives if no imports exist
+	const insertAt = lastImportIdx >= 0 ? lastImportIdx + 1 : lastDirectiveIdx + 1
+	const toInsert: ts.Statement[] = []
+
+	if (needsWithComponent) {
+		toInsert.push(
+			createImportDeclaration(
+				["withComponent"],
+				"library/styled/withComponent",
+			),
+		)
+	}
+
+	if (partition.imports.length > 0) {
+		toInsert.push(createImportDeclaration(partition.imports, importPath))
+	}
+
+	if (partition.reexports.length > 0) {
+		toInsert.push(createReExportDeclaration(partition.reexports, importPath))
+	}
+
+	statements.splice(insertAt, 0, ...toInsert)
+
+	return statements
+}
+
+// =============================================================================
+// Import path rewriting
+// =============================================================================
+
+/**
+ * Rewrites relative imports to tsconfig-safe specifiers.
+ */
+function rewriteToTsconfig(
+	code: string,
+	originalFilePath: string,
+	rootDir: string,
+): string {
 	const sf = ts.createSourceFile(
-		"temp.ts",
-		`const __TEMP__ = ${text}`,
+		"rewrite.ts",
+		code,
 		ts.ScriptTarget.ES2020,
 		true,
 		ts.ScriptKind.TS,
 	)
-	return collectDependenciesForNode(sf)
-}
 
-/**
- * Builds the source code for the virtual .css.ts module by combining imports,
- * moved declarations, and moved expressions.
- * Only includes imports that are actually used in the moved code.
- */
-const buildVirtualModuleSource = (
-	sourceFile: ts.SourceFile,
-	imports: ts.ImportDeclaration[],
-	movedDecls: MovedDeclaration[],
-	movedExprs: MovedExpression[],
-	supportingStatements: ts.Statement[],
-): string => {
-	const parts: string[] = []
+	const updates: Array<{ node: ts.ImportDeclaration; newSpec: string }> = []
 
-	// Collect all identifiers used in the moved code
-	const usedIdentifiers = new Set<string>()
+	for (const st of sf.statements) {
+		if (!ts.isImportDeclaration(st)) continue
+		const spec = (st.moduleSpecifier as ts.StringLiteral).text
+		if (!spec.startsWith("./") && !spec.startsWith("../")) continue
 
-	for (const stmt of supportingStatements) {
-		collectDependenciesForNode(stmt).forEach((d) => {
-			usedIdentifiers.add(d)
-		})
-	}
-	for (const md of movedDecls) {
-		// We must parse initializerText because it might be transformed (e.g. styled replacement)
-		// and different from the original AST node
-		getDependenciesFromText(md.initializerText).forEach((d) => {
-			usedIdentifiers.add(d)
-		})
-	}
-	for (const ex of movedExprs) {
-		collectDependenciesForNode(ex.expression).forEach((d) => {
-			usedIdentifiers.add(d)
-		})
+		const originalDir = path.dirname(originalFilePath)
+		const absolutePath = path.resolve(originalDir, spec).replace(/\\/g, "/")
+		const relRoot = path.relative(rootDir, absolutePath).replace(/\\/g, "/")
+		const newSpec = `@/${relRoot}`
+		updates.push({ node: st, newSpec })
 	}
 
-	// only include imports that are referenced in the moved code
-	for (const i of imports) {
-		const importText = i.getText(sourceFile)
-		const importClause = i.importClause
-		if (!importClause) {
-			// side-effect import, include it
-			parts.push(importText)
-			continue
-		}
+	if (updates.length === 0) return code
 
-		// check if any imported names are used in moved code
-		let isUsed = false
-
-		if (importClause.name) {
-			// default import
-			if (usedIdentifiers.has(importClause.name.text)) {
-				isUsed = true
+	const statements: ts.Statement[] = []
+	for (const st of sf.statements) {
+		if (ts.isImportDeclaration(st)) {
+			const upd = updates.find((u) => u.node === st)
+			if (upd) {
+				statements.push(
+					ts.factory.updateImportDeclaration(
+						st,
+						st.modifiers,
+						st.importClause,
+						ts.factory.createStringLiteral(upd.newSpec),
+						st.attributes,
+					),
+				)
+				continue
 			}
 		}
-
-		if (
-			importClause.namedBindings &&
-			ts.isNamedImports(importClause.namedBindings)
-		) {
-			// named imports
-			for (const el of importClause.namedBindings.elements) {
-				const localName = el.name.text
-				if (usedIdentifiers.has(localName)) {
-					isUsed = true
-					break
-				}
-			}
-		}
-
-		if (isUsed) {
-			parts.push(importText)
-		}
+		statements.push(st)
 	}
 
-	// ensure supporting statements are emitted in original source order
-	const units: Array<{ pos: number; text: string }> = []
-	for (const stmtNode of supportingStatements) {
-		let text = stmtNode.getText(sourceFile)
-		// avoid exporting functions/values from .css.ts that vanilla-extract can't serialize
-		if (/^\s*export\s+/.test(text)) {
-			text = text.replace(/^\s*export\s+/, "")
-		}
-		units.push({
-			pos: stmtNode.getStart(sourceFile),
-			text,
-		})
-	}
-	for (const md of movedDecls) {
-		units.push({
-			pos: md.initializer.getStart(),
-			text: `export ${md.kind} ${md.name} = ${md.initializerText};`,
-		})
-	}
-	for (const ex of movedExprs) {
-		const text = ex.text.endsWith(";") ? ex.text : `${ex.text};`
-		units.push({
-			pos: ex.expression.getStart(),
-			text,
-		})
-	}
-	units.sort((a, b) => a.pos - b.pos)
-	for (const u of units) {
-		parts.push(u.text)
-	}
-
-	return `${parts.join("\n")}\n`
-}
-
-// =============================================================================
-// Import injection
-// =============================================================================
-
-/**
- * Injects the virtual module import and re-exports into the transformed statements.
- * Also injects withComponent helper import if needed.
- */
-const injectImports = (
-	statements: ts.Statement[],
-	movedNames: string[],
-	reexportNames: string[],
-	importPath: string,
-	needsWithComponentHelper: boolean,
-): ts.Statement[] => {
-	const importDecl = createNamedImport(movedNames, importPath)
-
-	// find last import to insert after it
-	let lastImportIndex = -1
-	statements.forEach((st, i) => {
-		if (ts.isImportDeclaration(st)) lastImportIndex = i
-	})
-
-	const insertAt = lastImportIndex >= 0 ? lastImportIndex + 1 : 0
-	const newStatements = [...statements]
-
-	// inject withComponent helper if needed
-	if (needsWithComponentHelper) {
-		const helperImport = createNamedImport(
-			["withComponent"],
-			"library/styled/withComponent",
-		)
-		newStatements.splice(insertAt, 0, helperImport)
-	}
-
-	// inject virtual module import
-	const virtualImportAt = needsWithComponentHelper ? insertAt + 1 : insertAt
-	newStatements.splice(virtualImportAt, 0, importDecl)
-
-	// inject re-exports if needed
-	if (reexportNames.length > 0) {
-		const reexp = createReExport(reexportNames, importPath)
-		newStatements.splice(virtualImportAt + 1, 0, reexp)
-	}
-
-	return newStatements
+	const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed })
+	const nextFile = ts.factory.updateSourceFile(sf, statements)
+	return printer.printFile(nextFile)
 }
 
 // =============================================================================
 // Vanilla-extract plugin integration
 // =============================================================================
 
-const handleVanillaExtractError = (
+function handleVanillaExtractError(
 	err: Error,
 	reject: (reason: Error) => void,
-): void => {
-	const rawMsg = (err && (err as Error).message) || String(err)
-	const stack = (err && (err as Error).stack) || ""
+): void {
+	const rawMsg = err?.message || String(err)
+	const stack = err?.stack || ""
+
 	if (rawMsg.includes("Styles were unable to be assigned to a file")) {
 		const offenderMatch =
 			stack.match(/\(([^)]+\.(?:ts|tsx))\)/) ||
 			stack.match(/at\s+.*?\s+\(([^)]+\.(?:ts|tsx))\)/) ||
 			stack.match(/\s(\/[^\s]+\.(?:ts|tsx))/)
+
 		const offender = offenderMatch?.[1] ?? "Unable to determine offending file!"
 		const offenderName = offender.split("/").pop() ?? offender
+
 		const message = [
 			"Styles were unable to be assigned to a file. You likely created styles outside of a '.css.ts' context",
 			"",
@@ -900,24 +752,23 @@ const handleVanillaExtractError = (
 			"",
 			`Offending file: ${offender}`,
 		].join("\n")
+
 		reject(new Error(message))
 		return
 	}
 
-	// eslint-disable-next-line no-console
 	console.error(err)
-	// eslint-disable-next-line no-console
 	console.warn(
 		"Encountered an error processing styles. The error message may or may not be helpful, talk to Robbie if you're stuck.",
 	)
 	reject(err)
 }
 
-const runVePluginOnTempFile = async (
+async function runVePluginOnTempFile(
 	originalThis: TurboLoaderContext<TurboLoaderOptions>,
 	tempFilePath: string,
 	loaderOptions: Partial<TurboLoaderOptions>,
-): Promise<string> => {
+): Promise<string> {
 	return new Promise<string>((resolve, reject) => {
 		const modifiedThis = {
 			getOptions: () => ({
@@ -932,9 +783,7 @@ const runVePluginOnTempFile = async (
 		} satisfies TurboLoaderContext<TurboLoaderOptions>
 
 		Promise.resolve(turboLoader.call(modifiedThis))
-			.then((data) => {
-				resolve(data)
-			})
+			.then(resolve)
 			.catch((err: Error) => handleVanillaExtractError(err, reject))
 	})
 }
@@ -943,197 +792,105 @@ const runVePluginOnTempFile = async (
 // Main transform
 // =============================================================================
 
-const transform = async (
+async function transform(
 	loaderThis: TurboLoaderContext<TurboLoaderOptions>,
 	rootContext: string,
 	filePath: string,
 	sourceCode: string,
 	options: Partial<TurboLoaderOptions>,
-): Promise<{ code: string; movedNames: string[] }> => {
+): Promise<{ code: string; movedNames: string[] }> {
 	const isTsx = filePath.endsWith(".tsx") || filePath.endsWith(".jsx")
-	const sourceFile = ts.createSourceFile(
-		filePath,
-		sourceCode,
-		ts.ScriptTarget.ES2020,
-		true,
-		isTsx ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
-	)
 
-	// 1) build import registry
-	const registry = buildImportRegistry(sourceFile)
+	// 1) Build dependency graph
+	const graph = analyzeDependencies(sourceCode, { isTsx })
 
-	// 2) split declarations
-	const splitResult = splitDeclarations(sourceFile, registry)
+	// 2) Build tracked import registry
+	const registry = buildTrackedRegistry(graph)
 
-	// nothing to move? return original code unchanged
-	if (splitResult.movedNames.length === 0) {
+	// 3) Compute tainted nodes
+	const { tainted, invalidTainted } = computeTaintedNodes(graph, registry)
+
+	// 4) Error on tainted functions/classes (skip for library/styled files which are part of the system)
+	const isStyledLibrary = filePath.includes("library/styled/")
+	if (invalidTainted.length > 0 && !isStyledLibrary) {
+		const names = invalidTainted.map((n) => n.name ?? "anonymous").join(", ")
+		throw new Error(
+			`Cannot use style functions inside function/class body: ${names}. ` +
+				`Move style calls to module scope or a .css.ts file.`,
+		)
+	}
+
+	// 5) Early exit if nothing tainted
+	if (tainted.size === 0) {
 		return { code: sourceCode, movedNames: [] }
 	}
 
-	// 2.5) iteratively include supporting statements (and their own deps)
-	const importLocalNames = collectImportLocalNames(registry.allImports)
-	const movedNamesSet = new Set(splitResult.movedNames)
-	const includedSupport = new Set<ts.Statement>()
-	const declaredBySupport = new Set<string>()
+	// 6) Analyze styled() calls
+	const styledTransforms = analyzeStyledCalls(graph, registry, tainted)
 
-	const computeUnresolved = (): Set<string> => {
-		const deps = new Set<string>()
-		for (const md of splitResult.movedDecls) {
-			for (const dep of collectDependenciesForNode(md.initializer))
-				deps.add(dep)
-		}
-		for (const ex of splitResult.movedExprs) {
-			for (const dep of collectDependenciesForNode(ex.expression)) deps.add(dep)
-		}
-		for (const st of splitResult.supportingStatements) {
-			for (const dep of collectDependenciesForNode(st)) deps.add(dep)
-		}
-		const unresolved = new Set<string>()
-		for (const name of deps) {
-			if (movedNamesSet.has(name)) continue
-			if (importLocalNames.has(name)) continue
-			if (GLOBAL_IDENTIFIERS.has(name)) continue
-			if (declaredBySupport.has(name)) continue
-			unresolved.add(name)
-		}
-		return unresolved
-	}
+	// 7) Partition nodes
+	const partition = partitionNodes(graph, tainted, styledTransforms)
 
-	let unresolvedNames = computeUnresolved()
-	// Increased limit to 50 to handle deep dependency chains.
-	// The loop exits early if no new supporting statements are found.
-	for (let i = 0; i < 50 && unresolvedNames.size > 0; i++) {
-		const support = findSupportingStatements(
-			sourceFile,
-			unresolvedNames,
-		).filter(
-			(s) =>
-				!includedSupport.has(s) &&
-				!isTrackedStyledCall(s, registry) &&
-				!containsJsx(s),
-		)
-		if (support.length === 0) break
-		for (const st of support) {
-			includedSupport.add(st)
-			splitResult.supportingStatements.push(st)
-			for (const nm of getDeclaredNamesFromStatement(st)) {
-				declaredBySupport.add(nm)
-			}
-		}
-		unresolvedNames = computeUnresolved()
-	}
-
-	// 3) build virtual module source
-	const virtualSource = buildVirtualModuleSource(
-		sourceFile,
-		registry.allImports,
-		splitResult.movedDecls,
-		splitResult.movedExprs,
-		splitResult.supportingStatements,
+	// 8) Build virtual module source
+	const virtualSource = buildVirtualSource(
+		graph,
+		partition,
+		tainted,
+		styledTransforms,
 	)
 
-	// 4) rewrite imports in virtual module to be tsconfig-safe specifiers
-	const rewriteToTsconfig = (
-		code: string,
-		originalFilePath: string,
-		rootDir: string,
-	): string => {
-		const sf = ts.createSourceFile(
-			"rewrite.ts",
-			code,
-			ts.ScriptTarget.ES2020,
-			true,
-			ts.ScriptKind.TS,
-		)
-		const updates: Array<{ node: ts.ImportDeclaration; newSpec: string }> = []
-		for (const st of sf.statements) {
-			if (!ts.isImportDeclaration(st)) continue
-			const spec = (st.moduleSpecifier as ts.StringLiteral).text
-			if (!spec.startsWith("./") && !spec.startsWith("../")) continue
-			const originalDir = path.dirname(originalFilePath)
-			const absolutePath = path.resolve(originalDir, spec).replace(/\\/g, "/")
-			const relRoot = path.relative(rootDir, absolutePath).replace(/\\/g, "/")
-			const newSpec = `@/${relRoot}`
-			updates.push({ node: st, newSpec })
-		}
-		if (updates.length === 0) return code
-		const statements: ts.Statement[] = []
-		for (const st of sf.statements) {
-			if (ts.isImportDeclaration(st)) {
-				const upd = updates.find((u) => u.node === st)
-				if (upd) {
-					statements.push(
-						ts.factory.updateImportDeclaration(
-							st,
-							st.modifiers,
-							st.importClause,
-							ts.factory.createStringLiteral(upd.newSpec),
-							st.assertClause,
-						),
-					)
-					continue
-				}
-			}
-			statements.push(st)
-		}
-		const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed })
-		const nextFile = ts.factory.updateSourceFile(sf, statements)
-		return printer.printFile(nextFile)
-	}
+	// 9) Rewrite imports to tsconfig-safe specifiers
 	const virtualSourceResolved = rewriteToTsconfig(
 		virtualSource,
 		filePath,
 		rootContext,
 	)
 
-	// use relative path from rootContext for better class name prefixes
-	// e.g., app/sections/BrandedComps/index.tsx -> sections-BrandedComps-index
+	// Paths for debug and temp files
 	const relPath = path.relative(rootContext, filePath).replace(/\\/g, "/")
 	const relPathNoExt = relPath.replace(/\.(?:tsx|ts|jsx|js)$/i, "")
+	const virtualExt = isTsx ? ".css.tsx" : ".css.ts"
 
-	// write pre-process debug file
+	// Write pre-process debug file
 	const preProcessDebugPath = path.join(
 		rootContext,
 		".next",
 		"debug",
 		"pre-process",
-		`${relPathNoExt}.css.ts`,
+		`${relPathNoExt}${virtualExt}`,
 	)
 	await fs.mkdir(path.dirname(preProcessDebugPath), { recursive: true })
 	await fs.writeFile(preProcessDebugPath, virtualSourceResolved)
 
-	// 5) write temp file mirroring the original relative path
+	// 10) Write temp file
 	const tmpRoot = path.join(rootContext, ".next", "vanilla")
 	const tmpFile = path
-		.join(tmpRoot, `${relPathNoExt}.css.ts`)
+		.join(tmpRoot, `${relPathNoExt}${virtualExt}`)
 		.replace(/\\/g, "/")
 	fsSync.mkdirSync(path.dirname(tmpFile), { recursive: true })
 	fsSync.writeFileSync(tmpFile, virtualSourceResolved, "utf8")
 
-	// 6) run VE plugin on temp file (keep file on disk for debugging)
-	let veJs = ""
-	veJs = await runVePluginOnTempFile(loaderThis, tmpFile, options)
-
-	// 7) rewrite imports in VE output to tsconfig-safe specifiers
+	// 11) Run VE plugin
+	const veJs = await runVePluginOnTempFile(loaderThis, tmpFile, options)
 	const veJsResolved = rewriteToTsconfig(veJs, tmpFile, rootContext)
 
-	// 8) embed as data URL and inject imports
+	// 12) Embed as data URL and build original module
 	const jsBase64 = Buffer.from(veJsResolved, "utf8").toString("base64")
 	const importPath = `data:text/javascript;base64,${jsBase64}`
-	const newStatements = injectImports(
-		splitResult.statements,
-		splitResult.movedNames,
-		splitResult.reexportNames,
+
+	const newStatements = buildOriginalStatements(
+		graph,
+		partition,
+		tainted,
+		styledTransforms,
 		importPath,
-		splitResult.needsWithComponentHelper,
 	)
 
-	// 7) print final transformed source
-	const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed })
-	const updated = ts.factory.updateSourceFile(sourceFile, newStatements)
-	const printed = printer.printFile(updated)
+	// 13) Print final transformed source
+	const updated = ts.factory.updateSourceFile(graph.sourceFile, newStatements)
+	const printed = printSourceFile(updated)
 
-	// write final debug file (transformed source that gets passed to loader)
+	// Write final debug file
 	const finalDebugPath = path.join(
 		rootContext,
 		".next",
@@ -1146,7 +903,7 @@ const transform = async (
 
 	return {
 		code: printed,
-		movedNames: splitResult.movedNames,
+		movedNames: partition.imports,
 	}
 }
 
@@ -1158,11 +915,16 @@ export default async function vanillaSplitLoader(
 	this: TurboLoaderContext<TurboLoaderOptions>,
 	sourceCode: string,
 ) {
-	// pass through pure vanilla-extract files untouched
+	// Pass through pure vanilla-extract files untouched
 	if (
 		this.resourcePath.endsWith(".css.ts") ||
 		this.resourcePath.endsWith(".css.tsx")
 	) {
+		return sourceCode
+	}
+
+	// Skip styled library files - they ARE the style system, not consumers of it
+	if (this.resourcePath.includes("library/styled/")) {
 		return sourceCode
 	}
 

--- a/vanilla/withVanillaSplit.ts
+++ b/vanilla/withVanillaSplit.ts
@@ -32,5 +32,12 @@ export const withVanillaSplit = (config: NextConfig): NextConfig => {
 		],
 	}
 
-	return withVanillaExtract(config)
+	const updatedConfig = withVanillaExtract(config)
+
+	// @ts-expect-error not safe but fine for now
+	updatedConfig.turbopack?.rules["vanilla.virtual.css"].loaders.unshift(
+		require.resolve("./css-loader.ts"),
+	)
+
+	return updatedConfig
 }

--- a/videos/BatterySaverVideo.tsx
+++ b/videos/BatterySaverVideo.tsx
@@ -1,7 +1,7 @@
 import type MuxVideoComponent from "@mux/mux-video-react"
 import { eases } from "library/eases"
 import Portal from "library/Portal"
-import { css, f, keyframes, styled } from "library/styled/alpha"
+import { css, f, styled } from "library/styled/alpha"
 import {
 	type ComponentProps,
 	type Ref,
@@ -12,6 +12,7 @@ import {
 	useState,
 } from "react"
 import { MuxVideo } from "./MuxVideo"
+import { keyframes } from "@vanilla-extract/css"
 
 // Set to true to simulate NotAllowedError for testing
 const FORCE_FAIL = false
@@ -170,14 +171,14 @@ const Video = styled(
 	`),
 )
 
-const fadeIn = keyframes`
-	from {
-		opacity: 0;
-	}
-	to {
-		opacity: 1;
-	}
-`
+const fadeIn = keyframes({
+	from: {
+		opacity: 0,
+	},
+	to: {
+		opacity: 1,
+	},
+})
 
 const LowPowerOverlay = styled(
 	"button",

--- a/videos/BatterySaverVideo.tsx
+++ b/videos/BatterySaverVideo.tsx
@@ -1,4 +1,5 @@
 import type MuxVideoComponent from "@mux/mux-video-react"
+import { keyframes } from "@vanilla-extract/css"
 import { eases } from "library/eases"
 import Portal from "library/Portal"
 import { css, f, styled } from "library/styled/alpha"
@@ -12,7 +13,6 @@ import {
 	useState,
 } from "react"
 import { MuxVideo } from "./MuxVideo"
-import { keyframes } from "@vanilla-extract/css"
 
 // Set to true to simulate NotAllowedError for testing
 const FORCE_FAIL = false

--- a/videos/MuxVideo.tsx
+++ b/videos/MuxVideo.tsx
@@ -7,5 +7,15 @@ export function MuxVideo({
 }: ComponentProps<typeof MuxVideoComponent> & {
 	ref?: Ref<HTMLVideoElement>
 }) {
-	return <MuxVideoComponent ref={ref} {...props} />
+	return (
+		<MuxVideoComponent
+			ref={ref}
+			preferPlayback="mse"
+			renditionOrder="desc"
+			_hlsConfig={{
+				backBufferLength: 0,
+			}}
+			{...props}
+		/>
+	)
 }

--- a/videos/MuxVideo.tsx
+++ b/videos/MuxVideo.tsx
@@ -10,7 +10,7 @@ export function MuxVideo({
 	return (
 		<MuxVideoComponent
 			ref={ref}
-			preferPlayback="mse"
+			preferPlayback="native"
 			renditionOrder="desc"
 			_hlsConfig={{
 				backBufferLength: 0,


### PR DESCRIPTION
AI driven refactors from the last week or so

- css`` accepts any arbitrary selector
- `within` api is now useless (still exists for now)
- css is not reformatted, which should eliminate an entire class of errors
- the splitter is much more efficient
- the splitter tracks and splits variable dependencies
- compileTime helper
- added a new 'engine' option. choose between `calc` (new) or `media` (similar to older system) based styles
- more declarative utilities config for `f.whatever` (you should be able to add utilities that do what you want much more easily without editing much of the engine code)