### PR TITLE
Update auto header with transitioner

### DIFF
--- a/useAutoHideHeader.ts
+++ b/useAutoHideHeader.ts
@@ -74,7 +74,7 @@ export default function useAutoHideHeader(
 			let isHovered = false
 			if (!wrapper?.current) return
 
-			// reset header position on route change
+			// reset header position on route change. This is important because otherwise the header could get stuck in the wrong position if the user navigates while it's hidden
 			const resetHeader = (target: typeof wrapper.current) => {
 				gsap.set(target, { y: 0 })
 				if (target) {

--- a/useAutoHideHeader.ts
+++ b/useAutoHideHeader.ts
@@ -74,6 +74,16 @@ export default function useAutoHideHeader(
 			let isHovered = false
 			if (!wrapper?.current) return
 
+			// reset header position on route change
+			const resetHeader = (target: typeof wrapper.current) => {
+				gsap.set(target, { y: 0 })
+				if (target) {
+					target.dataset.headerHiding = "false"
+					target.dataset.headerScrolled = "false"
+				}
+			}
+			resetHeader(wrapper.current)
+
 			const props = {
 				ease: "power1.out",
 				duration: 0.4,

--- a/vanilla/withVanillaSplit.ts
+++ b/vanilla/withVanillaSplit.ts
@@ -5,7 +5,7 @@ import type { NextConfig } from "next"
 import type { TurbopackLoaderItem } from "next/dist/server/config-shared"
 
 const withVanillaExtract = createVanillaExtractPlugin({
-	unstable_turbopack: { mode: "on" },
+	turbopackMode: "on",
 })
 
 export const withVanillaSplit = (config: NextConfig): NextConfig => {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Reset auto-hide header state on route change via `useAutoHideHeader`
- Adds a `resetHeader` helper to [`useAutoHideHeader`](https://github.com/reformcollective/library/pull/459/files#diff-b14a74e115bbf457ceb955667011fac6889f557e9b51103f4fc5e44dd70daffd) that sets the header's y position to `0` and clears `headerHiding`/`headerScrolled` dataset flags on navigation, preventing the header from staying hidden across route changes.
- Updates [`withVanillaSplit`](https://github.com/reformcollective/library/pull/459/files#diff-fd64b1bc4c9f652a3626202b430dedef93f954e5e367092dfc70f3b8477db747) to use `turbopackMode: "on"` instead of the deprecated `unstable_turbopack: { mode: "on" }` in the vanilla-extract plugin config.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a72d54.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->