### PR TITLE
recreation scroll experiment

### DIFF
--- a/ScreenContext.tsx
+++ b/ScreenContext.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { viewport } from "next-sanity/studio"
 import {
 	desktopBreakpoint,
 	mobileBreakpoint,

--- a/ScreenContext.tsx
+++ b/ScreenContext.tsx
@@ -13,6 +13,7 @@ import {
 	useState,
 	useTransition,
 } from "react"
+import { getVH } from "./viewportUtils"
 
 type HydrationPhase =
 	| "hydrating-react"
@@ -80,7 +81,7 @@ export function ScreenProvider({ children }: Props) {
 		)
 		setFw(window.innerWidth > desktopBreakpoint)
 		setInnerWidth(window.innerWidth)
-		setViewportHeight(window.innerHeight)
+		setViewportHeight(getVH(100))
 	}, [])
 
 	useEffect(() => {

--- a/ScreenContext.tsx
+++ b/ScreenContext.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { viewport } from "next-sanity/studio"
 import {
 	createContext,
 	useCallback,
@@ -13,6 +14,7 @@ import {
 	mobileBreakpoint,
 	tabletBreakpoint,
 } from "styles/media"
+import { set } from "zod"
 
 type HydrationPhase =
 	| "hydrating-react"
@@ -24,6 +26,7 @@ type HydrationPhase =
  */
 export const ScreenContext = createContext({
 	innerWidth: 0,
+	viewportHeight: 0,
 	fullWidth: false,
 	desktop: false,
 	tablet: false,
@@ -59,6 +62,7 @@ export function ScreenProvider({ children }: Props) {
 	const [t, setT] = useState<boolean>(false)
 	const [m, setM] = useState<boolean>(true)
 	const [innerWidth, setInnerWidth] = useState(0)
+	const [viewportHeight, setViewportHeight] = useState(0)
 
 	/**
 	 * preloading utilities
@@ -78,6 +82,7 @@ export function ScreenProvider({ children }: Props) {
 		)
 		setFw(window.innerWidth > desktopBreakpoint)
 		setInnerWidth(window.innerWidth)
+		setViewportHeight(window.innerHeight)
 	}, [])
 
 	useEffect(() => {
@@ -155,6 +160,7 @@ export function ScreenProvider({ children }: Props) {
 				desktop: d,
 				tablet: t,
 				mobile: m,
+				viewportHeight,
 				shouldHydrateUtilities:
 					phase === "hydrating-utilities" || phase === "hydration-complete",
 				initComplete: phase === "hydration-complete",

--- a/useAnimation.ts
+++ b/useAnimation.ts
@@ -1,5 +1,5 @@
 import gsap from "gsap"
-import { viewport } from "next-sanity/studio"
+import { ScrollTrigger } from "gsap/all"
 import {
 	type DependencyList,
 	use,
@@ -10,7 +10,8 @@ import {
 } from "react"
 import { isBrowser } from "./deviceDetection"
 import { ScreenContext } from "./ScreenContext"
-import { useVH } from "./viewportUtils"
+
+let microtaskWaiting = false
 
 const useIsomorphicLayoutEffect =
 	typeof document !== "undefined" ? useLayoutEffect : useEffect
@@ -157,16 +158,30 @@ export const useAnimation = <InputFn extends Creation>(
 		if (!shouldHydrateUtilities) return
 
 		const newContext = gsap.context((self) => {
-			// const lenis = window.lenis
+			const lenis = window.lenis
 
-			// if (lenis && lenis.animatedScroll > 0.1 && updateBehavior === "revert") {
-			// 	const savedPosition = lenis.animatedScroll
-			// 	lenis.scrollTo(0, { immediate: true, force: true })
-
-			// 	requestAnimationFrame(() => {
-			// 		lenis.scrollTo(savedPosition, { immediate: true, force: true })
-			// 	})
-			// }
+			if (
+				// lenis exists
+				lenis &&
+				// we're not already at the top of the page
+				lenis.animatedScroll > 0.1 &&
+				// there's not already a microtask waiting
+				!microtaskWaiting
+			) {
+				microtaskWaiting = true
+				queueMicrotask(() => {
+					const savedPosition = lenis.animatedScroll
+					lenis.scrollTo(0, {
+						immediate: true,
+						force: true,
+						onComplete: () => {
+							microtaskWaiting = false
+							ScrollTrigger.refresh()
+							lenis.scrollTo(savedPosition, { immediate: true, force: true })
+						},
+					})
+				})
+			}
 
 			const result = createAnimations({
 				context: self,

--- a/useAnimation.ts
+++ b/useAnimation.ts
@@ -223,7 +223,7 @@ export const useAnimation = <InputFn extends Creation>(
 		updateBehavior,
 		shouldHydrateUtilities,
 		recreateOnResize ? innerWidth : null,
-		viewportHeight,
+		recreateOnResize ? viewportHeight : null,
 
 		...dependencies,
 		hmrHash,

--- a/useAnimation.ts
+++ b/useAnimation.ts
@@ -154,6 +154,17 @@ export const useAnimation = <InputFn extends Creation>(
 		if (!shouldHydrateUtilities) return
 
 		const newContext = gsap.context((self) => {
+			const lenis = window.lenis
+
+			if (lenis && lenis.animatedScroll > 0.1 && updateBehavior === 'revert') {
+				const savedPosition = lenis.animatedScroll
+				lenis.scrollTo(0, { immediate: true, force: true })
+
+				requestAnimationFrame(() => {
+					lenis.scrollTo(savedPosition, { immediate: true, force: true })
+				})
+			}
+
 			const result = createAnimations({
 				context: self,
 				contextSafe: ((func) =>

--- a/useAnimation.ts
+++ b/useAnimation.ts
@@ -10,6 +10,7 @@ import {
 import { isBrowser } from "./deviceDetection"
 import { ScreenContext } from "./ScreenContext"
 import { useVH } from "./viewportUtils"
+import { viewport } from "next-sanity/studio"
 
 const useIsomorphicLayoutEffect =
 	typeof document !== "undefined" ? useLayoutEffect : useEffect
@@ -100,7 +101,8 @@ export const useAnimation = <InputFn extends Creation>(
 		updateBehavior = "revert",
 		unmountBehavior = "kill",
 	} = options ?? {}
-	const { innerWidth, shouldHydrateUtilities } = use(ScreenContext)
+	const { innerWidth, viewportHeight, shouldHydrateUtilities } =
+		use(ScreenContext)
 
 	const dependencies = [...deps, ...extraDeps]
 
@@ -155,16 +157,16 @@ export const useAnimation = <InputFn extends Creation>(
 		if (!shouldHydrateUtilities) return
 
 		const newContext = gsap.context((self) => {
-			const lenis = window.lenis
+			// const lenis = window.lenis
 
-			if (lenis && lenis.animatedScroll > 0.1 && updateBehavior === "revert") {
-				const savedPosition = lenis.animatedScroll
-				lenis.scrollTo(0, { immediate: true, force: true })
+			// if (lenis && lenis.animatedScroll > 0.1 && updateBehavior === "revert") {
+			// 	const savedPosition = lenis.animatedScroll
+			// 	lenis.scrollTo(0, { immediate: true, force: true })
 
-				requestAnimationFrame(() => {
-					lenis.scrollTo(savedPosition, { immediate: true, force: true })
-				})
-			}
+			// 	requestAnimationFrame(() => {
+			// 		lenis.scrollTo(savedPosition, { immediate: true, force: true })
+			// 	})
+			// }
 
 			const result = createAnimations({
 				context: self,
@@ -206,7 +208,8 @@ export const useAnimation = <InputFn extends Creation>(
 		updateBehavior,
 		shouldHydrateUtilities,
 		recreateOnResize ? innerWidth : null,
-		useVH(recreateOnResize ? 100 : 0),
+		viewportHeight,
+
 		...dependencies,
 		hmrHash,
 	])

--- a/useAnimation.ts
+++ b/useAnimation.ts
@@ -1,4 +1,5 @@
 import gsap from "gsap"
+import { viewport } from "next-sanity/studio"
 import {
 	type DependencyList,
 	use,
@@ -10,7 +11,6 @@ import {
 import { isBrowser } from "./deviceDetection"
 import { ScreenContext } from "./ScreenContext"
 import { useVH } from "./viewportUtils"
-import { viewport } from "next-sanity/studio"
 
 const useIsomorphicLayoutEffect =
 	typeof document !== "undefined" ? useLayoutEffect : useEffect

--- a/useAnimation.ts
+++ b/useAnimation.ts
@@ -9,6 +9,7 @@ import {
 } from "react"
 import { isBrowser } from "./deviceDetection"
 import { ScreenContext } from "./ScreenContext"
+import { useVH } from "./viewportUtils"
 
 const useIsomorphicLayoutEffect =
 	typeof document !== "undefined" ? useLayoutEffect : useEffect
@@ -156,7 +157,7 @@ export const useAnimation = <InputFn extends Creation>(
 		const newContext = gsap.context((self) => {
 			const lenis = window.lenis
 
-			if (lenis && lenis.animatedScroll > 0.1 && updateBehavior === 'revert') {
+			if (lenis && lenis.animatedScroll > 0.1 && updateBehavior === "revert") {
 				const savedPosition = lenis.animatedScroll
 				lenis.scrollTo(0, { immediate: true, force: true })
 
@@ -205,6 +206,7 @@ export const useAnimation = <InputFn extends Creation>(
 		updateBehavior,
 		shouldHydrateUtilities,
 		recreateOnResize ? innerWidth : null,
+		useVH(recreateOnResize ? 100 : 0),
 		...dependencies,
 		hmrHash,
 	])

--- a/useAnimation.ts
+++ b/useAnimation.ts
@@ -165,6 +165,8 @@ export const useAnimation = <InputFn extends Creation>(
 				lenis &&
 				// we're not already at the top of the page
 				lenis.animatedScroll > 0.1 &&
+				// this animation is expecting to be cleaned up
+				updateBehavior === "revert" &&
 				// there's not already a microtask waiting
 				!microtaskWaiting
 			) {


### PR DESCRIPTION
**Screen context enhancements:**

* Added `viewportHeight` to the `ScreenContext` state and context value, allowing utilities  to access the current viewport height. [[1]](diffhunk://#diff-fb969991fb6b5847f3af517a382ae390660b7c3024df0eeedc1394dfdbbe79d0R27) [[2]](diffhunk://#diff-fb969991fb6b5847f3af517a382ae390660b7c3024df0eeedc1394dfdbbe79d0R63) [[3]](diffhunk://#diff-fb969991fb6b5847f3af517a382ae390660b7c3024df0eeedc1394dfdbbe79d0R83) [[4]](diffhunk://#diff-fb969991fb6b5847f3af517a382ae390660b7c3024df0eeedc1394dfdbbe79d0R161)

**Animation utilities improvements:**

* Updated the `useAnimation` hook to consume `viewportHeight` from the context and include it as a dependency, ensuring animations respond to viewport height changes when `recreateOnResize` is true. [[1]](diffhunk://#diff-ebc83b44f3b8872d53cb1bea1d4091df0fb47318874d9f07c71fea454aa788ecL102-R106) [[2]](diffhunk://#diff-ebc83b44f3b8872d53cb1bea1d4091df0fb47318874d9f07c71fea454aa788ecR226-R227)
* Implemented a microtask-based scroll reset mechanism using lenis to reliably refresh scroll-triggered animations at the top of the page after creation. [[1]](diffhunk://#diff-ebc83b44f3b8872d53cb1bea1d4091df0fb47318874d9f07c71fea454aa788ecR2) [[2]](diffhunk://#diff-ebc83b44f3b8872d53cb1bea1d4091df0fb47318874d9f07c71fea454aa788ecR14-R15) [[3]](diffhunk://#diff-ebc83b44f3b8872d53cb1bea1d4091df0fb47318874d9f07c71fea454aa788ecR161-R185)