### PR TITLE
reform site fixes

### DIFF
--- a/ViewTransition.tsx
+++ b/ViewTransition.tsx
@@ -4,8 +4,6 @@ import {
 	type ComponentProps,
 	ViewTransition as ReactViewTransition,
 } from "react"
-// biome-ignore lint/correctness/noUnusedImports: required to load type definitions
-import {} from "react/canary"
 import { usePreloader } from "./link/usePreloader"
 import { type CSSObject, createStyle } from "./styled"
 

--- a/videos/BackgroundVideo.tsx
+++ b/videos/BackgroundVideo.tsx
@@ -217,6 +217,7 @@ export function BackgroundVideo({
 						muted={muted}
 						playsInline
 						loop={loop}
+						preferPlayback="mse"
 						streamType="on-demand"
 						onCanPlay={() => setVideoCanPlay(false)}
 						onEnded={onEnded}
@@ -255,6 +256,7 @@ export function BackgroundVideo({
 				preload="metadata"
 				muted={muted}
 				playsInline
+				preferPlayback="mse"
 				style={{ opacity: videoCanPlay ? 1 : 0 }}
 			/>
 			{/* this is to combat a safari rendering bug where the video doesn't render properly if being lazy loaded or dynamically loaded. */}
@@ -272,6 +274,7 @@ export function BackgroundVideo({
 					muted={muted}
 					playsInline
 					loop={loop}
+					preferPlayback="mse"
 					poster={
 						playbackFailure
 							? `https://image.mux.com/${playbackId}/thumbnail.webp?time=${videoDuration}&width=${posterSize}`
@@ -291,6 +294,7 @@ export function BackgroundVideo({
 					muted={muted}
 					playsInline
 					loop={loop}
+					preferPlayback="mse"
 					streamType="on-demand"
 					onEnded={onEnded}
 					onTimeUpdate={handleTimeUpdate}

--- a/videos/CarouselBGVideo.tsx
+++ b/videos/CarouselBGVideo.tsx
@@ -178,6 +178,7 @@ export function CarouselBackgroundVideo({
 					muted={muted}
 					playsInline
 					loop={loop}
+					preferPlayback="mse"
 					poster={
 						playbackFailure
 							? `https://image.mux.com/${playbackId}/thumbnail.webp?time=${videoDuration}&width=${posterSize}`


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add MSE playback preference to background video components and configure Stylelint
- Adds `preferPlayback="mse"` to all `<MainVideo>` elements in [BackgroundVideo.tsx](https://github.com/reformcollective/library/pull/463/files#diff-ac7841958726f7672f19b539a3c48e0025bd46b542551e086a4d081b15bad67d) and [CarouselBGVideo.tsx](https://github.com/reformcollective/library/pull/463/files#diff-23471f374d383d46cf6703e249f3aa83be2b3763d3b3259a775bece370dfec4f), requesting MSE-based playback when available.
- Adds a [Stylelint configuration](https://github.com/reformcollective/library/pull/463/files#diff-a0f99a5f9eb4f6c558334c82182e57b9caf6d4d15cf3382dde1aa41a83312913) extending `stylelint-config-standard` with `postcss-styled-syntax` for JS/TS files and `stylelint-plugin-use-baseline`, plus rule overrides for CSS properties and selectors.
- Removes an unused `react/canary` side-effect import from [ViewTransition.tsx](https://github.com/reformcollective/library/pull/463/files#diff-2fda8775fbb6fbec8e1ab5c9deb250ac9c84011e02ab64eef6bdda80c8ef4f2a).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3429a6e. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->