### PR TITLE
formatting

### DIFF
--- a/config/stylelint.config.js
+++ b/config/stylelint.config.js
@@ -1,4 +1,4 @@
-import postcssSyntax from "postcss-styled-syntax";
+import postcssSyntax from "postcss-styled-syntax"
 
 export default {
 	extends: "stylelint-config-standard",
@@ -20,11 +20,11 @@ export default {
 				ignoreSelectors: ["/^view-transition-/"],
 				ignoreProperties: {
 					"background-clip": ["text"],
-          "view-transition-name": [],
-          "text-wrap": ['pretty'],
-					"user-select":['none']
+					"view-transition-name": [],
+					"text-wrap": ["pretty"],
+					"user-select": ["none"],
 				},
 			},
 		],
 	},
-};
+}

--- a/link/transitioner.ts
+++ b/link/transitioner.ts
@@ -154,6 +154,7 @@ export const useTransitioner = () => {
 			await sleep(10) // give the page a moment to render
 
 			window.lenisInstance?.scrollTo(0, { immediate: true, force: true })
+			window.scrollTo(0, 0)
 
 			// after the page has changed, an abort does nothing
 			if (signal?.aborted) return

--- a/useAutoHideHeader.ts
+++ b/useAutoHideHeader.ts
@@ -153,7 +153,8 @@ export default function useAutoHideHeader(
 					ScrollTrigger.refresh()
 					const scroll = window.lenisInstance?.scroll ?? window.scrollY
 					if (wrapper.current) {
-						wrapper.current.dataset.headerScrolled = scroll <= 5 ? "false" : "true"
+						wrapper.current.dataset.headerScrolled =
+							scroll <= 5 ? "false" : "true"
 					}
 				})
 			}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Apply formatting fixes to stylelint config and `useAutoHideHeader` hook
Formatting-only changes across two files with no logic or behavioral modifications.

- [stylelint.config.js](https://github.com/reformcollective/library/pull/465/files#diff-a0f99a5f9eb4f6c558334c82182e57b9caf6d4d15cf3382dde1aa41a83312913): removes trailing semicolons, switches to double quotes, adjusts indentation, and normalizes array literals.
- [useAutoHideHeader.ts](https://github.com/reformcollective/library/pull/465/files#diff-b14a74e115bbf457ceb955667011fac6889f557e9b51103f4fc5e44dd70daffd): splits a long assignment across two lines for readability.

<!-- Macroscope's changelog starts here -->
#### Changes since #465 opened

- Added native `window.scrollTo(0, 0)` call after existing `window.lenisInstance?.scrollTo(0, { immediate: true, force: true })` call within the `useTransitioner` hook's async transition function [99fd7c9]
<!-- Macroscope's changelog ends here -->

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08fccdf.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->