### PR TITLE
various sanity fixes

### DIFF
--- a/sanity/FirefoxFix.tsx
+++ b/sanity/FirefoxFix.tsx
@@ -47,8 +47,10 @@ export const FirefoxFix = () => {
 		if (browserData.isFireFox) checkZeroWidthChars()
 	}, 1000)
 	useHMR("postbuild", () => {
-		hasWarned = false
-		checkZeroWidthChars()
+		if (browserData.isFireFox) {
+			hasWarned = false
+			checkZeroWidthChars()
+		}
 	})
 
 	return null

--- a/sanity/FirefoxFix.tsx
+++ b/sanity/FirefoxFix.tsx
@@ -4,7 +4,6 @@ import { useInterval } from "ahooks"
 import { browserData } from "library/deviceDetection"
 import { useHMR } from "library/useHMR"
 import { stegaClean } from "next-sanity"
-import { useDraftModePerspective } from "next-sanity/hooks"
 import { toast } from "sonner"
 
 let hasWarned = false
@@ -25,7 +24,7 @@ const checkZeroWidthChars = (startNode: Node = document.body) => {
 				const letterSpacing = parseFloat(computedStyle.letterSpacing)
 
 				// remove the stega and replace the content
-				if (letterSpacing < 0) {
+				if (letterSpacing !== 0) {
 					const cleanContent = stegaClean(node.textContent ?? "")
 					node.textContent = cleanContent
 
@@ -44,10 +43,8 @@ const checkZeroWidthChars = (startNode: Node = document.body) => {
 }
 
 export const FirefoxFix = () => {
-	const perspective = useDraftModePerspective()
-
 	useInterval(() => {
-		if (browserData.isFireFox && perspective === "drafts") checkZeroWidthChars()
+		if (browserData.isFireFox) checkZeroWidthChars()
 	}, 1000)
 	useHMR("postbuild", () => {
 		hasWarned = false

--- a/sanity/PortableText.tsx
+++ b/sanity/PortableText.tsx
@@ -20,12 +20,13 @@ type PossibleMarks =
 
 type Input = {
 	_type: string
+	_key?: string
 	style?: string
 	list?: string
 	listItem?: string
 	markDefs?: Array<{
 		_type: string
-	}>
+	}> | null
 }
 
 type UnionToIntersection<U> = (
@@ -36,13 +37,12 @@ type UnionToIntersection<U> = (
 	? I
 	: never
 
-type Component = ({ children }: { children: ReactNode }) => ReactNode
-type ValueComponent<ValueType = never> = ({
+type ValueComponent<V = never> = ({
 	children,
 	value,
 }: {
 	children: ReactNode
-	value: ValueType
+	value: V
 }) => ReactNode
 
 type GetMarkDefinition<Item extends Input> = Item extends unknown
@@ -50,21 +50,21 @@ type GetMarkDefinition<Item extends Input> = Item extends unknown
 		? {
 				block?: NonNullable<Item["style"]> extends string
 					? {
-							[style in NonNullable<Item["style"]>]?: Component
+							[style in NonNullable<Item["style"]>]?: ValueComponent<Item>
 						}
 					: undefined
 				list?: NonNullable<Item["listItem"]> extends string
 					? {
-							[listItem in NonNullable<Item["listItem"]>]: Component
+							[listItem in NonNullable<Item["listItem"]>]: ValueComponent<Item>
 						}
 					: undefined
 				listItem?: NonNullable<Item["listItem"]> extends string
 					? {
-							[listItem in NonNullable<Item["listItem"]>]: Component
+							[listItem in NonNullable<Item["listItem"]>]: ValueComponent<Item>
 						}
 					: undefined
 				marks?: {
-					[mark in PossibleMarks]?: Component
+					[mark in PossibleMarks]?: ValueComponent
 				} & {
 					[customMark in NonNullable<
 						Item["markDefs"]

--- a/sanity/PortableText.tsx
+++ b/sanity/PortableText.tsx
@@ -9,7 +9,14 @@ import {
 } from "next-sanity"
 import type { ReactNode } from "react"
 
-type PossibleMarks = string
+type PossibleMarks =
+	| "strong"
+	| "em"
+	| "code"
+	| "underline"
+	| "strike-through"
+	| "super"
+	| "sub"
 
 type Input = {
 	_type: string
@@ -18,7 +25,7 @@ type Input = {
 	listItem?: string
 	markDefs?: Array<{
 		_type: string
-	}> | null
+	}>
 }
 
 type UnionToIntersection<U> = (
@@ -43,10 +50,7 @@ type GetMarkDefinition<Item extends Input> = Item extends unknown
 		? {
 				block?: NonNullable<Item["style"]> extends string
 					? {
-							[style in NonNullable<Item["style"]>]?: (props: {
-								children: ReactNode
-								value: Item
-							}) => ReactNode
+							[style in NonNullable<Item["style"]>]?: Component
 						}
 					: undefined
 				list?: NonNullable<Item["listItem"]> extends string

--- a/sanity/PortableText.tsx
+++ b/sanity/PortableText.tsx
@@ -9,14 +9,7 @@ import {
 } from "next-sanity"
 import type { ReactNode } from "react"
 
-type PossibleMarks =
-	| "strong"
-	| "em"
-	| "code"
-	| "underline"
-	| "strike-through"
-	| "super"
-	| "sub"
+type PossibleMarks = string
 
 type Input = {
 	_type: string
@@ -25,7 +18,7 @@ type Input = {
 	listItem?: string
 	markDefs?: Array<{
 		_type: string
-	}>
+	}> | null
 }
 
 type UnionToIntersection<U> = (
@@ -50,7 +43,10 @@ type GetMarkDefinition<Item extends Input> = Item extends unknown
 		? {
 				block?: NonNullable<Item["style"]> extends string
 					? {
-							[style in NonNullable<Item["style"]>]?: Component
+							[style in NonNullable<Item["style"]>]?: (props: {
+								children: ReactNode
+								value: Item
+							}) => ReactNode
 						}
 					: undefined
 				list?: NonNullable<Item["listItem"]> extends string

--- a/sanity/SanityImage.tsx
+++ b/sanity/SanityImage.tsx
@@ -20,7 +20,7 @@ import {
 	objectPositionVar,
 } from "../StaticImage.css"
 
-type SanityImageData<CropType, WithAlt extends "true" | "false"> = {
+export type SanityImageData<CropType, WithAlt extends "true" | "false"> = {
 	asset?: { _ref: string }
 	crop?: SanityImageCrop
 	hotspot?: SanityImageHotspot

--- a/sanity/assetMetadata.ts
+++ b/sanity/assetMetadata.ts
@@ -143,7 +143,9 @@ export const fetchAssetMeta = async <InputType>(
 							size: asset?.size,
 							extension: asset?.extension,
 							url: asset?.url,
-							dimensionsAspectRatio: (meta as { dimensions?: { aspectRatio?: number } } | null)?.dimensions?.aspectRatio,
+							dimensionsAspectRatio: (
+								meta as { dimensions?: { aspectRatio?: number } } | null
+							)?.dimensions?.aspectRatio,
 						} satisfies ImageAssetMeta)
 
 			return {

--- a/sanity/assetMetadata.ts
+++ b/sanity/assetMetadata.ts
@@ -59,7 +59,7 @@ type ImageAssetMeta = {
 	size: number | undefined
 	extension: string | undefined
 	url: string | undefined
-	dimensionsAspectRatio: number | undefined
+	aspectRatio: number | undefined
 }
 
 export type AssetMeta = VideoAssetMeta & ImageAssetMeta
@@ -143,9 +143,7 @@ export const fetchAssetMeta = async <InputType>(
 							size: asset?.size,
 							extension: asset?.extension,
 							url: asset?.url,
-							dimensionsAspectRatio: (
-								meta as { dimensions?: { aspectRatio?: number } } | null
-							)?.dimensions?.aspectRatio,
+							aspectRatio: meta?.dimensions?.aspectRatio,
 						} satisfies ImageAssetMeta)
 
 			return {

--- a/sanity/assetMetadata.ts
+++ b/sanity/assetMetadata.ts
@@ -59,6 +59,7 @@ type ImageAssetMeta = {
 	size: number | undefined
 	extension: string | undefined
 	url: string | undefined
+	dimensionsAspectRatio: number | undefined
 }
 
 export type AssetMeta = VideoAssetMeta & ImageAssetMeta
@@ -142,6 +143,7 @@ export const fetchAssetMeta = async <InputType>(
 							size: asset?.size,
 							extension: asset?.extension,
 							url: asset?.url,
+							dimensionsAspectRatio: (meta as { dimensions?: { aspectRatio?: number } } | null)?.dimensions?.aspectRatio,
 						} satisfies ImageAssetMeta)
 
 			return {

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -84,7 +84,7 @@ export const LibraryLive = async () => {
 	return (
 		<LiveWrapper>
 			<Toaster />
-			<FirefoxFix />
+			{isDraftMode && <FirefoxFix />}
 			{isDraftMode && <DraftModeOverlay />}
 			{useProxy ? (
 				<SanityLiveProxy />

--- a/sanity/reusables.tsx
+++ b/sanity/reusables.tsx
@@ -11,8 +11,6 @@ import {
 	MATCH_URL_YOUTUBE,
 } from "react-player/patterns"
 import type {
-	AutocompleteString,
-	IntrinsicTypeName,
 	PreviewValue,
 	StrictDefinition,
 } from "sanity"

--- a/sanity/reusables.tsx
+++ b/sanity/reusables.tsx
@@ -10,10 +10,7 @@ import {
 	MATCH_URL_WISTIA,
 	MATCH_URL_YOUTUBE,
 } from "react-player/patterns"
-import type {
-	PreviewValue,
-	StrictDefinition,
-} from "sanity"
+import type { PreviewValue, StrictDefinition } from "sanity"
 import {
 	type ArrayOfEntry,
 	defineArrayMember,

--- a/sanity/reusables.tsx
+++ b/sanity/reusables.tsx
@@ -13,13 +13,16 @@ import {
 import type {
 	AutocompleteString,
 	IntrinsicTypeName,
+	PreviewValue,
 	StrictDefinition,
 } from "sanity"
 import {
 	defineArrayMember,
 	defineField,
 	defineType,
+	type ArrayOfEntry,
 	type ImageDefinition,
+	type ObjectDefinition,
 } from "sanity"
 import { requiredLinkField } from "sanity-plugin-link-field"
 
@@ -182,32 +185,17 @@ export const redirect = defineArrayMember({
 	},
 })
 
-export function definePageSection<
-	const TType extends IntrinsicTypeName | AutocompleteString,
-	const TName extends string,
-	TSelect extends Record<string, string> | undefined,
-	// biome-ignore lint/suspicious/noExplicitAny: intentional behavior
-	TPrepareValue extends Record<keyof TSelect, any> | undefined,
-	TAlias extends IntrinsicTypeName | undefined,
-	TStrict extends StrictDefinition,
->(
+export function definePageSection<const TName extends string>(
 	{
 		group,
 		icon,
 		...options
-	}: Omit<
-		Parameters<
-			typeof defineArrayMember<
-				TType,
-				TName,
-				TSelect,
-				TPrepareValue,
-				TAlias,
-				TStrict
-			>
-		>[0],
-		"groups" | "icon"
-	> & {
+	}: Omit<ArrayOfEntry<ObjectDefinition>, "name" | "groups" | "icon" | "preview"> & {
+		name: TName
+		preview?: {
+			select?: Record<string, string>
+			prepare?: (value: Record<string, string | undefined>) => PreviewValue
+		}
 		/**
 		 * for example, "Designed for Home"
 		 *
@@ -220,18 +208,11 @@ export function definePageSection<
 		icon: StaticImageData
 	},
 	secondary?: Parameters<
-		typeof defineArrayMember<
-			TType,
-			TName,
-			TSelect,
-			TPrepareValue,
-			TAlias,
-			TStrict
-		>
+		typeof defineArrayMember<"object", TName, undefined, undefined, undefined, StrictDefinition>
 	>[1],
+
 ) {
 	return defineArrayMember(
-		// @ts-expect-error doesn't match due to narrowing constraints
 		{
 			...options,
 			groups: [{ name: group }],

--- a/sanity/reusables.tsx
+++ b/sanity/reusables.tsx
@@ -17,10 +17,10 @@ import type {
 	StrictDefinition,
 } from "sanity"
 import {
+	type ArrayOfEntry,
 	defineArrayMember,
 	defineField,
 	defineType,
-	type ArrayOfEntry,
 	type ImageDefinition,
 	type ObjectDefinition,
 } from "sanity"
@@ -190,7 +190,10 @@ export function definePageSection<const TName extends string>(
 		group,
 		icon,
 		...options
-	}: Omit<ArrayOfEntry<ObjectDefinition>, "name" | "groups" | "icon" | "preview"> & {
+	}: Omit<
+		ArrayOfEntry<ObjectDefinition>,
+		"name" | "groups" | "icon" | "preview"
+	> & {
 		name: TName
 		preview?: {
 			select?: Record<string, string>
@@ -208,9 +211,15 @@ export function definePageSection<const TName extends string>(
 		icon: StaticImageData
 	},
 	secondary?: Parameters<
-		typeof defineArrayMember<"object", TName, undefined, undefined, undefined, StrictDefinition>
+		typeof defineArrayMember<
+			"object",
+			TName,
+			undefined,
+			undefined,
+			undefined,
+			StrictDefinition
+		>
 	>[1],
-
 ) {
 	return defineArrayMember(
 		{
@@ -250,7 +259,7 @@ const videoSourceValidation: Record<string, RegExp> = {
 }
 
 const videoSourceTypes = [
-	{ title: "Upload a File", value: "mux" },
+	{ title: "Upload or Select a File", value: "mux" },
 	{ title: "YouTube", value: "youtube" },
 	{ title: "Vimeo", value: "vimeo" },
 	{ title: "Wistia", value: "wistia" },

--- a/useHMR.ts
+++ b/useHMR.ts
@@ -6,30 +6,27 @@ const socket =
 		? new WebSocket("ws://localhost:3000/_next/webpack-hmr")
 		: null
 
-const messageSchema =
-	process.env.NODE_ENV === "development"
-		? z.union([
-				z.strictObject({
-					type: z.literal("built"),
-					hash: z.string(),
-					errors: z.array(z.unknown()),
-					warnings: z.array(z.unknown()),
-				}),
-				z.strictObject({
-					type: z.literal("building"),
-				}),
-				// unused messages
-				z.object({
-					type: z.enum([
-						"serverComponentChanges",
-						"turbopack-connected",
-						"turbopack-message",
-						"isrManifest",
-						"sync",
-					]),
-				}),
-			])
-		: null
+const messageSchema = z.union([
+	z.strictObject({
+		type: z.literal("built"),
+		hash: z.string(),
+		errors: z.array(z.unknown()),
+		warnings: z.array(z.unknown()),
+	}),
+	z.strictObject({
+		type: z.literal("building"),
+	}),
+	// unused messages
+	z.object({
+		type: z.enum([
+			"serverComponentChanges",
+			"turbopack-connected",
+			"turbopack-message",
+			"isrManifest",
+			"sync",
+		]),
+	}),
+])
 
 export const useHMR =
 	process.env.NODE_ENV === "development"
@@ -40,10 +37,8 @@ export const useHMR =
 					if (process.env.NODE_ENV === "development") {
 						const handler = (event: MessageEvent) => {
 							const message = JSON.parse(event.data)
-							let parsedMessage: z.infer<NonNullable<typeof messageSchema>>
-							try {
-								parsedMessage = messageSchema!.parse(message)
-							} catch (err) {
+							const result = messageSchema.safeParse(message)
+							if (!result.success) {
 								throw new Error(
 									`useHMR (library/useHMR.ts): WebSocket message from Next.js HMR does not match the expected schema.
 ` +
@@ -53,11 +48,10 @@ export const useHMR =
 ` +
 										`Received message: ${JSON.stringify(message)}
 ` +
-										`Original error: ${err}`,
+										`Original error: ${result.error}`,
 								)
 							}
-
-							if (!parsedMessage) throw new Error("Invalid message")
+							const parsedMessage = result.data
 
 							if (type === "prebuild" && parsedMessage.type === "building") {
 								sendMessage("building")

--- a/useHMR.ts
+++ b/useHMR.ts
@@ -40,7 +40,22 @@ export const useHMR =
 					if (process.env.NODE_ENV === "development") {
 						const handler = (event: MessageEvent) => {
 							const message = JSON.parse(event.data)
-							const parsedMessage = messageSchema?.parse(message)
+							let parsedMessage: z.infer<NonNullable<typeof messageSchema>>
+							try {
+								parsedMessage = messageSchema!.parse(message)
+							} catch (err) {
+								throw new Error(
+									`useHMR (library/useHMR.ts): WebSocket message from Next.js HMR does not match the expected schema.
+` +
+										`This usually means the Next.js version changed the HMR message format.
+` +
+										`Update the messageSchema in library/useHMR.ts to match the new format.
+` +
+										`Received message: ${JSON.stringify(message)}
+` +
+										`Original error: ${err}`,
+								)
+							}
 
 							if (!parsedMessage) throw new Error("Invalid message")
 

--- a/videos/VideoEmbed.tsx
+++ b/videos/VideoEmbed.tsx
@@ -8,10 +8,10 @@ import type { Video } from "sanity.types"
 type VideoEmbedProps = {
 	className?: string
 	video: DeepAssetMeta<Video>
-	controls: boolean
-	playing: boolean
-	muted: boolean
-	loop: boolean
+	controls?: boolean
+	playing?: boolean
+	muted?: boolean
+	loop?: boolean
 }
 
 function getVideoSrc(video: DeepAssetMeta<Video>) {

--- a/videos/VideoEmbed.tsx
+++ b/videos/VideoEmbed.tsx
@@ -1,31 +1,43 @@
 import ClientOnly from "library/ClientOnly"
 import type { DeepAssetMeta } from "library/sanity/assetMetadata"
-import { css, fresponsive, styled } from "library/styled"
+import { css, f, styled } from "library/styled/alpha"
+import { stegaClean } from "next-sanity"
 import ReactPlayer from "react-player"
 import type { Video } from "sanity.types"
 
 type VideoEmbedProps = {
 	className?: string
 	video: DeepAssetMeta<Video>
+	controls: boolean
+	playing: boolean
+	muted: boolean
+	loop: boolean
 }
 
 function getVideoSrc(video: DeepAssetMeta<Video>) {
-	if (video.sourceType === "mux") {
+	if (stegaClean(video.sourceType) === "mux") {
 		const playbackId = video.muxVideo?.data?.playbackId
 		return {
 			src: playbackId ? `https://stream.mux.com/${playbackId}.m3u8` : null,
 			thumbnail: video.muxVideo?.data?.videoThumbnailUrl,
 		}
 	}
-	return { src: video.url, thumbnail: null }
+	return { src: video.url ?? null, thumbnail: null }
 }
 
 /**
  * A React component for playing a variety of URLs, including file paths, HLS, DASH, YouTube, Vimeo, Wistia and Mux.
- * Accepts a Sanity `video` schema object directly.
+ * Accepts a Sanity `video` schema object directly. Fills its container — the parent is responsible for sizing.
  */
-export function VideoEmbed({ className, video }: VideoEmbedProps) {
-	const { src, thumbnail } = getVideoSrc(video)
+export function VideoEmbed({
+	className,
+	video,
+	controls = true,
+	muted,
+	loop,
+	playing,
+}: VideoEmbedProps) {
+	const { src } = getVideoSrc(video)
 	if (!src) return null
 
 	return (
@@ -35,8 +47,10 @@ export function VideoEmbed({ className, video }: VideoEmbedProps) {
 					src={src}
 					width="100%"
 					height="100%"
-					controls
-					light={thumbnail || undefined}
+					controls={controls}
+					muted={muted}
+					loop={loop}
+					playing={playing}
 				/>
 			</Embed>
 		</ClientOnly>
@@ -45,12 +59,10 @@ export function VideoEmbed({ className, video }: VideoEmbedProps) {
 
 const Embed = styled(
 	"div",
-	fresponsive(css`
+	f.unresponsive(css`
 		width: 100%;
-
-		> div {
-			width: 100% !important;
-			height: 100% !important;
-		}
+		height: 100%;
+		--media-object-fit: cover;
+		--media-object-position: center;
 	`),
 )


### PR DESCRIPTION
**Component and Type Improvements:**

* The `VideoEmbed` component now accepts additional props (`controls`, `playing`, `muted`, `loop`) for greater flexibility, uses `stegaClean` to sanitize the video source type, and improves its container styling for better layout control. [[1]](diffhunk://#diff-042b97c622f16cc850f109bc9e3adcb3693d911d3226374851c7b8e91bc96da4L3-R40) [[2]](diffhunk://#diff-042b97c622f16cc850f109bc9e3adcb3693d911d3226374851c7b8e91bc96da4L38-R53) [[3]](diffhunk://#diff-042b97c622f16cc850f109bc9e3adcb3693d911d3226374851c7b8e91bc96da4L48-R66)
* The portable text types in `sanity/PortableText.tsx` are updated for stricter type safety, supporting optional keys and nullable mark definitions, and using generic value components for marks, blocks, and lists. [[1]](diffhunk://#diff-fa3377db16d8c58df6d26bc89a52daddd858084792c00d4fe1d6abdc2e34910fR23-R29) [[2]](diffhunk://#diff-fa3377db16d8c58df6d26bc89a52daddd858084792c00d4fe1d6abdc2e34910fL39-R67)
* The `definePageSection` helper is simplified to require fewer type parameters, making it easier to use and more strongly typed for Sanity object definitions. [[1]](diffhunk://#diff-af3333fa4277abc21a3bd183fe4da894bee29450ff3eedc36778034f39822557L185-R199) [[2]](diffhunk://#diff-af3333fa4277abc21a3bd183fe4da894bee29450ff3eedc36778034f39822557L224-L234)

**Sanity Integration and Metadata:**

* The asset metadata now includes a `dimensionsAspectRatio` field, and this value is extracted when fetching asset metadata, improving support for responsive image/video handling. [[1]](diffhunk://#diff-21a1b0cf75903ec16dfab0236a2aae247d372e72ae08fc09cdeaef578cbc34b8R62) [[2]](diffhunk://#diff-21a1b0cf75903ec16dfab0236a2aae247d372e72ae08fc09cdeaef578cbc34b8R146-R148)
* The video source types and labels are clarified for better content editor experience.

**Bug Fixes and Robustness:**

* The Firefox-specific fix now only runs in draft mode and no longer depends on the removed `useDraftModePerspective` hook. It also corrects the condition for cleaning up zero-width characters, improving reliability. [[1]](diffhunk://#diff-8fa468a74cf871e09b98479faf729ba62210794d91ba1cb66cabde01222d84e3L7) [[2]](diffhunk://#diff-8fa468a74cf871e09b98479faf729ba62210794d91ba1cb66cabde01222d84e3L28-R27) [[3]](diffhunk://#diff-8fa468a74cf871e09b98479faf729ba62210794d91ba1cb66cabde01222d84e3L47-R53) [[4]](diffhunk://#diff-133b49b7bb8d0ef32f864830fdb361dabf4df3cce6c82c54835099255a9458aaL87-R87)
* The HMR hook now uses stricter runtime validation with Zod, providing detailed error messages if the message schema does not match, making debugging easier when Next.js HMR messages change. [[1]](diffhunk://#diff-a096d3dd194ade15e40049b4971c967989ba9f3e68937632c02dfb5a2b6d21b9L9-R9) [[2]](diffhunk://#diff-a096d3dd194ade15e40049b4971c967989ba9f3e68937632c02dfb5a2b6d21b9L32) [[3]](diffhunk://#diff-a096d3dd194ade15e40049b4971c967989ba9f3e68937632c02dfb5a2b6d21b9L43-R54)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix steganographic text handling, video embed playback controls, and image aspect ratio metadata
> - [VideoEmbed](https://github.com/reformcollective/library/pull/443/files#diff-042b97c622f16cc850f109bc9e3adcb3693d911d3226374851c7b8e91bc96da4) now accepts `controls`, `playing`, `muted`, and `loop` props passed to ReactPlayer; removes light thumbnail preview so the player renders immediately; embed fills parent container via 100% width/height
> - [`getVideoSrc`](https://github.com/reformcollective/library/pull/443/files#diff-042b97c622f16cc850f109bc9e3adcb3693d911d3226374851c7b8e91bc96da4) uses `stegaClean` on `sourceType` to reliably detect Mux sources and returns `null` instead of `undefined` when no URL is available
> - [`checkZeroWidthChars`](https://github.com/reformcollective/library/pull/443/files#diff-8fa468a74cf871e09b98479faf729ba62210794d91ba1cb66cabde01222d84e3) now runs `stegaClean` whenever letter-spacing is any non-zero value (previously only negative); `FirefoxFix` is rendered only in draft mode
> - [`fetchAssetMeta`](https://github.com/reformcollective/library/pull/443/files#diff-21a1b0cf75903ec16dfab0236a2aae247d372e72ae08fc09cdeaef578cbc34b8) now includes `aspectRatio` in the returned `ImageAssetMeta`
> - [`useHMR`](https://github.com/reformcollective/library/pull/443/files#diff-a096d3dd194ade15e40049b4971c967989ba9f3e68937632c02dfb5a2b6d21b9) throws a descriptive error with the received message and zod details on invalid HMR messages
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c57846f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->