### PR TITLE
deprecate fetchAssetMeta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,65 @@
 
+# 2026-04-13
+
+## `enrichAssets` now opt-in; `fetchAssetMeta` deprecated
+
+`libraryFetch` / `sanityFetch` previously called `fetchAssetMeta` after every query, recursively enriching image refs with LQIP/aspect-ratio data, Mux video refs with playback metadata, and link objects with a resolved `internalSlug`. This happened automatically with no action required.
+
+That behaviour is now **opt-in**. The `enrichAssets` option defaults to `false`. Calls that relied on automatic enrichment will silently receive un-enriched data unless migrated.
+
+**Why**
+
+Post-query enrichment fired N+1 Sanity API calls per render (one per asset ref), added up to 1 second of SSR latency (Mux `@mux/blurup` HTTP requests), and made it impossible to know at query time what shape the data would have. Inline GROQ projections resolve the same data in a single round-trip and make the shape explicit and type-safe.
+
+**Migration Advice**
+
+Replace post-query enrichment with inline GROQ projections in your query. The patterns below cover all enriched field types:
+
+```groq
+# Image — adds lqip and aspectRatio under a `data` key
+customImage {
+  ...,
+  "data": {
+    "lqip": asset->metadata.lqip,
+    "aspectRatio": asset->metadata.dimensions.aspectRatio
+  }
+}
+
+# Mux video — adds playback metadata under a `data` key
+muxVideo {
+  ...,
+  "data": {
+    "playbackId": asset->playbackId,
+    "videoThumbnailUrl": "https://image.mux.com/" + asset->playbackId + "/thumbnail.jpg",
+    "videoBlurUrl": "https://image.mux.com/" + asset->playbackId + "/thumbnail.webp?time=0&width=32",
+    "videoAspectRatio": select(
+      defined(asset->data.aspect_ratio) =>
+        string::split(asset->data.aspect_ratio, ":")[0] + "/" + string::split(asset->data.aspect_ratio, ":")[1]
+    ),
+    "videoDuration": asset->data.duration
+  }
+}
+
+# Link — adds resolved internalSlug
+link {
+  ...,
+  "internalSlug": select(
+    type != "internal" => null,
+    !defined(internalLink) => null,
+    internalLink->._type == "page" => select(
+      internalLink->slug.current == "home" => "/",
+      internalLink->slug.current
+    ),
+    internalLink->._type == "product" => "/products/" + internalLink->store.slug.current,
+    internalLink->._type == "collection" => "/collections/" + internalLink->store.slug.current
+  )
+}
+```
+
+Once migrated, remove any explicit `enrichAssets: true` from your `sanityFetch` calls. If you cannot migrate a call-site immediately, pass `enrichAssets: true` to preserve the old behaviour — but note that `fetchAssetMeta` is now `@deprecated` and will be removed in a future release.
+
+Note: `CMSLink.internalSlug` has been widened from `string | undefined` to `string | null | undefined` to match the `null` that GROQ `select()` returns on the fallback path.
+
 # 2026-04-07
 
 ## Use published vanilla-extract packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ That behaviour is now **opt-in**. The `enrichAssets` option defaults to `false`.
 
 **Why**
 
-Post-query enrichment fired N+1 Sanity API calls per render (one per asset ref), added up to 1 second of SSR latency (Mux `@mux/blurup` HTTP requests), and made it impossible to know at query time what shape the data would have. Inline GROQ projections resolve the same data in a single round-trip and make the shape explicit and type-safe.
+Post-query enrichment fired N+1 Sanity API calls per render (one per asset ref) and added a lot of render latency, sometimes up to several seconds. Inline GROQ projections resolve the same data in a single round-trip, which is much faster.
 
 **Migration Advice**
 
