### PR TITLE
Pin Biome to exact version 2.4.10

### DIFF
--- a/InfiniteSideScroll.tsx
+++ b/InfiniteSideScroll.tsx
@@ -117,10 +117,10 @@ export function InfiniteSideScroll({
 			const gap =
 				firstLastChild && secondFirstChild
 					? // distance from right edge of first to left edge of second,
-					  // minus secondFirstLeftMargin only (already in totalWidth via spaceBefore[0]).
-					  // firstLastRightMargin is NOT subtracted: horizontalLoop's getTotalWidth ends
-					  // at the last item's offsetWidth (no trailing margin), so that margin must
-					  // remain in paddingRight to produce an even gap at the loop point.
+						// minus secondFirstLeftMargin only (already in totalWidth via spaceBefore[0]).
+						// firstLastRightMargin is NOT subtracted: horizontalLoop's getTotalWidth ends
+						// at the last item's offsetWidth (no trailing margin), so that margin must
+						// remain in paddingRight to produce an even gap at the loop point.
 						Math.abs(
 							firstLastChild.getBoundingClientRect().right -
 								secondFirstChild.getBoundingClientRect().left,

--- a/package.json
+++ b/package.json
@@ -38,5 +38,5 @@
 		"lint": "biome lint",
 		"format": "biome check --write"
 	},
-	"packageManager": "pnpm@10.28.2"
+	"packageManager": "pnpm@10.33.0"
 }

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
 		"@mux/blurup": "^1",
 		"@mux/mux-video-react": "^0.29",
 		"@sanity/image-url": "^2",
+		"@types/semver": "^7",
 		"@vanilla-extract/css": "https://pkg.pr.new/RJWadley/vanilla-extract/@vanilla-extract/css@edaedbb",
 		"@vanilla-extract/next-plugin": "https://pkg.pr.new/RJWadley/vanilla-extract/@vanilla-extract/next-plugin@edaedbb",
 		"@vanilla-extract/turbopack-plugin": "https://pkg.pr.new/RJWadley/vanilla-extract/@vanilla-extract/turbopack-plugin@edaedbb",
-		"@types/semver": "^7",
 		"ahooks": "^3",
 		"browser-dtector": "^4",
 		"class-variance-authority": "^0.7",
@@ -28,7 +28,7 @@
 		"zod": "^4"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2",
+		"@biomejs/biome": "2.4.10",
 		"@types/stylis": "^4",
 		"typescript": "^5",
 		"vitest": "^4"


### PR DESCRIPTION
## Summary
- Changes `@biomejs/biome` from `^2` to `2.4.10` (exact pin)
- Prevents version drift between local dev and CI, which causes spurious formatting failures

## Test plan
- [ ] CI formatting check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin Biome to exact version 2.4.10 in package.json
> - Pins `@biomejs/biome` from `^2` to `2.4.10` to prevent unexpected version drift.
> - Updates `pnpm` package manager from `10.28.2` to `10.33.0`.
> - Moves `@types/semver` to a different section in [package.json](https://github.com/reformcollective/library/pull/454/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acdb441.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->