### PR TITLE
fix(InfiniteSideScroll): correct loop gap when items use margin-right for spacing

### DIFF
--- a/InfiniteSideScroll.tsx
+++ b/InfiniteSideScroll.tsx
@@ -116,13 +116,15 @@ export function InfiniteSideScroll({
 			)
 			const gap =
 				firstLastChild && secondFirstChild
-					? // distance from right edge of first to left edge of second
+					? // distance from right edge of first to left edge of second,
+					  // minus secondFirstLeftMargin only (already in totalWidth via spaceBefore[0]).
+					  // firstLastRightMargin is NOT subtracted: horizontalLoop's getTotalWidth ends
+					  // at the last item's offsetWidth (no trailing margin), so that margin must
+					  // remain in paddingRight to produce an even gap at the loop point.
 						Math.abs(
 							firstLastChild.getBoundingClientRect().right -
 								secondFirstChild.getBoundingClientRect().left,
-						) -
-						firstLastRightMargin -
-						secondFirstLeftMargin
+						) - secondFirstLeftMargin
 					: 0
 
 			const loop = horizontalLoop(rowRef.current.children, {


### PR DESCRIPTION
## Summary

- `horizontalLoop`'s `getTotalWidth` ends at the last item's `offsetWidth` (border box — no trailing margin included)
- The old formula subtracted `firstLastRightMargin` from `paddingRight`, assuming that margin was already in `totalWidth` — it isn't
- This caused the loop seam to be exactly `margin-right`px too tight, visually squashing the last item against the first

## Root cause

```
gap = border_to_border_distance − firstLastRightMargin − secondFirstLeftMargin
```

The intent was to compute "CSS gap only (excluding per-item margins)", reasoning that `offsetLeft` chains bake margins into the layout. That's true for items 0..N-2 — but the **last item's** `margin-right` has no following sibling to absorb it into `offsetLeft`, so it's genuinely absent from `totalWidth`.

## Fix

Only subtract `secondFirstLeftMargin` (which IS already counted via `spaceBefore[0]`):

```
gap = border_to_border_distance − secondFirstLeftMargin
```

CSS-gap-based layouts are unaffected (`firstLastRightMargin` is 0 for those).

## Test plan

- [ ] Carousel with `margin-right` spacing: gap between last and first item matches gap between all other items
- [ ] Carousel with CSS `gap` spacing: unchanged, still seamless
- [ ] Carousel with no spacing: still seamless

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix loop boundary gap in `InfiniteSideScroll` by excluding last item's margin-right
> The gap calculation between the last item of the first sequence and the first item of the second sequence was incorrectly subtracting both the last item's `margin-right` and the second sequence's first item's `margin-left`. Now only the first item's `margin-left` is subtracted, keeping the last item's `margin-right` in `paddingRight` as intended. Comments are added to [InfiniteSideScroll.tsx](https://github.com/reformcollective/library/pull/450/files#diff-912ab74ce54e84d40466bef7a610ca8251f9a43e5632dfb3c7c36a9cadafb877) to clarify `horizontalLoop`'s total width semantics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e8881a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->