### PR TITLE
Enable Claude push access on ping

### DIFF
--- a/.github/workflows/call-claude.yml
+++ b/.github/workflows/call-claude.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     uses: reformcollective/library/.github/workflows/claude.yml@next-main
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,10 +15,38 @@ jobs:
         with:
           secrets: ${{ secrets.SECRETS_JSON }}
 
+      - name: Resolve checkout target
+        id: checkout-target
+        uses: actions/github-script@v8
+        with:
+          script: |
+            if (context.payload.pull_request) {
+              core.setOutput("repository", context.payload.pull_request.head.repo.full_name)
+              core.setOutput("ref", context.payload.pull_request.head.ref)
+              return
+            }
+
+            if (context.payload.issue?.pull_request) {
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.issue.number,
+              })
+
+              core.setOutput("repository", pullRequest.head.repo.full_name)
+              core.setOutput("ref", pullRequest.head.ref)
+              return
+            }
+
+            core.setOutput("repository", `${context.repo.owner}/${context.repo.repo}`)
+            core.setOutput("ref", context.ref.replace("refs/heads/", ""))
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          repository: ${{ steps.checkout-target.outputs.repository }}
+          ref: ${{ steps.checkout-target.outputs.ref }}
+          fetch-depth: 0
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Summary
- grant the pinged Claude workflow 
- resolve the correct PR head branch before checkout
- fetch full history so Claude can commit and push fixes

## Notes
- same-repo PR branches should now be pushable from  pings
- fork PRs may still be limited by token permissions

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable Claude workflow push access and dynamic PR checkout on ping
> - Upgrades `GITHUB_TOKEN` permissions in [call-claude.yml](.github/workflows/call-claude.yml) from `contents: read` to `contents: write` so Claude can push changes.
> - Adds a 'Resolve checkout target' step in [claude.yml](.github/workflows/claude.yml) that dynamically resolves the repository and ref for pull request, issue, or other events using `actions/github-script@v8`.
> - Changes the checkout step to use the resolved ref and switches `fetch-depth` from `1` to `0` to fetch full history.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6fc832c. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->