### PR TITLE
Enable Claude workflow to check out PR head refs

### DIFF
--- a/.github/workflows/call-claude.yml
+++ b/.github/workflows/call-claude.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     uses: reformcollective/library/.github/workflows/claude.yml@next-main
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,12 +36,14 @@ jobs:
 
             Before reviewing or posting anything, check if you've already reviewed the PR - there may be a pending review or existing comments if you've reviewed before. If this is the case, you are performing a follow-up review and should behave accordingly.
             - Be aware that previous comments may have replies or been marked resolved.
+            - When you find previously opened bot review comments that are fully addressed by the current diff, resolve those comment threads before submitting your review. Do not resolve comments unless the fix is present and verified in the current code.
 
             Post code feedback as inline GitHub review comments using these steps:
             1. Start a review: Use mcp__github__create_pending_pull_request_review to begin a pending review.
             2. Get diff info: Use mcp__github__get_pull_request_diff to understand the code changes and line numbers. Paginate if needed.
             3. Add inline comments: Use mcp__github__add_comment_to_pending_review for feedback on specific lines. Always use inline comments for specific code issues — never post them as top-level PR comments.
-            4. Submit the review: Use mcp__github__submit_pending_pull_request_review with event type "COMMENT" (not "REQUEST_CHANGES") to publish all comments as a non-blocking review.
+            4. Resolve addressed bot comment threads using the GitHub MCP tools when appropriate.
+            5. Submit the review: Use mcp__github__submit_pending_pull_request_review with event type "COMMENT" (not "REQUEST_CHANGES") to publish all comments as a non-blocking review.
 
           claude_args: >-
             --dangerously-skip-permissions

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,10 +15,38 @@ jobs:
         with:
           secrets: ${{ secrets.SECRETS_JSON }}
 
+      - name: Resolve checkout target
+        id: checkout-target
+        uses: actions/github-script@v8
+        with:
+          script: |
+            if (context.payload.pull_request) {
+              core.setOutput("repository", context.payload.pull_request.head.repo.full_name)
+              core.setOutput("ref", context.payload.pull_request.head.ref)
+              return
+            }
+
+            if (context.payload.issue?.pull_request) {
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.issue.number,
+              })
+
+              core.setOutput("repository", pullRequest.head.repo.full_name)
+              core.setOutput("ref", pullRequest.head.ref)
+              return
+            }
+
+            core.setOutput("repository", `${context.repo.owner}/${context.repo.repo}`)
+            core.setOutput("ref", context.ref.replace("refs/heads/", ""))
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          repository: ${{ steps.checkout-target.outputs.repository }}
+          ref: ${{ steps.checkout-target.outputs.ref }}
+          fetch-depth: 0
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,10 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            const defaultRepository = `${context.repo.owner}/${context.repo.repo}`
+
             if (context.payload.pull_request) {
-              core.setOutput("repository", context.payload.pull_request.head.repo.full_name)
+              core.setOutput("repository", context.payload.pull_request.head.repo?.full_name ?? defaultRepository)
               core.setOutput("ref", context.payload.pull_request.head.ref)
               return
             }
@@ -33,12 +35,12 @@ jobs:
                 pull_number: context.payload.issue.number,
               })
 
-              core.setOutput("repository", pullRequest.head.repo.full_name)
+              core.setOutput("repository", pullRequest.head.repo?.full_name ?? defaultRepository)
               core.setOutput("ref", pullRequest.head.ref)
               return
             }
 
-            core.setOutput("repository", `${context.repo.owner}/${context.repo.repo}`)
+            core.setOutput("repository", defaultRepository)
             core.setOutput("ref", context.ref.replace("refs/heads/", ""))
 
       - name: Checkout repository
@@ -61,3 +63,4 @@ jobs:
           claude_args: >-
             --dangerously-skip-permissions
             --allowedTools "mcp__github__*"
+            --mcp-config '{"mcpServers":{"github":{"type":"http","url":"https://api.githubcopilot.com/mcp","headers":{"Authorization":"Bearer ${{ github.token }}"}}}}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,43 +15,70 @@ jobs:
         with:
           secrets: ${{ secrets.SECRETS_JSON }}
 
-      - name: Resolve PR branch from issue comment
-        id: issue-comment-pr
-        if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
+      - name: Resolve checkout target
+        id: checkout-target
         uses: actions/github-script@v8
         with:
           script: |
             const defaultRepository = `${context.repo.owner}/${context.repo.repo}`
-            const { data: pullRequest } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.issue.number,
-            })
+            let pullRequest = context.payload.pull_request ?? null
 
