### PR TITLE
Add generic video

### DIFF
--- a/sanity/assetMetadata.ts
+++ b/sanity/assetMetadata.ts
@@ -47,6 +47,7 @@ const linkSchema = z.object({
 
 type VideoAssetMeta = {
 	playbackId: string | undefined
+	videoThumbnailUrl: string | undefined
 	videoBlurUrl: string | undefined
 	videoAspectRatio: string | undefined
 	videoDuration: number | undefined
@@ -116,10 +117,19 @@ export const fetchAssetMeta = async <InputType>(
 
 			const meta = "metadata" in asset ? asset.metadata : null
 
+			const cleanPlaybackId = asset?._type === "mux.videoAsset" && asset.playbackId
+				? stegaClean(asset.playbackId)
+				: undefined
+			const thumbTime = asset?._type === "mux.videoAsset" ? asset.thumbTime : undefined
+			const videoThumbnailUrl = cleanPlaybackId
+				? `https://image.mux.com/${cleanPlaybackId}/thumbnail.jpg${thumbTime != null ? `?time=${thumbTime}` : ""}`
+				: undefined
+
 			const data =
 				asset._type === "mux.videoAsset"
 					? ({
 							playbackId: asset?.playbackId,
+							videoThumbnailUrl,
 							videoBlurUrl: blurDataURL,
 							videoAspectRatio: asset.data?.aspect_ratio?.replace(":", "/"),
 							videoDuration: asset?.data?.duration,

--- a/sanity/assetMetadata.ts
+++ b/sanity/assetMetadata.ts
@@ -117,10 +117,12 @@ export const fetchAssetMeta = async <InputType>(
 
 			const meta = "metadata" in asset ? asset.metadata : null
 
-			const cleanPlaybackId = asset?._type === "mux.videoAsset" && asset.playbackId
-				? stegaClean(asset.playbackId)
-				: undefined
-			const thumbTime = asset?._type === "mux.videoAsset" ? asset.thumbTime : undefined
+			const cleanPlaybackId =
+				asset?._type === "mux.videoAsset" && asset.playbackId
+					? stegaClean(asset.playbackId)
+					: undefined
+			const thumbTime =
+				asset?._type === "mux.videoAsset" ? asset.thumbTime : undefined
 			const videoThumbnailUrl = cleanPlaybackId
 				? `https://image.mux.com/${cleanPlaybackId}/thumbnail.jpg${thumbTime != null ? `?time=${thumbTime}` : ""}`
 				: undefined

--- a/sanity/reusables.ts
+++ b/sanity/reusables.ts
@@ -1,4 +1,12 @@
 import { PlayIcon } from "@sanity/icons"
+import {
+	MATCH_URL_YOUTUBE,
+	MATCH_URL_VIMEO,
+	MATCH_URL_WISTIA,
+	MATCH_URL_SPOTIFY,
+	MATCH_URL_TWITCH,
+	MATCH_URL_TIKTOK,
+} from "react-player/patterns"
 import type libraryConfig from "app/libraryConfig"
 import { attrs, styled } from "library/styled"
 import type { StaticImageData } from "next/image"
@@ -247,6 +255,30 @@ export const youtube = defineType({
 	],
 })
 
+/**
+ * URL validation patterns sourced from react-player.
+ * @see https://github.com/cookpete/react-player/blob/master/src/patterns.ts
+ */
+const videoSourceValidation: Record<string, RegExp> = {
+	youtube: MATCH_URL_YOUTUBE,
+	vimeo: MATCH_URL_VIMEO,
+	wistia: MATCH_URL_WISTIA,
+	spotify: MATCH_URL_SPOTIFY,
+	twitch: MATCH_URL_TWITCH,
+	tiktok: MATCH_URL_TIKTOK,
+}
+
+const videoSourceTypes = [
+	{ title: "Mux Video", value: "mux" },
+	{ title: "YouTube", value: "youtube" },
+	{ title: "Vimeo", value: "vimeo" },
+	{ title: "Wistia", value: "wistia" },
+	{ title: "Spotify", value: "spotify" },
+	{ title: "Twitch", value: "twitch" },
+	{ title: "TikTok", value: "tiktok" },
+	{ title: "Video URL", value: "url" },
+]
+
 export const video = defineType({
 	name: "video",
 	type: "object",
@@ -256,22 +288,29 @@ export const video = defineType({
 		defineField({
 			name: "sourceType",
 			type: "string",
-			title: "Source Type",
+			title: "Source",
 			options: {
-				list: [
-					{ title: "URL (YouTube, Vimeo, Wistia, etc.)", value: "url" },
-					{ title: "Mux Upload", value: "mux" },
-				],
-				layout: "radio",
+				list: videoSourceTypes,
 			},
-			initialValue: "url",
+			initialValue: "mux",
 		}),
 		defineField({
 			name: "url",
 			type: "url",
 			title: "Video URL",
-			description: "YouTube, Vimeo, Wistia, or any direct video URL",
-			hidden: ({ parent }) => parent?.sourceType !== "url",
+			hidden: ({ parent }) => !parent?.sourceType || parent.sourceType === "mux",
+			validation: (rule) =>
+				rule.custom((value, context) => {
+					const sourceType = (context.parent as { sourceType?: string })?.sourceType
+					if (!sourceType || sourceType === "mux" || sourceType === "url") return true
+					if (!value) return "URL is required"
+					const pattern = videoSourceValidation[sourceType]
+					if (pattern && !pattern.test(value)) {
+						const label = videoSourceTypes.find((s) => s.value === sourceType)?.title
+						return `This doesn't look like a valid ${label} URL`
+					}
+					return true
+				}),
 		}),
 		defineField({
 			name: "muxVideo",

--- a/sanity/reusables.ts
+++ b/sanity/reusables.ts
@@ -269,7 +269,7 @@ const videoSourceValidation: Record<string, RegExp> = {
 }
 
 const videoSourceTypes = [
-	{ title: "Mux Video", value: "mux" },
+	{ title: "Upload a File", value: "mux" },
 	{ title: "YouTube", value: "youtube" },
 	{ title: "Vimeo", value: "vimeo" },
 	{ title: "Wistia", value: "wistia" },

--- a/sanity/reusables.ts
+++ b/sanity/reusables.ts
@@ -246,3 +246,38 @@ export const youtube = defineType({
 		}),
 	],
 })
+
+export const video = defineType({
+	name: "video",
+	type: "object",
+	title: "Video",
+	icon: PlayIcon,
+	fields: [
+		defineField({
+			name: "sourceType",
+			type: "string",
+			title: "Source Type",
+			options: {
+				list: [
+					{ title: "URL (YouTube, Vimeo, Wistia, etc.)", value: "url" },
+					{ title: "Mux Upload", value: "mux" },
+				],
+				layout: "radio",
+			},
+			initialValue: "url",
+		}),
+		defineField({
+			name: "url",
+			type: "url",
+			title: "Video URL",
+			description: "YouTube, Vimeo, Wistia, or any direct video URL",
+			hidden: ({ parent }) => parent?.sourceType !== "url",
+		}),
+		defineField({
+			name: "muxVideo",
+			type: "mux.video",
+			title: "Mux Video",
+			hidden: ({ parent }) => parent?.sourceType !== "mux",
+		}),
+	],
+})

--- a/videos/VideoEmbed.tsx
+++ b/videos/VideoEmbed.tsx
@@ -6,29 +6,26 @@ import type { Video } from "sanity.types"
 
 type VideoEmbedProps = {
 	className?: string
-	url?: string | null
-	playbackId?: string | null
-	thumbnail?: string | null
+	video: DeepAssetMeta<Video>
 }
 
-/**
- * Extract VideoEmbed props from a generic `video` schema object.
- */
-export function getVideoProps(video: DeepAssetMeta<Video>): VideoEmbedProps {
+function getVideoSrc(video: DeepAssetMeta<Video>) {
 	if (video.sourceType === "mux") {
+		const playbackId = video.muxVideo?.data?.playbackId
 		return {
-			playbackId: video.muxVideo?.data?.playbackId,
+			src: playbackId ? `https://stream.mux.com/${playbackId}.m3u8` : null,
 			thumbnail: video.muxVideo?.data?.videoThumbnailUrl,
 		}
 	}
-	return { url: video.url }
+	return { src: video.url, thumbnail: null }
 }
 
 /**
  * A React component for playing a variety of URLs, including file paths, HLS, DASH, YouTube, Vimeo, Wistia and Mux.
+ * Accepts a Sanity `video` schema object directly.
  */
-export function VideoEmbed({ className, url, playbackId, thumbnail }: VideoEmbedProps) {
-	const src = url || (playbackId ? `https://stream.mux.com/${playbackId}.m3u8` : null)
+export function VideoEmbed({ className, video }: VideoEmbedProps) {
+	const { src, thumbnail } = getVideoSrc(video)
 	if (!src) return null
 
 	return (
@@ -44,7 +41,6 @@ const Embed = styled(
 	"div",
 	fresponsive(css`
 		width: 100%;
-		aspect-ratio: 16 / 9;
 
 		> div {
 			width: 100% !important;

--- a/videos/VideoEmbed.tsx
+++ b/videos/VideoEmbed.tsx
@@ -1,0 +1,54 @@
+import ClientOnly from "library/ClientOnly"
+import type { DeepAssetMeta } from "library/sanity/assetMetadata"
+import { css, fresponsive, styled } from "library/styled"
+import ReactPlayer from "react-player"
+import type { Video } from "sanity.types"
+
+type VideoEmbedProps = {
+	className?: string
+	url?: string | null
+	playbackId?: string | null
+	thumbnail?: string | null
+}
+
+/**
+ * Extract VideoEmbed props from a generic `video` schema object.
+ */
+export function getVideoProps(video: DeepAssetMeta<Video>): VideoEmbedProps {
+	if (video.sourceType === "mux") {
+		return {
+			playbackId: video.muxVideo?.data?.playbackId,
+			thumbnail: video.muxVideo?.data?.videoThumbnailUrl,
+		}
+	}
+	return { url: video.url }
+}
+
+/**
+ * A React component for playing a variety of URLs, including file paths, HLS, DASH, YouTube, Vimeo, Wistia and Mux.
+ */
+export function VideoEmbed({ className, url, playbackId, thumbnail }: VideoEmbedProps) {
+	const src = url || (playbackId ? `https://stream.mux.com/${playbackId}.m3u8` : null)
+	if (!src) return null
+
+	return (
+		<ClientOnly>
+			<Embed className={className}>
+				<ReactPlayer src={src} width="100%" height="100%" controls light={thumbnail || undefined} />
+			</Embed>
+		</ClientOnly>
+	)
+}
+
+const Embed = styled(
+	"div",
+	fresponsive(css`
+		width: 100%;
+		aspect-ratio: 16 / 9;
+
+		> div {
+			width: 100% !important;
+			height: 100% !important;
+		}
+	`),
+)


### PR DESCRIPTION
# Update Video Player

## Summary
- Created a reusable `video` Sanity schema type with a radio toggle between URL-based sources (YouTube, Vimeo, HLS, DASH, Wistia, direct files) and Mux uploads
- Updated `VideoEmbed` component to accept `url`, `playbackId`, and `thumbnail` props, powered by ReactPlayer
- Added `getVideoProps()` helper to simplify consuming the `video` schema in components
- Added `videoThumbnailUrl` to `VideoAssetMeta`, built from Mux's `playbackId` + `thumbTime`
- Wired up test fields in `Sample` section for validation

## Files Changed

### New: `video` schema type (`library/sanity/reusables.ts`)
- Added alongside existing `youtube` type (kept for legacy)
- `sourceType` radio: "URL (YouTube, Vimeo, etc.)" or "Mux Upload"
- `url` field (type `url`) — hidden when sourceType is "mux"
- `muxVideo` field (type `mux.video`) — hidden when sourceType is "url"

### Updated: `sanity.config.ts`
- Imported and registered the new `video` type

### Updated: `library/sanity/assetMetadata.ts`
- Added `videoThumbnailUrl` to `VideoAssetMeta` type
- Builds thumbnail URL from `playbackId` + `thumbTime`: `https://image.mux.com/{id}/thumbnail.jpg?time={t}`

### Updated: `app/components/VideoEmbed.tsx`
- Reworked props to `VideoEmbedProps` type: `url`, `playbackId`, `thumbnail`, `className`
- Added `getVideoProps()` — takes a `DeepAssetMeta<Video>` object from the schema and returns spread-ready props for `VideoEmbed`
- Mux playback IDs are converted to HLS stream URLs (`stream.mux.com/{id}.m3u8`)
- Thumbnail passed to ReactPlayer's `light` prop for click-to-play behavior

### Updated: `sanity/schemas/sections/sample.ts`
- Removed old mux-specific test fields (`video`, `audio`, `muxTest`)
- Added 3 `genericVideo` fields using the new `video` type for testing

### Updated: `app/sections/Sample.tsx`
- Simplified to use `getVideoProps()` spread pattern
- Renders all 3 generic video test fields