### PR TITLE
customizable left snap padding

### DIFF
--- a/InfiniteSideScroll.tsx
+++ b/InfiniteSideScroll.tsx
@@ -25,6 +25,7 @@ export function InfiniteSideScroll({
 	ArrowButton,
 	BackArrowButton,
 	className,
+	snapPaddingLeft = 0,
 	marqueeSpeed = 0,
 	reversed = false,
 	disableDrag = false,
@@ -36,6 +37,13 @@ export function InfiniteSideScroll({
 }: {
 	children: React.ReactNode
 	className?: string
+	/**
+	 * Pixel offset from the left edge where items snap.
+	 * For example, pass the inter-card gap to have items snap flush with
+	 * the first visible card rather than the raw container edge.
+	 * Changes to this value trigger a loop recreation.
+	 */
+	snapPaddingLeft?: number
 	/**
 	 * if specified, a button will be shown to scroll forward and backward by an item
 	 */
@@ -139,6 +147,8 @@ export function InfiniteSideScroll({
 				manageResize: false,
 				// padding right should match the calculated gap
 				paddingRight: gap,
+				// pixel offset from left edge where items snap (ignored in center mode)
+				snapOffset: centerMode ? undefined : snapPaddingLeft || undefined,
 				onChange: (_, index) => {
 					latestOnChange.current?.(index)
 				},
@@ -221,6 +231,7 @@ export function InfiniteSideScroll({
 			numberNeeded,
 			internalLoopRef,
 			centerMode,
+			snapPaddingLeft,
 		],
 		{
 			recreateOnResize: true,

--- a/gsapHelpers/horizontalLoop.d.ts
+++ b/gsapHelpers/horizontalLoop.d.ts
@@ -11,6 +11,8 @@ interface HorizontalLoopConfig {
 	snap?: boolean | number | ((value: number) => number)
 	draggable?: boolean
 	center?: boolean
+	/** Pixel offset from the container's left edge where items snap. Ignored when center is true. */
+	snapOffset?: number
 	onChange?: (items: unknown, index: number) => void
 	/**
 	 * When false, the helper will not attach a window resize listener.

--- a/gsapHelpers/horizontalLoop.js
+++ b/gsapHelpers/horizontalLoop.js
@@ -92,6 +92,8 @@ export function horizontalLoop(items, config) {
 			populateOffsets = () => {
 				timeOffset = center
 					? (tl.duration() * (container.offsetWidth / 2)) / totalWidth
+					: config.snapOffset
+					? (tl.duration() * config.snapOffset) / totalWidth
 					: 0
 				center &&
 					times.forEach((t, i) => {
@@ -100,6 +102,10 @@ export function horizontalLoop(items, config) {
 								(tl.duration() * widths[i]) / 2 / totalWidth -
 								timeOffset,
 						)
+					})
+				!center && config.snapOffset &&
+					times.forEach((t, i) => {
+						times[i] = timeWrap(tl.labels["label" + i] - timeOffset)
 					})
 			},
 			getClosest = (values, value, wrap) => {


### PR DESCRIPTION
Adds a snapOffset config option to horizontalLoop that shifts all snap positions by a fixed pixel amount from the container's left edge, analogous to how center mode offsets by half the container width. Exposed via a snapPaddingLeft prop on InfiniteSideScroll.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `snapPaddingLeft` prop to `InfiniteSideScroll` for left-edge snap offset
> - Adds an optional `snapPaddingLeft` prop (default `0`) to [`InfiniteSideScroll`](https://github.com/reformcollective/library/pull/462/files#diff-912ab74ce54e84d40466bef7a610ca8251f9a43e5632dfb3c7c36a9cadafb877); when `centerMode` is false, the value is passed as `snapOffset` to `horizontalLoop`, shifting snap positions by the specified pixel offset from the container's left edge.
> - Extends [`horizontalLoop.js`](https://github.com/reformcollective/library/pull/462/files#diff-aaedf2b2c172111f4a3cb3f18c2776d96f79b432c592a30c02a239e4663ae8d8) to convert the pixel offset into timeline time and apply it to label times during snap calculation; behavior is unchanged when `center` is true or `snapOffset` is omitted.
> - Changes to `snapPaddingLeft` trigger loop recreation via the hook dependency list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d633302.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->