### PR TITLE
add back correct unstable_turbopack option to createVanillaExtractPlugin

### DIFF
--- a/vanilla/withVanillaSplit.ts
+++ b/vanilla/withVanillaSplit.ts
@@ -5,7 +5,7 @@ import type { NextConfig } from "next"
 import type { TurbopackLoaderItem } from "next/dist/server/config-shared"
 
 const withVanillaExtract = createVanillaExtractPlugin({
-	turbopackMode: "on",
+	unstable_turbopack: { mode: "on" },
 })
 
 export const withVanillaSplit = (config: NextConfig): NextConfig => {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix `unstable_turbopack` option format in `createVanillaExtractPlugin`
Corrects the Turbopack config passed to `createVanillaExtractPlugin` in [withVanillaSplit.ts](https://github.com/reformcollective/library/pull/461/files#diff-fd64b1bc4c9f652a3626202b430dedef93f954e5e367092dfc70f3b8477db747), replacing the invalid `turbopackMode: "on"` with the correct `unstable_turbopack: { mode: "on" }` shape.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6df8041.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->