### PR TITLE
Add header visibility state management to useAutoHideHeader

### DIFF
--- a/useAutoHideHeader.ts
+++ b/useAutoHideHeader.ts
@@ -94,17 +94,21 @@ export default function useAutoHideHeader(
 				const showHeader = style === "snap" && delta < 0
 				const hideHeader = style === "snap" && delta > 0
 
+				const el = wrapper.current
 				// if forced sticky
 				if (forceShowHeader || (showHeader && !forceHideHeader)) {
 					yTo(0)
+					if (el) el.dataset.headerHiding = "false"
 				}
 				// if forced not sticky
 				else if (forceHideHeader || hideHeader) {
 					yTo(reverse ? height : -height)
+					if (el) el.dataset.headerHiding = "true"
 				}
 				// if hovered
 				else if (isHovered) {
 					yTo(0)
+					if (el) el.dataset.headerHiding = "false"
 				}
 				// scrub behavior, if needed
 				else if (style === "scrub") {
@@ -112,6 +116,7 @@ export default function useAutoHideHeader(
 					const newY = Math.min(0, Math.max(-height, currentY - delta))
 					const newPotentiallyReversedY = reverse ? -newY : newY
 					yTo(newPotentiallyReversedY, newPotentiallyReversedY)
+					if (el) el.dataset.headerHiding = String(delta > 0)
 				}
 			}
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `data-header-hiding` dataset attribute updates to `useAutoHideHeader`
Sets `data-header-hiding` on the wrapper element during scroll and hover events to reflect the header's current visibility state. The attribute is `"false"` when showing, `"true"` when hiding, and dynamically set to `String(delta > 0)` during scrub mode on each scroll event. No control flow or existing logic is changed in [useAutoHideHeader.ts](https://github.com/reformcollective/library/pull/451/files#diff-b14a74e115bbf457ceb955667011fac6889f557e9b51103f4fc5e44dd70daffd).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 303bb37.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->