### PR TITLE
Fix update-hash.js to work correctly in git worktrees

### DIFF
--- a/.github/update-hash.js
+++ b/.github/update-hash.js
@@ -11,20 +11,26 @@ import { fileURLToPath } from "node:url"
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
-// Path to the submodule (../)
-const submodulePath = path.join(__dirname, "..")
-
 // Path to the .github/workflows folder
 const workflowsPath = ".github/workflows"
+
+// Submodule name (folder name relative to repo root)
+const submoduleName = path.basename(path.join(__dirname, ".."))
 
 // Regex to match the submodule reference in workflow files
 const submoduleRegex = /(code-checks|check-updates|lighthouse)\.yml@(.*)/g
 
 try {
-	// Get the latest commit hash of the submodule
-	const latestHash = execSync(`git -C ${submodulePath} rev-parse HEAD`)
+	// Get the latest commit hash of the submodule from the parent repo's index.
+	// Using `git ls-files --stage` rather than `git -C library rev-parse HEAD`
+	// because in git worktrees the submodule's .git redirect can cause the
+	// latter to resolve HEAD against the wrong context.
+	const lsOutput = execSync(`git ls-files --stage -- ${submoduleName}`)
 		.toString()
 		.trim()
+	// Output format: "160000 <hash> 0\t<name>"
+	const latestHash = lsOutput.split(/\s+/)[1]
+	if (!latestHash) throw new Error(`Could not determine submodule hash for "${submoduleName}" from git index`)
 
 	// Update all files in the workflows folder
 	const files = fs.readdirSync(workflowsPath)


### PR DESCRIPTION
## Summary
- `git -C library/ rev-parse HEAD` can resolve against the wrong context in a git worktree, where the submodule's `.git` is a redirect file pointing to the main clone's git dir
- Switches to `git ls-files --stage -- <submodule>` which reads the hash directly from the parent repo's index — worktree-safe and also correctly reflects what's staged rather than whatever local branch the submodule happens to be checked out on

## Test plan
- [ ] Run `node ./library/.github/update-hash.js` from a project using this submodule inside a git worktree and verify the workflow hash matches `git ls-files --stage -- library`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `update-hash.js` to read submodule commit hash from parent repo index for git worktree compatibility
> The script previously used `git -C <submodulePath> rev-parse HEAD` to get the submodule's commit hash, which fails in git worktrees where the submodule directory layout differs. [update-hash.js](.github/update-hash.js) now uses `git ls-files --stage -- <submoduleName>` against the parent repo index and parses the hash from that output. An explicit error is thrown if the hash cannot be determined.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8daed19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->