### PR TITLE
Rename window.lenis to window.lenisInstance to fix type collision

### DIFF
--- a/.github/update-hash.js
+++ b/.github/update-hash.js
@@ -30,7 +30,10 @@ try {
 		.trim()
 	// Output format: "160000 <hash> 0\t<name>"
 	const latestHash = lsOutput.split(/\s+/)[1]
-	if (!latestHash) throw new Error(`Could not determine submodule hash for "${submoduleName}" from git index`)
+	if (!latestHash)
+		throw new Error(
+			`Could not determine submodule hash for "${submoduleName}" from git index`,
+		)
 
 	// Update all files in the workflows folder
 	const files = fs.readdirSync(workflowsPath)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## `window.lenis` renamed to `window.lenisInstance`
 
-`lenis@1.x` declares its own `window.lenis` global as a metadata object (`{ version?, horizontal?, snap? }`), which conflicts with the library's `window.lenis?: Lenis` instance declaration and causes TypeScript errors.
+`lenis@1.3.18` introduced a breaking change: `window.lenis` is now a package-owned metadata object (`{ version?, horizontal?, snap? }`) rather than the Lenis scroll instance. This conflicts with the library's `window.lenis?: Lenis` declaration and causes TypeScript errors if you're on `lenis >= 1.3.18`.
 
 **Migration Advice**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 
+# 2026-03-24
+
+## `window.lenis` renamed to `window.lenisInstance`
+
+`lenis@1.x` declares its own `window.lenis` global as a metadata object (`{ version?, horizontal?, snap? }`), which conflicts with the library's `window.lenis?: Lenis` instance declaration and causes TypeScript errors.
+
+**Migration Advice**
+
+Replace all usages of `window.lenis` with `window.lenisInstance` in your project.
 
 # 2026-02-10
 

--- a/Scroll.tsx
+++ b/Scroll.tsx
@@ -95,10 +95,10 @@ export const useIsSmooth = () => {
 		let isMounted = true
 
 		const updateFromLenis = () => {
-			const lenis = window.lenis
+			const lenis = window.lenisInstance
 			if (!lenis) return
 
-			const state = window.lenis?.isScrolling
+			const state = window.lenisInstance?.isScrolling
 
 			if (state === "smooth") {
 				if (isMounted) setSmooth(true)
@@ -109,7 +109,7 @@ export const useIsSmooth = () => {
 
 		updateFromLenis()
 
-		const lenis = window.lenis
+		const lenis = window.lenisInstance
 		lenis?.on("scroll", updateFromLenis)
 
 		return () => {
@@ -123,7 +123,7 @@ export const useIsSmooth = () => {
 
 declare global {
 	interface Window {
-		lenis?: Lenis
+		lenisInstance?: Lenis
 	}
 }
 
@@ -145,7 +145,7 @@ export const SmoothScrollStyle = (config: LenisOptions) => {
 	}, [lenis])
 
 	useEffect(() => {
-		window.lenis = lenis
+		window.lenisInstance = lenis
 		if (!lenis) return
 
 		let needsRefresh = false

--- a/link/transitioner.ts
+++ b/link/transitioner.ts
@@ -73,13 +73,13 @@ export const useTransitioner = () => {
 				// scroll to anchor if applicable, otherwise scroll to top
 				if (destination.hash) {
 					const scrollOffset = getScrollOffset(destination.hash)
-					window.lenis?.scrollTo(destination.hash, {
+					window.lenisInstance?.scrollTo(destination.hash, {
 						offset: scrollOffset,
 						onComplete: scrollLock.release,
 					})
 					loader.dispatchEvent("scroll", destination.hash)
 				} else {
-					window.lenis?.scrollTo(0, {
+					window.lenisInstance?.scrollTo(0, {
 						onComplete: scrollLock.release,
 					})
 					loader.dispatchEvent("scroll", null)
@@ -153,7 +153,7 @@ export const useTransitioner = () => {
 			await Promise.race([timeout, urlChange])
 			await sleep(10) // give the page a moment to render
 
-			window.lenis?.scrollTo(0, { immediate: true })
+			window.lenisInstance?.scrollTo(0, { immediate: true })
 
 			// after the page has changed, an abort does nothing
 			if (signal?.aborted) return

--- a/link/util.ts
+++ b/link/util.ts
@@ -58,7 +58,7 @@ export const instantScrollToAnchor = async (anchor: string) => {
 
 			const scrollOffset = getScrollOffset(anchor)
 			ScrollTrigger.refresh()
-			window.lenis?.scrollTo(anchor, {
+			window.lenisInstance?.scrollTo(anchor, {
 				offset: scrollOffset,
 				immediate: true,
 				force: true,

--- a/sanity/FirefoxFix.tsx
+++ b/sanity/FirefoxFix.tsx
@@ -13,7 +13,7 @@ const zeroWidthChars = /[\u200B\u200C\u200D\uFEFF]/g
 
 const checkZeroWidthChars = (startNode: Node = document.body) => {
 	const walk = (node: Node) => {
-		if (window.lenis?.isScrolling) return
+		if (window.lenisInstance?.isScrolling) return
 
 		if (node.nodeType === Node.TEXT_NODE) {
 			const parent = node.parentElement

--- a/useAnimation.ts
+++ b/useAnimation.ts
@@ -175,7 +175,7 @@ export const useAnimation = <InputFn extends Creation>(
 		if (!shouldHydrateUtilities) return
 
 		const newContext = gsap.context((self) => {
-			const lenis = window.lenis
+			const lenis = window.lenisInstance
 
 			if (
 				// lenis exists

--- a/useAutoHideHeader.ts
+++ b/useAutoHideHeader.ts
@@ -70,7 +70,7 @@ export default function useAutoHideHeader(
 
 	useAnimation(
 		() => {
-			let lastScroll = window.lenis?.scroll ?? window.scrollY
+			let lastScroll = window.lenisInstance?.scroll ?? window.scrollY
 			let isHovered = false
 			if (!wrapper?.current) return
 
@@ -82,7 +82,7 @@ export default function useAutoHideHeader(
 			const yTo = gsap.quickTo(wrapper.current, "y", props)
 
 			const onUpdate = () => {
-				const scroll = window.lenis?.scroll ?? window.scrollY
+				const scroll = window.lenisInstance?.scroll ?? window.scrollY
 				const delta = scroll - lastScroll
 				lastScroll = scroll
 				const height = (wrapper.current?.offsetHeight ?? 0) + extraOffset


### PR DESCRIPTION
## Summary
- `lenis@1.x` declares `window.lenis` as a metadata object `{ version?, horizontal?, snap? }` in its own type definitions, conflicting with the library's `window.lenis?: Lenis` instance declaration — TypeScript rejects the mismatch
- Renames all `window.lenis` usages to `window.lenisInstance` across `Scroll.tsx`, `useAnimation.ts`, `useAutoHideHeader.ts`, `sanity/FirefoxFix.tsx`, `link/transitioner.ts`, `link/util.ts`
- Also picks up a formatter tweak to `update-hash.js` from the previous PR

## Test plan
- [ ] `pnpm typecheck` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `window.lenis` to `window.lenisInstance` to fix type collision with lenis@1.3.18
> Replaces all references to `window.lenis` with `window.lenisInstance` across the codebase to resolve a type collision introduced in `lenis@1.3.18`. Updates the global `Window` interface declaration, the Lenis instance assignment in [Scroll.tsx](https://github.com/reformcollective/library/pull/448/files#diff-e2b20508cb3fd0800a764aa2390a8e22b10108be49ce67f1bcedc693476f04a9), and all consumers including [transitioner.ts](https://github.com/reformcollective/library/pull/448/files#diff-f3b472bec34872ee595f2ecdbf6826506458f93dd517184295b014206defc608), [util.ts](https://github.com/reformcollective/library/pull/448/files#diff-44967de9edb80379b56fe8d8e978522a4361f9336a680c693e1c7e958cbb69ca), [FirefoxFix.tsx](https://github.com/reformcollective/library/pull/448/files#diff-8fa468a74cf871e09b98479faf729ba62210794d91ba1cb66cabde01222d84e3), [useAnimation.ts](https://github.com/reformcollective/library/pull/448/files#diff-ebc83b44f3b8872d53cb1bea1d4091df0fb47318874d9f07c71fea454aa788ec), and [useAutoHideHeader.ts](https://github.com/reformcollective/library/pull/448/files#diff-b14a74e115bbf457ceb955667011fac6889f557e9b51103f4fc5e44dd70daffd). Behavioral Change: any external code reading `window.lenis` will no longer find the Lenis instance and must be updated to use `window.lenisInstance`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85526d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->