-            core.setOutput("repository", pullRequest.head.repo?.full_name ?? defaultRepository)
-            core.setOutput("ref", pullRequest.head.ref)
+            if (!pullRequest && context.payload.issue?.pull_request) {
+              const response = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.issue.number,
+              })
+              pullRequest = response.data
+            }
+
+            if (!pullRequest) {
+              core.setOutput("repository", defaultRepository)
+              core.setOutput("ref", context.ref.replace("refs/heads/", ""))
+              core.setOutput("persist_credentials", "true")
+              core.setOutput("is_fork", "false")
+              return
+            }
+
+            const headRepository = pullRequest.head.repo?.full_name ?? defaultRepository
+            const baseRef = pullRequest.base.ref
+            const headRef = pullRequest.head.ref
+            const isFork = headRepository !== defaultRepository
+
+            core.setOutput("repository", isFork ? defaultRepository : headRepository)
+            core.setOutput("ref", isFork ? baseRef : headRef)
+            core.setOutput("persist_credentials", isFork ? "false" : "true")
+            core.setOutput("is_fork", isFork ? "true" : "false")
+            core.setOutput("head_repository", headRepository)
+            core.setOutput("head_ref", headRef)
+            core.setOutput("base_ref", baseRef)
+            core.setOutput("pr_number", String(pullRequest.number))
 
       - name: Checkout repository
-        if: ${{ github.event_name != 'issue_comment' || !github.event.issue.pull_request }}
         uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-          fetch-depth: 1
-
-      - name: Checkout PR branch from issue comment
-        if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ steps.issue-comment-pr.outputs.repository }}
-          ref: ${{ steps.issue-comment-pr.outputs.ref }}
-          fetch-depth: 1
+          repository: ${{ steps.checkout-target.outputs.repository }}
+          ref: ${{ steps.checkout-target.outputs.ref }}
+          fetch-depth: 0
+          persist-credentials: ${{ steps.checkout-target.outputs.persist_credentials }}
 
       - name: Run Claude Code
         id: claude
+        env:
+          PR_NUMBER: ${{ steps.checkout-target.outputs.pr_number }}
+          PR_IS_FORK: ${{ steps.checkout-target.outputs.is_fork }}
+          PR_HEAD_REPOSITORY: ${{ steps.checkout-target.outputs.head_repository }}
+          PR_HEAD_REF: ${{ steps.checkout-target.outputs.head_ref }}
+          PR_BASE_REF: ${{ steps.checkout-target.outputs.base_ref }}
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            If `PR_IS_FORK` is `true`, this run is for a fork-based pull request.
+            - The checked out code is the trusted base branch, not the fork head.
+            - Do not attempt to push commits for fork PRs.
+            - Use GitHub tools to inspect the PR and leave comments or guidance instead.
+            - For same-repo branches, you may edit and push when asked.
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,24 +35,19 @@ jobs:
             if (!pullRequest) {
               core.setOutput("repository", defaultRepository)
               core.setOutput("ref", context.ref.replace("refs/heads/", ""))
-              core.setOutput("persist_credentials", "true")
-              core.setOutput("is_fork", "false")
               return
             }
 
-            const headRepository = pullRequest.head.repo?.full_name ?? defaultRepository
-            const baseRef = pullRequest.base.ref
+            const headRepository = pullRequest.head.repo?.full_name
             const headRef = pullRequest.head.ref
-            const isFork = headRepository !== defaultRepository
 
-            core.setOutput("repository", isFork ? defaultRepository : headRepository)
-            core.setOutput("ref", isFork ? baseRef : headRef)
-            core.setOutput("persist_credentials", isFork ? "false" : "true")
-            core.setOutput("is_fork", isFork ? "true" : "false")
-            core.setOutput("head_repository", headRepository)
-            core.setOutput("head_ref", headRef)
-            core.setOutput("base_ref", baseRef)
-            core.setOutput("pr_number", String(pullRequest.number))
+            if (!headRepository || headRepository !== defaultRepository) {
+              core.setFailed("Claude ping workflow only supports pull requests from branches in this repository.")
+              return
+            }
+
+            core.setOutput("repository", headRepository)
+            core.setOutput("ref", headRef)
 
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -60,25 +55,12 @@ jobs:
           repository: ${{ steps.checkout-target.outputs.repository }}
           ref: ${{ steps.checkout-target.outputs.ref }}
           fetch-depth: 0
-          persist-credentials: ${{ steps.checkout-target.outputs.persist_credentials }}
 
       - name: Run Claude Code
         id: claude
-        env:
-          PR_NUMBER: ${{ steps.checkout-target.outputs.pr_number }}
-          PR_IS_FORK: ${{ steps.checkout-target.outputs.is_fork }}
-          PR_HEAD_REPOSITORY: ${{ steps.checkout-target.outputs.head_repository }}
-          PR_HEAD_REF: ${{ steps.checkout-target.outputs.head_ref }}
-          PR_BASE_REF: ${{ steps.checkout-target.outputs.base_ref }}
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            If `PR_IS_FORK` is `true`, this run is for a fork-based pull request.
-            - The checked out code is the trusted base branch, not the fork head.
-            - Do not attempt to push commits for fork PRs.
-            - Use GitHub tools to inspect the PR and leave comments or guidance instead.
-            - For same-repo branches, you may edit and push when asked.
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,4 +60,3 @@ jobs:
           claude_args: >-
             --dangerously-skip-permissions
             --allowedTools "mcp__github__*"
