### PR TITLE
Scale code review agents dynamically based on PR size

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,6 +34,12 @@ jobs:
           prompt: |
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 
+            This PR has ${{ github.event.pull_request.changed_files }} changed files and ${{ github.event.pull_request.additions + github.event.pull_request.deletions }} total lines changed.
+            Scale the number of parallel review agents based on PR size:
+            - Small (≤100 lines or ≤3 files): run 2 agents (CLAUDE.md audit + bug scan)
+            - Medium (101–300 lines or 4–10 files): run 3 agents (add git history)
+            - Large (>300 lines or >10 files): run all 5 agents
+
             Before reviewing or posting anything, check if you've already reviewed the PR - there may be a pending review or existing comments if you've reviewed before. If this is the case, you are performing a follow-up review and should behave accordingly.
             - Be aware that previous comments may have replies or been marked resolved.
             - When you find previously opened bot review comments that are fully addressed by the current diff, resolve those comment threads before submitting your review. Do not resolve comments unless the fix is present and verified in the current code.


### PR DESCRIPTION
## Summary

- Small PRs (≤100 lines or ≤3 files): 2 agents (CLAUDE.md audit + bug scan)
- Medium PRs (101–300 lines or 4–10 files): 3 agents (adds git history)
- Large PRs (>300 lines or >10 files): all 5 agents

Uses GitHub's built-in `pull_request.additions`, `pull_request.deletions`, and `pull_request.changed_files` context to pass PR size to Claude at runtime, so no extra API calls needed.

## Test plan

- [ ] Open a small PR and verify only 2 review agents run
- [ ] Open a larger PR and verify agent count scales up accordingly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scale parallel review agents dynamically based on PR size in Claude code review
> Adds PR size statistics (`changed_files`, total lines changed) and explicit scaling rules to the prompt in [claude-code-review.yml](https://github.com/reformcollective/library/pull/452/files#diff-27456786e30ce9b1fa39c43f4e26f41177ee995f0a650d6d5aba7a826efbfe30). The prompt now instructs the action to spawn fewer parallel agents for small PRs and more for large ones.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c203d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->