-Replace post-query enrichment with inline GROQ projections in your query. The patterns below cover all enriched field types:
+For a quick fix, just enable asset enrichment on all your queries.
+
+Long term, replace post-query enrichment with inline GROQ projections in your query. The patterns below cover all enriched field types:
 
 ```groq
 # Image — adds lqip and aspectRatio under a `data` key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,28 @@ Once migrated, remove any explicit `enrichAssets: true` from your `sanityFetch` 
 
 Note: `CMSLink.internalSlug` has been widened from `string | undefined` to `string | null | undefined` to match the `null` that GROQ `select()` returns on the fallback path.
 
+## `isRouteDefined` helper — use instead of `!!link`
+
+A new `isRouteDefined(link)` export is available from `library/link`.
+
+**Why**
+
+`sanity-plugin-link-field` writes an `initialValue` of `{ type: "internal", toNewTab: false }` into every link field when a section is first created in Studio. This means the link field is **never** `null` or `undefined` in the database — it always contains at least a partial object, even when the editor has not selected any destination.
+
+As a result, `!!link` is always `true` for these fields and is an unreliable guard for "does this section link anywhere?". Previously, `fetchAssetMeta` resolved an `internalSlug` onto the link object, but that enrichment did not change the object's truthiness or null out links with no destination — the check was subtly broken in both the old and new systems.
+
+`isRouteDefined` fixes this by running the value through `resolveRoute` and checking whether a URL was produced:
+
+```ts
+import { isRouteDefined } from "library/link"
+
+// ✓
+const hasLink = isRouteDefined(link)
+
+// ✗ — always true; the link object exists even with no destination selected
+const hasLink = !!link
+```
+
 # 2026-04-07
 
 ## Use published vanilla-extract packages

--- a/link/index.tsx
+++ b/link/index.tsx
@@ -10,7 +10,8 @@ type CMSLink = {
 	_type: "link"
 	text?: string
 	type?: string
-	internalSlug?: string
+	/** Resolved by inline GROQ projection; null when not an internal link. */
+	internalSlug?: string | null
 	url?: string
 	email?: string
 	phone?: string

--- a/link/index.tsx
+++ b/link/index.tsx
@@ -1,25 +1,13 @@
 "use client"
 
 import Link, { type LinkProps } from "next/link"
-import { stegaClean } from "next-sanity"
 import type { ComponentProps, Ref } from "react"
 import { linkIsInternal } from "../functions"
 import { useTransitioner } from "./transitioner"
+import { resolveRoute, isRouteDefined, type CMSLink, type LinkHref } from "./resolve"
 
-type CMSLink = {
-	_type: "link"
-	text?: string
-	type?: string
-	/** Resolved by inline GROQ projection; null when not an internal link. */
-	internalSlug?: string | null
-	url?: string
-	email?: string
-	phone?: string
-	value?: string
-	blank?: boolean
-	parameters?: string
-	anchor?: string
-}
+export type { CMSLink, LinkHref }
+export { resolveRoute, isRouteDefined }
 
 type ButtonProps = {
 	/**
@@ -38,7 +26,7 @@ type AnchorProps = {
 	/**
 	 * where should the link navigate to?
 	 */
-	href: string | null | undefined | CMSLink
+	href: LinkHref
 	/**
 	 * open this link in a new tab?
 	 */
@@ -62,53 +50,6 @@ export type UniversalLinkProps = (ButtonProps | AnchorProps) & {
 		| Ref<HTMLButtonElement | null>
 		| Ref<HTMLAnchorElement | null>
 		| Ref<HTMLButtonElement | HTMLAnchorElement | null>
-}
-
-export const resolveRoute = (
-	link: AnchorProps["href"],
-): { url: string | undefined; newTab: boolean } => {
-	if (typeof link === "string")
-		return {
-			url: link,
-			newTab: !linkIsInternal(link),
-		}
-	if (!link)
-		return {
-			url: undefined,
-			newTab: false,
-		}
-
-	if (link.type === "internal" && link.internalSlug) {
-		const slugToUse = link.internalSlug === "home" ? "" : link.internalSlug
-		return {
-			url: `/${stegaClean(slugToUse || "")}${stegaClean(link.parameters || "")}${stegaClean(link.anchor || "")}`,
-			// default to same tab if not specified
-			newTab: link.blank ?? false,
-		}
-	}
-
-	if (link.type === "external" && link.url)
-		return {
-			url: `${stegaClean(link.url || "")}${stegaClean(link.parameters || "")}${stegaClean(link.anchor || "")}`,
-			// default to other tab if not specified
-			newTab: link.blank ?? true,
-		}
-
-	if (link.type === "email" && link.email) {
-		return { url: `mailto:${stegaClean(link.email || "")}`, newTab: true }
-	}
-
-	if (link.type === "phone") {
-		return {
-			url: `tel:${stegaClean(link.phone || "")}`,
-			newTab: true,
-		}
-	}
-
-	return {
-		url: undefined,
-		newTab: false,
-	}
 }
 
 /**

--- a/link/resolve.ts
+++ b/link/resolve.ts
@@ -1,0 +1,78 @@
+import { stegaClean } from "next-sanity"
+import { linkIsInternal } from "../functions"
+
+export type CMSLink = {
+	_type: "link"
+	text?: string
+	type?: string
+	/** Resolved by inline GROQ projection; null when not an internal link. */
+	internalSlug?: string | null
+	url?: string
+	email?: string
+	phone?: string
+	value?: string
+	blank?: boolean
+	parameters?: string
+	anchor?: string
+}
+
+/** All values accepted by resolveRoute / isRouteDefined. */
+export type LinkHref = string | null | undefined | CMSLink
+
+export const resolveRoute = (
+	link: LinkHref,
+): { url: string | undefined; newTab: boolean } => {
+	if (typeof link === "string")
+		return {
+			url: link,
+			newTab: !linkIsInternal(link),
+		}
+	if (!link)
+		return {
+			url: undefined,
+			newTab: false,
+		}
+
+	if (link.type === "internal" && link.internalSlug) {
+		const slugToUse = link.internalSlug === "home" ? "" : link.internalSlug
+		return {
+			url: `/${stegaClean(slugToUse || "")}${stegaClean(link.parameters || "")}${stegaClean(link.anchor || "")}`,
+			// default to same tab if not specified
+			newTab: link.blank ?? false,
+		}
+	}
+
+	if (link.type === "external" && link.url)
+		return {
+			url: `${stegaClean(link.url || "")}${stegaClean(link.parameters || "")}${stegaClean(link.anchor || "")}`,
+			// default to other tab if not specified
+			newTab: link.blank ?? true,
+		}
+
+	if (link.type === "email" && link.email) {
+		return { url: `mailto:${stegaClean(link.email || "")}`, newTab: true }
+	}
+
+	if (link.type === "phone") {
+		return {
+			url: `tel:${stegaClean(link.phone || "")}`,
+			newTab: true,
+		}
+	}
+
+	return {
+		url: undefined,
+		newTab: false,
+	}
+}
+
+/**
+ * Returns true if the link resolves to an actual destination URL.
+ *
+ * Prefer this over `!!link` — the link field stores a partial object
+ * (e.g. `{ _type: "link", type: "internal" }`) via initialValue even when no
+ * destination has been selected by the editor, so a plain truthiness check will
+ * always be true regardless of whether the link goes anywhere.
+ */
+export const isRouteDefined = (link: LinkHref): boolean =>
+	!!resolveRoute(link).url

--- a/link/resolve.ts
+++ b/link/resolve.ts
@@ -53,7 +53,7 @@ export const resolveRoute = (
 		return { url: `mailto:${stegaClean(link.email || "")}`, newTab: true }
 	}
 
-	if (link.type === "phone") {
+	if (link.type === "phone" && link.phone) {
 		return {
 			url: `tel:${stegaClean(link.phone || "")}`,
 			newTab: true,

--- a/sanity/assetMetadata.ts
+++ b/sanity/assetMetadata.ts
@@ -80,11 +80,19 @@ const linkQuery = defineQuery(`
 // get-it (used by @sanity/client) bypasses Next.js's fetch deduplication by
 // going through node:http directly, so we memoize at the JS call level instead.
 const fetchAssetDoc = cache((ref: string) =>
-	sanityFetch({ query: assetQuery, params: { asset: ref }, enrichAssets: false }),
+	sanityFetch({
+		query: assetQuery,
+		params: { asset: ref },
+		enrichAssets: false,
+	}),
 )
 
 const fetchLinkDoc = cache((ref: string) =>
-	sanityFetch({ query: linkQuery, params: { asset: ref }, enrichAssets: false }),
+	sanityFetch({
+		query: linkQuery,
+		params: { asset: ref },
+		enrichAssets: false,
+	}),
 )
 
 export type DeepAssetMeta<T> = T extends { asset?: { _ref?: string } }
