### PR TITLE
Add "use client" to VideoEmbed

### DIFF
--- a/videos/VideoEmbed.tsx
+++ b/videos/VideoEmbed.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import ClientOnly from "library/ClientOnly"
 import type { DeepAssetMeta } from "library/sanity/assetMetadata"
 import { css, f, styled } from "library/styled/alpha"


### PR DESCRIPTION
## Summary
- `VideoEmbed.tsx` uses `useRef` but was missing the `"use client"` directive, causing a Turbopack Server Component build error in consuming apps

## Test plan
- [ ] Build passes without Server Component errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `use client` directive to `VideoEmbed` component
> Marks [VideoEmbed.tsx](https://github.com/reformcollective/library/pull/456/files#diff-042b97c622f16cc850f109bc9e3adcb3693d911d3226374851c7b8e91bc96da4) as a client component so it renders on the client side in Next.js.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e782ef0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->