### PR TITLE
no more style flash on rest.

### DIFF
--- a/useAutoHideHeader.ts
+++ b/useAutoHideHeader.ts
@@ -125,9 +125,7 @@ export default function useAutoHideHeader(
 			wrapper.current?.addEventListener("pointerleave", onLeave)
 
 			ScrollTrigger.create({ onUpdate })
-			const interval = setInterval(onUpdate, 100)
 			return () => {
-				clearInterval(interval)
 				wrapper.current?.removeEventListener("pointerenter", onHover)
 				wrapper.current?.removeEventListener("pointerleave", onLeave)
 			}


### PR DESCRIPTION
Header was rapidly adding inline styles even when at rest. Also, scrollTriggers.update was being called a lot. adjusted the behavior for both elements. Jank is gone at rest, and did not see any performance issues removing the  const interval = setInterval(onUpdate, 100) function. Performance was degraded overall when leaving that in after making the initial change. 


