### PR TITLE
add resetOnPlay prop to VideoEmbed that seeks to 0 on each play

### DIFF
--- a/videos/VideoEmbed.tsx
+++ b/videos/VideoEmbed.tsx
@@ -1,8 +1,9 @@
 import ClientOnly from "library/ClientOnly"
 import type { DeepAssetMeta } from "library/sanity/assetMetadata"
 import { css, f, styled } from "library/styled/alpha"
+import { useCombinedRefs } from "library/useCombinedRefs"
 import { stegaClean } from "next-sanity"
-import { useRef } from "react"
+import { forwardRef, useRef } from "react"
 import ReactPlayer from "react-player"
 import type { Video } from "sanity.types"
 
@@ -32,45 +33,44 @@ function getVideoSrc(video: DeepAssetMeta<Video>) {
  * A React component for playing a variety of URLs, including file paths, HLS, DASH, YouTube, Vimeo, Wistia and Mux.
  * Accepts a Sanity `video` schema object directly. Fills its container — the parent is responsible for sizing.
  */
-export function VideoEmbed({
-	className,
-	video,
-	controls = true,
-	resetOnPlay,
-	onPlay,
-	...props
-}: VideoEmbedProps) {
-	const { src } = getVideoSrc(video)
-	const playerRef = useRef<HTMLVideoElement>(null)
+export const VideoEmbed = forwardRef<HTMLVideoElement, VideoEmbedProps>(
+	function VideoEmbed(
+		{ className, video, controls = true, resetOnPlay, onPlay, ...props },
+		externalRef,
+	) {
+		const { src } = getVideoSrc(video)
+		const internalRef = useRef<HTMLVideoElement>(null)
+		const combinedRef = useCombinedRefs(externalRef, internalRef)
 
-	if (!src) return null
+		if (!src) return null
 
-	return (
-		<ClientOnly>
-			<Embed className={className}>
-				<ReactPlayer
-					ref={playerRef}
-					src={src}
-					width="100%"
-					height="100%"
-					controls={controls}
-					onPlay={
-						resetOnPlay
-							? (e) => {
-									const el = playerRef.current
-									if (el && el.currentTime > 0.1) {
-										el.currentTime = 0
+		return (
+			<ClientOnly>
+				<Embed className={className}>
+					<ReactPlayer
+						ref={combinedRef}
+						src={src}
+						width="100%"
+						height="100%"
+						controls={controls}
+						onPlay={
+							resetOnPlay
+								? (e) => {
+										const el = internalRef.current
+										if (el && el.currentTime > 0.1) {
+											el.currentTime = 0
+										}
+										onPlay?.(e)
 									}
-									onPlay?.(e)
-								}
-							: onPlay
-					}
-					{...props}
-				/>
-			</Embed>
-		</ClientOnly>
-	)
-}
+								: onPlay
+						}
+						{...props}
+					/>
+				</Embed>
+			</ClientOnly>
+		)
+	},
+)
 
 const Embed = styled(
 	"div",

--- a/videos/VideoEmbed.tsx
+++ b/videos/VideoEmbed.tsx
@@ -3,7 +3,7 @@ import type { DeepAssetMeta } from "library/sanity/assetMetadata"
 import { css, f, styled } from "library/styled/alpha"
 import { useCombinedRefs } from "library/useCombinedRefs"
 import { stegaClean } from "next-sanity"
-import { forwardRef, useRef } from "react"
+import { useRef } from "react"
 import ReactPlayer from "react-player"
 import type { Video } from "sanity.types"
 
@@ -11,6 +11,7 @@ type VideoEmbedProps = Omit<
 	React.ComponentPropsWithoutRef<typeof ReactPlayer>,
 	"src" | "width" | "height"
 > & {
+	ref?: React.Ref<HTMLVideoElement>
 	className?: string
 	video: DeepAssetMeta<Video>
 	controls?: boolean
@@ -33,44 +34,47 @@ function getVideoSrc(video: DeepAssetMeta<Video>) {
  * A React component for playing a variety of URLs, including file paths, HLS, DASH, YouTube, Vimeo, Wistia and Mux.
  * Accepts a Sanity `video` schema object directly. Fills its container — the parent is responsible for sizing.
  */
-export const VideoEmbed = forwardRef<HTMLVideoElement, VideoEmbedProps>(
-	function VideoEmbed(
-		{ className, video, controls = true, resetOnPlay, onPlay, ...props },
-		externalRef,
-	) {
-		const { src } = getVideoSrc(video)
-		const internalRef = useRef<HTMLVideoElement>(null)
-		const combinedRef = useCombinedRefs(externalRef, internalRef)
+export function VideoEmbed({
+	className,
+	video,
+	controls = true,
+	resetOnPlay,
+	onPlay,
+	ref: externalRef,
+	...props
+}: VideoEmbedProps) {
+	const { src } = getVideoSrc(video)
+	const internalRef = useRef<HTMLVideoElement>(null)
+	const combinedRef = useCombinedRefs(externalRef, internalRef)
 
-		if (!src) return null
+	if (!src) return null
 
-		return (
-			<ClientOnly>
-				<Embed className={className}>
-					<ReactPlayer
-						ref={combinedRef}
-						src={src}
-						width="100%"
-						height="100%"
-						controls={controls}
-						onPlay={
-							resetOnPlay
-								? (e) => {
-										const el = internalRef.current
-										if (el && el.currentTime > 0.1) {
-											el.currentTime = 0
-										}
-										onPlay?.(e)
+	return (
+		<ClientOnly>
+			<Embed className={className}>
+				<ReactPlayer
+					ref={combinedRef}
+					src={src}
+					width="100%"
+					height="100%"
+					controls={controls}
+					onPlay={
+						resetOnPlay
+							? (e) => {
+									const el = internalRef.current
+									if (el && el.currentTime > 0.1) {
+										el.currentTime = 0
 									}
-								: onPlay
-						}
-						{...props}
-					/>
-				</Embed>
-			</ClientOnly>
-		)
-	},
-)
+									onPlay?.(e)
+								}
+							: onPlay
+					}
+					{...props}
+				/>
+			</Embed>
+		</ClientOnly>
+	)
+}
 
 const Embed = styled(
 	"div",

--- a/videos/VideoEmbed.tsx
+++ b/videos/VideoEmbed.tsx
@@ -2,6 +2,7 @@ import ClientOnly from "library/ClientOnly"
 import type { DeepAssetMeta } from "library/sanity/assetMetadata"
 import { css, f, styled } from "library/styled/alpha"
 import { stegaClean } from "next-sanity"
+import { useRef } from "react"
 import ReactPlayer from "react-player"
 import type { Video } from "sanity.types"
 
@@ -12,6 +13,8 @@ type VideoEmbedProps = {
 	playing?: boolean
 	muted?: boolean
 	loop?: boolean
+	/** When true, seeks to 0 each time playback starts */
+	resetOnPlay?: boolean
 }
 
 function getVideoSrc(video: DeepAssetMeta<Video>) {
@@ -36,14 +39,18 @@ export function VideoEmbed({
 	muted,
 	loop,
 	playing,
+	resetOnPlay,
 }: VideoEmbedProps) {
 	const { src } = getVideoSrc(video)
+	const playerRef = useRef<HTMLVideoElement>(null)
+
 	if (!src) return null
 
 	return (
 		<ClientOnly>
 			<Embed className={className}>
 				<ReactPlayer
+					ref={playerRef}
 					src={src}
 					width="100%"
 					height="100%"
@@ -51,6 +58,16 @@ export function VideoEmbed({
 					muted={muted}
 					loop={loop}
 					playing={playing}
+					onPlay={
+						resetOnPlay
+							? () => {
+									const el = playerRef.current
+									if (el && el.currentTime > 0.1) {
+										el.currentTime = 0
+									}
+								}
+							: undefined
+					}
 				/>
 			</Embed>
 		</ClientOnly>

--- a/videos/VideoEmbed.tsx
+++ b/videos/VideoEmbed.tsx
@@ -6,13 +6,13 @@ import { useRef } from "react"
 import ReactPlayer from "react-player"
 import type { Video } from "sanity.types"
 
-type VideoEmbedProps = {
+type VideoEmbedProps = Omit<
+	React.ComponentPropsWithoutRef<typeof ReactPlayer>,
+	"src" | "width" | "height"
+> & {
 	className?: string
 	video: DeepAssetMeta<Video>
 	controls?: boolean
-	playing?: boolean
-	muted?: boolean
-	loop?: boolean
 	/** When true, seeks to 0 each time playback starts */
 	resetOnPlay?: boolean
 }
@@ -36,10 +36,9 @@ export function VideoEmbed({
 	className,
 	video,
 	controls = true,
-	muted,
-	loop,
-	playing,
 	resetOnPlay,
+	onPlay,
+	...props
 }: VideoEmbedProps) {
 	const { src } = getVideoSrc(video)
 	const playerRef = useRef<HTMLVideoElement>(null)
@@ -55,19 +54,18 @@ export function VideoEmbed({
 					width="100%"
 					height="100%"
 					controls={controls}
-					muted={muted}
-					loop={loop}
-					playing={playing}
 					onPlay={
 						resetOnPlay
-							? () => {
+							? (e) => {
 									const el = playerRef.current
 									if (el && el.currentTime > 0.1) {
 										el.currentTime = 0
 									}
+									onPlay?.(e)
 								}
-							: undefined
+							: onPlay
 					}
+					{...props}
 				/>
 			</Embed>
 		</ClientOnly>


### PR DESCRIPTION
Adds `resetOnPlay` to `VideoEmbed` and opens up the full `ReactPlayer` prop surface.

### Changes

- **`resetOnPlay` prop** — when `true`, seeks to position 0 each time playback starts (if `currentTime > 0.1`), then fires the provided `onPlay` callback.
- **Open props** — replaces the fixed prop list (`muted`, `loop`, `playing`) with an intersection type that forwards all `ReactPlayer` props except `src`, `width`, and `height`. Existing callers are unaffected; any `ReactPlayer` prop is now accepted.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> Adds `resetOnPlay` to `VideoEmbed` and opens up the full `ReactPlayer` prop surface.
>
> ### Changes
>
> - **`resetOnPlay` prop** — when `true`, seeks to position 0 each time playback starts (if `currentTime > 0.1`), then fires the provided `onPlay` callback.
> - **Open props** — replaces the fixed prop list (`muted`, `loop`, `playing`) with an intersection type that forwards all `ReactPlayer` props except `src`, `width`, and `height`. Existing callers are unaffected; any `ReactPlayer` prop is now accepted.<!-- Macroscope's changelog starts here -->
> #### Changes since #455 opened
>
> - Converted `VideoEmbed` component to use `forwardRef` and implemented ref forwarding using `useCombinedRefs` hook [de4f140]
> - Refactored `VideoEmbed` component to accept `ref` as a direct prop instead of using `forwardRef` [17f30a4]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->