### PR TITLE
Native scrollto backup

### DIFF
--- a/link/transitioner.ts
+++ b/link/transitioner.ts
@@ -154,6 +154,7 @@ export const useTransitioner = () => {
 			await sleep(10) // give the page a moment to render
 
 			window.lenisInstance?.scrollTo(0, { immediate: true })
+			window.scrollTo(0, 0)
 
 			// after the page has changed, an abort does nothing
 			if (signal?.aborted) return

--- a/link/transitioner.ts
+++ b/link/transitioner.ts
@@ -153,8 +153,7 @@ export const useTransitioner = () => {
 			await Promise.race([timeout, urlChange])
 			await sleep(10) // give the page a moment to render
 
-			window.lenisInstance?.scrollTo(0, { immediate: true })
-			window.scrollTo(0, 0)
+			window.lenisInstance?.scrollTo(0, { immediate: true, force: true })
 
 			// after the page has changed, an abort does nothing
 			if (signal?.aborted) return

--- a/useAutoHideHeader.ts
+++ b/useAutoHideHeader.ts
@@ -98,7 +98,7 @@ export default function useAutoHideHeader(
 				const height = (wrapper.current?.offsetHeight ?? 0) + extraOffset
 				if (delta > 100 || delta < -100) {
 					// short circuit on large scrolls, since those are probably page transitions
-					// still update scrolled state so frosted effect is correct (e.g. back button)
+					// still update scrolled state so scroll-dependent styles remain correct
 					const el = wrapper.current
 					if (el) el.dataset.headerScrolled = scroll <= 5 ? "false" : "true"
 					return

--- a/useAutoHideHeader.ts
+++ b/useAutoHideHeader.ts
@@ -96,7 +96,13 @@ export default function useAutoHideHeader(
 				const delta = scroll - lastScroll
 				lastScroll = scroll
 				const height = (wrapper.current?.offsetHeight ?? 0) + extraOffset
-				if (delta > 100 || delta < -100) return // short circuit on large scrolls, since those are probably page transitions
+				if (delta > 100 || delta < -100) {
+					// short circuit on large scrolls, since those are probably page transitions
+					// still update scrolled state so frosted effect is correct (e.g. back button)
+					const el = wrapper.current
+					if (el) el.dataset.headerScrolled = scroll <= 5 ? "false" : "true"
+					return
+				}
 
 				const forceHideHeader = dataHideAreOnScreen.current
 				const forceShowHeader =
@@ -142,13 +148,25 @@ export default function useAutoHideHeader(
 				isHovered = false
 			}
 
+			const onPopState = () => {
+				requestAnimationFrame(() => {
+					ScrollTrigger.refresh()
+					const scroll = window.lenisInstance?.scroll ?? window.scrollY
+					if (wrapper.current) {
+						wrapper.current.dataset.headerScrolled = scroll <= 5 ? "false" : "true"
+					}
+				})
+			}
+
 			wrapper.current?.addEventListener("pointerenter", onHover)
 			wrapper.current?.addEventListener("pointerleave", onLeave)
+			window.addEventListener("popstate", onPopState)
 
 			ScrollTrigger.create({ onUpdate })
 			return () => {
 				wrapper.current?.removeEventListener("pointerenter", onHover)
 				wrapper.current?.removeEventListener("pointerleave", onLeave)
+				window.removeEventListener("popstate", onPopState)
 			}
 		},
 		[wrapper, style, reverse, extraOffset],


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add native `window.scrollTo` fallback and fix header scroll state on navigation
- Adds a native `window.scrollTo(0, 0)` call after `window.lenisInstance?.scrollTo` in [transitioner.ts](https://github.com/reformcollective/library/pull/464/files#diff-f3b472bec34872ee595f2ecdbf6826506458f93dd517184295b014206defc608), ensuring the viewport resets to the top on route change even when Lenis is absent.
- In [useAutoHideHeader.ts](https://github.com/reformcollective/library/pull/464/files#diff-b14a74e115bbf457ceb955667011fac6889f557e9b51103f4fc5e44dd70daffd), syncs the wrapper's `data-header-scrolled` attribute during large scroll deltas (>100) that previously skipped the update.
- Adds a `popstate` listener that triggers `ScrollTrigger.refresh()` and updates `data-header-scrolled` on browser back/forward navigation.

<!-- Macroscope's changelog starts here -->
#### Changes since #464 opened

- Modified scroll-to-top behavior in `useTransitioner` hook to use only `lenis` with `{ force: true }` option [0e430da]
<!-- Macroscope's changelog ends here -->

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized e71c932.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->