### PR TITLE
fix base UI styled usage type errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
 		"zod": "^4"
 	},
 	"devDependencies": {
-		"@base-ui/react": "^1.0.0",
 		"@biomejs/biome": "^2",
 		"@types/stylis": "^4",
 		"typescript": "^5",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"zod": "^4"
 	},
 	"devDependencies": {
+		"@base-ui/react": "^1.0.0",
 		"@biomejs/biome": "^2",
 		"@types/stylis": "^4",
 		"typescript": "^5",

--- a/styled/alpha.ts
+++ b/styled/alpha.ts
@@ -26,7 +26,7 @@ export function compileTime<T>(getValue: () => T): T {
 // Overload: intrinsic tag (e.g., 'div')
 export function styled<
 	Tag extends keyof JSX.IntrinsicElements,
-	_Props extends { className?: string },
+	_Props extends { className?: unknown },
 	const Variants extends VariantsSchema = never,
 	const Tokens extends TokensSchema = never,
 	const DefaultVariants extends DefaultVariantsSchema<Variants> = never,
@@ -41,7 +41,7 @@ export function styled<
 // Overload: component target (function)
 export function styled<
 	_Tag extends keyof JSX.IntrinsicElements,
-	Props extends { className?: string },
+	Props extends { className?: unknown },
 	const Variants extends VariantsSchema = never,
 	const Tokens extends TokensSchema = never,
 	const DefaultVariants extends DefaultVariantsSchema<Variants> = never,
@@ -54,7 +54,7 @@ export function styled<
 // Overload: component target (class)
 export function styled<
 	_Tag extends keyof JSX.IntrinsicElements,
-	Props extends { className?: string },
+	Props extends { className?: unknown },
 	const Variants extends VariantsSchema = never,
 	const Tokens extends TokensSchema = never,
 	const DefaultVariants extends DefaultVariantsSchema<Variants> = never,
@@ -69,7 +69,7 @@ export function styled<
 // the last overload
 export function styled<
 	Tag extends keyof JSX.IntrinsicElements,
-	Props extends { className?: string },
+	Props extends { className?: unknown },
 	const Variants extends VariantsSchema = never,
 	const Tokens extends TokensSchema = never,
 	const DefaultVariants extends DefaultVariantsSchema<Variants> = never,
@@ -82,7 +82,7 @@ export function styled<
 // Implementation
 export function styled<
 	Tag extends keyof JSX.IntrinsicElements,
-	Props extends { className?: string },
+	Props extends { className?: unknown },
 	const Variants extends VariantsSchema = never,
 	const Tokens extends TokensSchema = never,
 	const DefaultVariants extends DefaultVariantsSchema<Variants> = never,

--- a/styled/runtime.tsx
+++ b/styled/runtime.tsx
@@ -75,11 +75,15 @@ export function runtimeStyled({
 		const Render = props.as ?? tag
 		// @ts-expect-error
 		const resolved = resolve(props)
+		const mergedClassName =
+			typeof className === "function"
+				? (state: unknown) => cx(resolved, className(state))
+				: cx(resolved, className)
 		return (
 			// @ts-expect-error
 			<Render
 				// @ts-expect-error
-				className={cx(resolved, className)}
+				className={mergedClassName}
 				// @ts-expect-error
 				style={{ ...style, ...tokenStyle }}
 				{...domProps}

--- a/styled/styled-gen.test-d.tsx
+++ b/styled/styled-gen.test-d.tsx
@@ -1,4 +1,5 @@
 import { style } from "@vanilla-extract/css"
+import { Field } from "@base-ui/react/field"
 import { styled } from "library/styled/alpha"
 import { Component, type ComponentProps, type FC } from "react"
 import { expectTypeOf, test } from "vitest"
@@ -263,6 +264,55 @@ test("component targets must accept className", () => {
 test("unrelated DOM props still forward", () => {
 	const Btn = styled("button", { base: [{}] } as const)
 	const _ok = <Btn disabled aria-label="x" />
+})
+
+// ---------- Base UI Field.Control + styled ----------
+
+test("styled(Field.Control) accepts input props when used with type assertion", () => {
+	const StyledInput = styled(Field.Control, {
+		base: [{ padding: "4px" }],
+	}) as typeof Field.Control
+
+	const handleChange = (_key: string, _value: string) => {}
+
+	const _ok = (
+		<Field.Root>
+			<StyledInput
+				type="text"
+				placeholder="Enter Number"
+				value=""
+				onChange={(e) => handleChange("posPerMonth", e.target.value)}
+				required
+				className="custom"
+			/>
+		</Field.Root>
+	)
+})
+
+test("styled(Field.Control) without type assertion: input props work at usage site", () => {
+	const StyledInput = styled(Field.Control, {
+		base: [{ padding: "4px" }],
+	})
+
+	// biome-ignore lint/suspicious/noExplicitAny: used for test
+	expectTypeOf(StyledInput).not.toExtend<any>()
+	expectTypeOf(StyledInput).toExtend<typeof Field.Control>()
+
+	const handleChange = (_key: string, _value: string) => {}
+
+	// same usage as Field.Control directly - type, placeholder, value, onChange, required, className
+	const _ok = (
+		<Field.Root>
+			<StyledInput
+				type="text"
+				placeholder="Enter Number"
+				value=""
+				onChange={(e) => handleChange("posPerMonth", e.target.value)}
+				required
+				className="custom"
+			/>
+		</Field.Root>
+	)
 })
 
 // ---------- generics preservation with variants ----------

--- a/styled/styled-gen.test-d.tsx
+++ b/styled/styled-gen.test-d.tsx
@@ -280,7 +280,6 @@ test("type is preserved when className is unconventional", () => {
 		base: [{ padding: "4px" }],
 	})
 
-	// same usage as Field.Control directly - type, placeholder, value, onChange, required, className
 	const _ok = (
 		<>
 			<CustomComponent

--- a/styled/styled-gen.test-d.tsx
+++ b/styled/styled-gen.test-d.tsx
@@ -273,7 +273,7 @@ test("type is preserved when className is unconventional", () => {
 		{
 			type?: string
 			onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
-			className?: string | ((state: unknown) => string | undefined)
+			className?: string | ((state: { checked: boolean}) => string | undefined)
 		} & React.RefAttributes<HTMLInputElement>
 	>
 	const StyledInput = styled(CustomComponent, {
@@ -292,12 +292,12 @@ test("type is preserved when className is unconventional", () => {
 			<CustomComponent
 				type="text"
 				onChange={(_event) => null}
-				className={(_state) => "custom"}
+				className={(state) => state.checked ? "enabled" : 'disabled'}
 			/>
 			<StyledInput
 				type="text"
 				onChange={(_event) => null}
-				className={(_state) => "custom"}
+				className={(state) => state.checked ? "enabled" : 'disabled'}
 			/>
 		</>
 	)

--- a/styled/styled-gen.test-d.tsx
+++ b/styled/styled-gen.test-d.tsx
@@ -273,7 +273,7 @@ test("type is preserved when className is unconventional", () => {
 		{
 			type?: string
 			onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
-			className?: string | ((state: { checked: boolean}) => string | undefined)
+			className?: string | ((state: { checked: boolean }) => string | undefined)
 		} & React.RefAttributes<HTMLInputElement>
 	>
 	const StyledInput = styled(CustomComponent, {
@@ -291,12 +291,12 @@ test("type is preserved when className is unconventional", () => {
 			<CustomComponent
 				type="text"
 				onChange={(_event) => null}
-				className={(state) => state.checked ? "enabled" : 'disabled'}
+				className={(state) => (state.checked ? "enabled" : "disabled")}
 			/>
 			<StyledInput
 				type="text"
 				onChange={(_event) => null}
-				className={(state) => state.checked ? "enabled" : 'disabled'}
+				className={(state) => (state.checked ? "enabled" : "disabled")}
 			/>
 		</>
 	)

--- a/styled/styled-gen.test-d.tsx
+++ b/styled/styled-gen.test-d.tsx
@@ -1,5 +1,4 @@
 import { style } from "@vanilla-extract/css"
-import { Field } from "@base-ui/react/field"
 import { styled } from "library/styled/alpha"
 import { Component, type ComponentProps, type FC } from "react"
 import { expectTypeOf, test } from "vitest"
@@ -268,50 +267,39 @@ test("unrelated DOM props still forward", () => {
 
 // ---------- Base UI Field.Control + styled ----------
 
-test("styled(Field.Control) accepts input props when used with type assertion", () => {
-	const StyledInput = styled(Field.Control, {
-		base: [{ padding: "4px" }],
-	}) as typeof Field.Control
-
-	const handleChange = (_key: string, _value: string) => {}
-
-	const _ok = (
-		<Field.Root>
-			<StyledInput
-				type="text"
-				placeholder="Enter Number"
-				value=""
-				onChange={(e) => handleChange("posPerMonth", e.target.value)}
-				required
-				className="custom"
-			/>
-		</Field.Root>
-	)
-})
-
-test("styled(Field.Control) without type assertion: input props work at usage site", () => {
-	const StyledInput = styled(Field.Control, {
+test("type is preserved when className is unconventional", () => {
+	const CustomComponent = (() =>
+		null) as unknown as React.ForwardRefExoticComponent<
+		{
+			type?: string
+			onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+			className?: string | ((state: unknown) => string | undefined)
+		} & React.RefAttributes<HTMLInputElement>
+	>
+	const StyledInput = styled(CustomComponent, {
 		base: [{ padding: "4px" }],
 	})
 
-	// biome-ignore lint/suspicious/noExplicitAny: used for test
-	expectTypeOf(StyledInput).not.toExtend<any>()
-	expectTypeOf(StyledInput).toExtend<typeof Field.Control>()
-
-	const handleChange = (_key: string, _value: string) => {}
-
 	// same usage as Field.Control directly - type, placeholder, value, onChange, required, className
 	const _ok = (
-		<Field.Root>
-			<StyledInput
+		<>
+			<CustomComponent
 				type="text"
-				placeholder="Enter Number"
-				value=""
-				onChange={(e) => handleChange("posPerMonth", e.target.value)}
-				required
+				onChange={(_event) => null}
 				className="custom"
 			/>
-		</Field.Root>
+			<StyledInput type="text" onChange={(_event) => null} className="custom" />
+			<CustomComponent
+				type="text"
+				onChange={(_event) => null}
+				className={(_state) => "custom"}
+			/>
+			<StyledInput
+				type="text"
+				onChange={(_event) => null}
+				className={(_state) => "custom"}
+			/>
+		</>
 	)
 })
 

--- a/styled/types.ts
+++ b/styled/types.ts
@@ -104,8 +104,11 @@ export type StyledOutProps<
 		: VariantProps<Variants, DefaultVariants>) &
 	([Tokens] extends [never] ? unknown : TokenProps<Tokens>)
 
+/** className from Props is preserved so Base UI-style function className works */
 export type StyledComponent<Props> = (
-	props: Props & { className?: string },
+	props: Props extends { className?: infer C }
+		? Omit<Props, "className"> & { className?: C }
+		: Props & { className?: string },
 ) => JSX.Element
 
 export type FunctionComponent<Props> = (


### PR DESCRIPTION
Base UI allows you to pass className as a function:

```javascript
<Switch.Thumb className={(state) => (state.checked ? 'checked' : 'unchecked')} />
```

Our styled types were not equipped to handle this. Added support for this pattern, including forwarding the function where needed so that this pattern still works when extending a styled component.