### PR TITLE
Update autohide mk ii

### DIFF
--- a/InfiniteSideScroll.tsx
+++ b/InfiniteSideScroll.tsx
@@ -117,10 +117,10 @@ export function InfiniteSideScroll({
 			const gap =
 				firstLastChild && secondFirstChild
 					? // distance from right edge of first to left edge of second,
-					  // minus secondFirstLeftMargin only (already in totalWidth via spaceBefore[0]).
-					  // firstLastRightMargin is NOT subtracted: horizontalLoop's getTotalWidth ends
-					  // at the last item's offsetWidth (no trailing margin), so that margin must
-					  // remain in paddingRight to produce an even gap at the loop point.
+						// minus secondFirstLeftMargin only (already in totalWidth via spaceBefore[0]).
+						// firstLastRightMargin is NOT subtracted: horizontalLoop's getTotalWidth ends
+						// at the last item's offsetWidth (no trailing margin), so that margin must
+						// remain in paddingRight to produce an even gap at the loop point.
 						Math.abs(
 							firstLastChild.getBoundingClientRect().right -
 								secondFirstChild.getBoundingClientRect().left,

--- a/useAutoHideHeader.ts
+++ b/useAutoHideHeader.ts
@@ -94,17 +94,26 @@ export default function useAutoHideHeader(
 				const showHeader = style === "snap" && delta < 0
 				const hideHeader = style === "snap" && delta > 0
 
+				const el = wrapper.current
+				if (el) {
+					if (scroll <= 5) el.dataset.headerScrolled = "false"
+					else if (delta < 0 || isHovered) el.dataset.headerScrolled = "true"
+				}
+
 				// if forced sticky
 				if (forceShowHeader || (showHeader && !forceHideHeader)) {
 					yTo(0)
+					if (el) el.dataset.headerHiding = "false"
 				}
 				// if forced not sticky
 				else if (forceHideHeader || hideHeader) {
 					yTo(reverse ? height : -height)
+					if (el) el.dataset.headerHiding = "true"
 				}
 				// if hovered
 				else if (isHovered) {
 					yTo(0)
+					if (el) el.dataset.headerHiding = "false"
 				}
 				// scrub behavior, if needed
 				else if (style === "scrub") {
@@ -112,6 +121,7 @@ export default function useAutoHideHeader(
 					const newY = Math.min(0, Math.max(-height, currentY - delta))
 					const newPotentiallyReversedY = reverse ? -newY : newY
 					yTo(newPotentiallyReversedY, newPotentiallyReversedY)
+					if (el) el.dataset.headerHiding = String(delta > 0)
 				}
 			}
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `data-header-scrolled` and `data-header-hiding` dataset flags to auto-hide header wrapper
Updates [useAutoHideHeader.ts](https://github.com/reformcollective/library/pull/453/files#diff-b14a74e115bbf457ceb955667011fac6889f557e9b51103f4fc5e44dd70daffd) to set two dataset attributes on the wrapper element during scroll and hover events. `data-header-scrolled` is `"false"` when scroll position is ≤5, otherwise `"true"`. `data-header-hiding` reflects the current hiding state: `"false"` on show/hover, `"true"` on forced hide, and dynamic during scrub mode based on scroll direction.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3de8b11.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->