-            --mcp-config '{"mcpServers":{"github":{"type":"http","url":"https://api.githubcopilot.com/mcp","headers":{"Authorization":"Bearer ${{ github.token }}"}}}}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,40 +15,37 @@ jobs:
         with:
           secrets: ${{ secrets.SECRETS_JSON }}
 
-      - name: Resolve checkout target
-        id: checkout-target
+      - name: Resolve PR branch from issue comment
+        id: issue-comment-pr
+        if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
         uses: actions/github-script@v8
         with:
           script: |
             const defaultRepository = `${context.repo.owner}/${context.repo.repo}`
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            })
 
-            if (context.payload.pull_request) {
-              core.setOutput("repository", context.payload.pull_request.head.repo?.full_name ?? defaultRepository)
-              core.setOutput("ref", context.payload.pull_request.head.ref)
-              return
-            }
-
-            if (context.payload.issue?.pull_request) {
-              const { data: pullRequest } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.payload.issue.number,
-              })
-
-              core.setOutput("repository", pullRequest.head.repo?.full_name ?? defaultRepository)
-              core.setOutput("ref", pullRequest.head.ref)
-              return
-            }
-
-            core.setOutput("repository", defaultRepository)
-            core.setOutput("ref", context.ref.replace("refs/heads/", ""))
+            core.setOutput("repository", pullRequest.head.repo?.full_name ?? defaultRepository)
+            core.setOutput("ref", pullRequest.head.ref)
 
       - name: Checkout repository
+        if: ${{ github.event_name != 'issue_comment' || !github.event.issue.pull_request }}
         uses: actions/checkout@v6
         with:
-          repository: ${{ steps.checkout-target.outputs.repository }}
-          ref: ${{ steps.checkout-target.outputs.ref }}
-          fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          fetch-depth: 1
+
+      - name: Checkout PR branch from issue comment
+        if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ steps.issue-comment-pr.outputs.repository }}
+          ref: ${{ steps.issue-comment-pr.outputs.ref }}
+          fetch-depth: 1
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Summary
- Updated the Claude workflow to resolve and check out the correct repository/ref for pull request and issue-triggered runs.
- Increased checkout depth to `0` so the workflow has full git history when operating on PR heads.
- Granted the caller workflow `contents: write` so the Claude workflow can access and operate on the checked-out code as intended.

## Testing
- Not run (workflow-only change).
- Verified the diff updates `.github/workflows/claude.yml` and `.github/workflows/call-claude.yml` only.
- Checked that the checkout target logic handles direct PR events, issue-linked PR events, and fallback branch runs.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable Claude workflow to check out PR head refs
> - Adds a 'Resolve checkout target' step in [claude.yml](.github/workflows/claude.yml) using `actions/github-script@v8` to compute the correct repository and ref, handling `pull_request` events, issues linked to PRs, and other event types as a fallback.
> - Changes `fetch-depth` from `1` to `0` in the checkout step to fetch full history instead of a shallow clone.
> - Updates [call-claude.yml](.github/workflows/call-claude.yml) to grant `contents: write` permission (previously `contents: read`) so the job can perform the checkout.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #445 opened
>
> - Added null-safe fallback logic when resolving the checkout target repository and configured MCP GitHub server integration in the Claude workflow [4226b74]
> - Updated the Claude code review workflow prompt to include explicit instructions for resolving bot comment threads [4226b74]
> - Added a step that resolves PR branch information from the GitHub API for `issue_comment` events on pull requests [fe88168]
> - Implemented separate checkout paths based on event type [fe88168]
> - Changed checkout fetch depth from full history to shallow clone [fe88168]
> - Removed the `--mcp-config` argument from the `claude_args` block in the `claude.yml` workflow [2db3b1e]
> - Replaced conditional checkout logic with a unified `actions/github-script@v8` step that dynamically resolves checkout parameters [2a2387e]
> - Added PR context environment variables and fork-specific behavior instructions to the Claude action step [2a2387e]
> - Added guard to fail workflow execution when pull request head repository is missing or differs from the default repository [cd8d82a]
> - Removed fork-related conditional logic and outputs from checkout resolution [cd8d82a]
> - Removed dynamic persist-credentials configuration from repository checkout [cd8d82a]
> - Removed pull request metadata environment variables and fork handling prompt from Claude Code action [cd8d82a]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 909be83. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->