### PR TITLE
format

### DIFF
--- a/sanity/assetMetadata.ts
+++ b/sanity/assetMetadata.ts
@@ -80,11 +80,19 @@ const linkQuery = defineQuery(`
 // get-it (used by @sanity/client) bypasses Next.js's fetch deduplication by
 // going through node:http directly, so we memoize at the JS call level instead.
 const fetchAssetDoc = cache((ref: string) =>
-	sanityFetch({ query: assetQuery, params: { asset: ref }, enrichAssets: false }),
+	sanityFetch({
+		query: assetQuery,
+		params: { asset: ref },
+		enrichAssets: false,
+	}),
 )
 
 const fetchLinkDoc = cache((ref: string) =>
-	sanityFetch({ query: linkQuery, params: { asset: ref }, enrichAssets: false }),
+	sanityFetch({
+		query: linkQuery,
+		params: { asset: ref },
+		enrichAssets: false,
+	}),
 )
 
 export type DeepAssetMeta<T> = T extends { asset?: { _ref?: string } }
@@ -158,7 +166,9 @@ export const fetchAssetMeta = async <InputType>(
 		}
 
 		if (isLink) {
-			const { data: linkedItem } = await fetchLinkDoc(linkParse.internalLink._ref)
+			const { data: linkedItem } = await fetchLinkDoc(
+				linkParse.internalLink._ref,
+			)
 
 			return {
 				...input,


### PR DESCRIPTION
pnpm format :p

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reformat `sanityFetch` calls in `assetMetadata.ts` to multi-line style
> Pure formatting change in [assetMetadata.ts](https://github.com/reformcollective/library/pull/469/files#diff-21a1b0cf75903ec16dfab0236a2aae247d372e72ae08fc09cdeaef578cbc34b8). Expands `sanityFetch` invocations in `fetchAssetDoc`, `fetchLinkDoc`, and `fetchAssetMeta` to multi-line object literals. No logic or behavior changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29e1a6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->