### PR TITLE
add shared stylelint config

### DIFF
--- a/config/stylelint.config.js
+++ b/config/stylelint.config.js
@@ -1,0 +1,30 @@
+import postcssSyntax from "postcss-styled-syntax";
+
+export default {
+	extends: "stylelint-config-standard",
+	customSyntax: postcssSyntax,
+	overrides: [{ files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"] }],
+	plugins: ["stylelint-plugin-use-baseline"],
+	rules: {
+		"no-empty-source": null,
+		"block-no-empty": null,
+		"media-query-no-invalid": null,
+		"custom-property-empty-line-before": null,
+		"nesting-selector-no-missing-scoping-root": null,
+		"layer-name-pattern": null,
+		"at-rule-prelude-no-invalid": null,
+		"plugin/use-baseline": [
+			true,
+			{
+				available: 2024,
+				ignoreSelectors: ["/^view-transition-/"],
+				ignoreProperties: {
+					"background-clip": ["text"],
+          "view-transition-name": [],
+          "text-wrap": ['pretty'],
+					"user-select":['none']
+				},
+			},
+		],
+	},
+};

--- a/package.json
+++ b/package.json
@@ -31,7 +31,12 @@
 		"@biomejs/biome": "2.4.10",
 		"@types/stylis": "^4",
 		"typescript": "^5",
-		"vitest": "^4"
+		"vitest": "^4",
+		"postcss": "^8.5.6",
+		"postcss-styled-syntax": "^0.7.1",
+		"stylelint": "^16.25.0",
+		"stylelint-config-standard": "^39.0.1",
+		"stylelint-plugin-use-baseline": "^1.1.0"
 	},
 	"scripts": {
 		"test": "vitest run",


### PR DESCRIPTION
use it by updating your package.json

```
"stylelint": {
	"extends": "./library/config/stylelint.config.js"
},
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add shared Stylelint config with baseline enforcement and styled-syntax support
> - Adds [stylelint.config.js](https://github.com/reformcollective/library/pull/460/files#diff-a0f99a5f9eb4f6c558334c82182e57b9caf6d4d15cf3382dde1aa41a83312913) extending `stylelint-config-standard`, using `postcss-styled-syntax` to parse CSS-in-JS, and enabling `stylelint-plugin-use-baseline` to enforce browser baseline compatibility.
> - Adds `postcss`, `postcss-styled-syntax`, `stylelint`, `stylelint-config-standard`, and `stylelint-plugin-use-baseline` as dependencies in [package.json](https://github.com/reformcollective/library/pull/460/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).
> - Several default Stylelint rules are disabled; `plugin/use-baseline` is configured with an available year, ignored selectors, and ignored properties.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c39c04.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->