@@ -95,6 +103,12 @@ export type DeepAssetMeta<T> = T extends { asset?: { _ref?: string } }
 			? { [K in keyof T]: DeepAssetMeta<T[K]> }
 			: T
 
+/**
+ * @deprecated Enrich assets inline in your GROQ query instead.
+ * Use `asset->metadata.lqip` for image LQIP, `asset->playbackId` for Mux video, and
+ * a `select()` projection for `internalSlug` on link fields.
+ * Pass `enrichAssets: true` explicitly on any legacy call-site that still needs this.
+ */
 export const fetchAssetMeta = async <InputType>(
 	input: InputType,
 ): Promise<DeepAssetMeta<InputType>> => {
@@ -158,7 +172,9 @@ export const fetchAssetMeta = async <InputType>(
 		}
 
 		if (isLink) {
-			const { data: linkedItem } = await fetchLinkDoc(linkParse.internalLink._ref)
+			const { data: linkedItem } = await fetchLinkDoc(
+				linkParse.internalLink._ref,
+			)
 
 			return {
 				...input,

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -35,7 +35,7 @@ export async function libraryFetch<const QueryString extends string>({
 	params = {},
 	perspective,
 	disableStega,
-	enrichAssets = true,
+	enrichAssets = false,
 }: {
 	query: QueryString
 	params?: QueryParams | Promise<QueryParams>
@@ -52,8 +52,12 @@ export async function libraryFetch<const QueryString extends string>({
 	 */
 	disableStega?: boolean
 	/**
-	 * enable asset metadata enrichment? can be disabled if you're in a context
-	 * where enriching the assets would cause an infinite loop.
+	 * Opt-in to legacy post-query asset enrichment via `fetchAssetMeta`.
+	 * Prefer projecting asset data inline in your GROQ query instead — e.g.
+	 * `asset->metadata.lqip` for images, `asset->playbackId` for Mux video.
+	 *
+	 * @deprecated Set `enrichAssets: true` only on legacy call-sites that have
+	 * not yet been migrated to inline GROQ projections.
 	 */
 	enrichAssets?: boolean
 }) {


### PR DESCRIPTION
- Mark fetchAssetMeta as @deprecated; prefer inline GROQ asset projections
- Flip enrichAssets default from true → false in libraryFetch
- Widen CMSLink.internalSlug to string | null | undefined (GROQ select() returns null on fallback)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deprecate `fetchAssetMeta` and make asset enrichment opt-in in `libraryFetch`
> - Changes the default value of `enrichAssets` in [`libraryFetch`](https://github.com/reformcollective/library/pull/468/files#diff-133b49b7bb8d0ef32f864830fdb361dabf4df3cce6c82c54835099255a9458aa) from `true` to `false`, so post-query asset enrichment no longer runs unless explicitly opted in.
> - Marks `fetchAssetMeta` in [`sanity/assetMetadata.ts`](https://github.com/reformcollective/library/pull/468/files#diff-21a1b0cf75903ec16dfab0236a2aae247d372e72ae08fc09cdeaef578cbc34b8) as `@deprecated`, recommending inline GROQ projections instead.
> - Adds `isRouteDefined` helper and `LinkHref` type alias to [`link/resolve.ts`](https://github.com/reformcollective/library/pull/468/files#diff-b76a108741b62f04027c6baaedb68c5e9d61e6b482fe9e7a43f385e71615263a), and re-exports them from [`link/index.tsx`](https://github.com/reformcollective/library/pull/468/files#diff-d5d0542ad486ee976c47463d8359f6e73550a5d99b9833bc66123de4a58f04ac). Also fixes `resolveRoute` to return `undefined` for phone links when the phone value is missing.
> - Widens `CMSLink.internalSlug` to `string | null | undefined` to handle null values from inline GROQ projections.
> - Behavioral Change: existing `libraryFetch` callers that relied on the default `enrichAssets: true` will now receive un-enriched data unless they pass `enrichAssets: true` explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6621e8f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->