### PR TITLE
minor tweaks and fixes

### DIFF
--- a/sanity/FirefoxFix.tsx
+++ b/sanity/FirefoxFix.tsx
@@ -48,7 +48,6 @@ export const FirefoxFix = () => {
 	}, 1000)
 	useHMR("postbuild", () => {
 		if (browserData.isFireFox) {
-			hasWarned = false
 			checkZeroWidthChars()
 		}
 	})

--- a/sanity/assetMetadata.ts
+++ b/sanity/assetMetadata.ts
@@ -112,11 +112,7 @@ export const fetchAssetMeta = async <InputType>(
 		const { data: linkParse, success: isLink } = z.safeParse(linkSchema, input)
 
 		if (isAsset) {
-			const assetT0 = performance.now()
 			const { data: asset } = await fetchAssetDoc(assetParse.asset._ref)
-			console.log(
-				`[sanity:asset  ] resolved ${assetParse.asset._ref} (${asset?._type ?? "not found"}) — ${(performance.now() - assetT0).toFixed(0)}ms`,
-			)
 			if (!asset) return input as Output
 
 			const { blurDataURL } =
@@ -162,11 +158,7 @@ export const fetchAssetMeta = async <InputType>(
 		}
 
 		if (isLink) {
-			const linkT0 = performance.now()
 			const { data: linkedItem } = await fetchLinkDoc(linkParse.internalLink._ref)
-			console.log(
-				`[sanity:link   ] resolved ${linkParse.internalLink._ref} → ${linkedItem ? `"${linkedItem.slug?.current}"` : "not found"} — ${(performance.now() - linkT0).toFixed(0)}ms`,
-			)
 
 			return {
 				...input,

--- a/sanity/assetMetadata.ts
+++ b/sanity/assetMetadata.ts
@@ -76,6 +76,17 @@ const linkQuery = defineQuery(`
 	*[_id == $asset && defined(slug.current)][0]
 `)
 
+// Deduplicate repeated lookups for the same ref within a single render pass.
+// get-it (used by @sanity/client) bypasses Next.js's fetch deduplication by
+// going through node:http directly, so we memoize at the JS call level instead.
+const fetchAssetDoc = cache((ref: string) =>
+	sanityFetch({ query: assetQuery, params: { asset: ref }, enrichAssets: false }),
+)
+
+const fetchLinkDoc = cache((ref: string) =>
+	sanityFetch({ query: linkQuery, params: { asset: ref }, enrichAssets: false }),
+)
+
 export type DeepAssetMeta<T> = T extends { asset?: { _ref?: string } }
 	? T & { data?: AssetMeta }
 	: T extends { _type: "link"; internalLink?: { _ref?: string } }
@@ -101,13 +112,11 @@ export const fetchAssetMeta = async <InputType>(
 		const { data: linkParse, success: isLink } = z.safeParse(linkSchema, input)
 
 		if (isAsset) {
-			const { data: asset } = await sanityFetch({
-				query: assetQuery,
-				params: {
-					asset: assetParse.asset._ref,
-				},
-				enrichAssets: false,
-			})
+			const assetT0 = performance.now()
+			const { data: asset } = await fetchAssetDoc(assetParse.asset._ref)
+			console.log(
+				`[sanity:asset  ] resolved ${assetParse.asset._ref} (${asset?._type ?? "not found"}) — ${(performance.now() - assetT0).toFixed(0)}ms`,
+			)
 			if (!asset) return input as Output
 
 			const { blurDataURL } =
@@ -153,11 +162,11 @@ export const fetchAssetMeta = async <InputType>(
 		}
 
 		if (isLink) {
-			const { data: linkedItem } = await sanityFetch({
-				query: linkQuery,
-				params: { asset: linkParse.internalLink._ref },
-				enrichAssets: false,
-			})
+			const linkT0 = performance.now()
+			const { data: linkedItem } = await fetchLinkDoc(linkParse.internalLink._ref)
+			console.log(
+				`[sanity:link   ] resolved ${linkParse.internalLink._ref} → ${linkedItem ? `"${linkedItem.slug?.current}"` : "not found"} — ${(performance.now() - linkT0).toFixed(0)}ms`,
+			)
 
 			return {
 				...input,

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -30,11 +30,6 @@ const { sanityFetch: internalFetch, SanityLive: InternalLive } = defineLive({
  * and will also fetch from the CDN.
  * When using the "drafts" perspective then the data is fetched from the live API and isn't cached, it will also fetch draft content that isn't published yet.
  */
-// Shared reference point so timestamps are relative offsets (easier to read than wall-clock)
-const _fetchEpoch = performance.now()
-const relMs = () => (performance.now() - _fetchEpoch).toFixed(0).padStart(6)
-const queryLabel = (q: string) => q.trimStart().slice(0, 70).replace(/\s+/g, " ")
-
 export async function libraryFetch<const QueryString extends string>({
 	query,
 	params = {},
@@ -62,10 +57,6 @@ export async function libraryFetch<const QueryString extends string>({
 	 */
 	enrichAssets?: boolean
 }) {
-	const label = queryLabel(query)
-	const t0 = performance.now()
-	console.log(`[sanity +${relMs()}ms] FETCH  start  "${label}"`)
-
 	const { data, sourceMap, tags } = await internalFetch({
 		query,
 		params,
@@ -73,20 +64,11 @@ export async function libraryFetch<const QueryString extends string>({
 		perspective,
 	})
 
-	const t1 = performance.now()
-	console.log(`[sanity +${relMs()}ms] FETCH  done   "${label}" — ${(t1 - t0).toFixed(0)}ms`)
-
-	if (!enrichAssets) {
-		return { data, sourceMap, tags }
+	return {
+		data: enrichAssets ? await fetchAssetMeta(data) : data,
+		sourceMap,
+		tags,
 	}
-
-	const enriched = await fetchAssetMeta(data)
-	const t2 = performance.now()
-	console.log(
-		`[sanity +${relMs()}ms] ENRICH done   "${label}" — enrich: ${(t2 - t1).toFixed(0)}ms | total: ${(t2 - t0).toFixed(0)}ms`,
-	)
-
-	return { data: enriched, sourceMap, tags }
 }
 
 const allowProxy =

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -30,6 +30,11 @@ const { sanityFetch: internalFetch, SanityLive: InternalLive } = defineLive({
  * and will also fetch from the CDN.
  * When using the "drafts" perspective then the data is fetched from the live API and isn't cached, it will also fetch draft content that isn't published yet.
  */
+// Shared reference point so timestamps are relative offsets (easier to read than wall-clock)
+const _fetchEpoch = performance.now()
+const relMs = () => (performance.now() - _fetchEpoch).toFixed(0).padStart(6)
+const queryLabel = (q: string) => q.trimStart().slice(0, 70).replace(/\s+/g, " ")
+
 export async function libraryFetch<const QueryString extends string>({
 	query,
 	params = {},
@@ -57,6 +62,10 @@ export async function libraryFetch<const QueryString extends string>({
 	 */
 	enrichAssets?: boolean
 }) {
+	const label = queryLabel(query)
+	const t0 = performance.now()
+	console.log(`[sanity +${relMs()}ms] FETCH  start  "${label}"`)
+
 	const { data, sourceMap, tags } = await internalFetch({
 		query,
 		params,
@@ -64,11 +73,20 @@ export async function libraryFetch<const QueryString extends string>({
 		perspective,
 	})
 
-	return {
-		data: enrichAssets ? await fetchAssetMeta(data) : data,
-		sourceMap,
-		tags,
+	const t1 = performance.now()
+	console.log(`[sanity +${relMs()}ms] FETCH  done   "${label}" — ${(t1 - t0).toFixed(0)}ms`)
+
+	if (!enrichAssets) {
+		return { data, sourceMap, tags }
 	}
+
+	const enriched = await fetchAssetMeta(data)
+	const t2 = performance.now()
+	console.log(
+		`[sanity +${relMs()}ms] ENRICH done   "${label}" — enrich: ${(t2 - t1).toFixed(0)}ms | total: ${(t2 - t0).toFixed(0)}ms`,
+	)
+
+	return { data: enriched, sourceMap, tags }
 }
 
 const allowProxy =


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Memoize asset and link document fetches in `fetchAssetMeta`
- Wraps `sanityFetch` calls for asset and link queries in `cache()`-based helpers (`fetchAssetDoc`, `fetchLinkDoc`) in [assetMetadata.ts](https://github.com/reformcollective/library/pull/467/files#diff-21a1b0cf75903ec16dfab0236a2aae247d372e72ae08fc09cdeaef578cbc34b8), so repeated calls with the same ref reuse the cached result.
- Fixes a bug in [FirefoxFix.tsx](https://github.com/reformcollective/library/pull/467/files#diff-8fa468a74cf871e09b98479faf729ba62210794d91ba1cb66cabde01222d84e3) where the `hasWarned` flag was incorrectly reset to `false` on every `postbuild` HMR event.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized f252e5b.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->