### PR TITLE
add vanilla extract to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+# 2026-04-09
+
+## Use published vanilla-extract packages
+
+The library now targets the published npm releases of vanilla-extract rather than PR builds.
+
+**Migration Advice**
+
+Remove any `@vanilla-extract/*` overrides and update to the latest published packages.
+
 # 2026-03-24
 
 ## `window.lenis` renamed to `window.lenisInstance`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-# 2026-04-09
+# 2026-04-07
 
 ## Use published vanilla-extract packages
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Document vanilla-extract published packages migration in changelog
Adds a 2026-04-07 entry to [CHANGELOG.md](https://github.com/reformcollective/library/pull/458/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) noting the switch from PR builds to published `@vanilla-extract/*` packages, with migration advice to remove any `@vanilla-extract/*` dependency overrides and update to the latest published versions.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized db2f552.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->