### PR TITLE
Add dev-time error for raw CSS strings in styled()

### DIFF
--- a/styled/core.ts
+++ b/styled/core.ts
@@ -45,6 +45,15 @@ function flattenArray<T>(input: T): InfinitelyFlattened<T>[] {
 
 function classFromStyleRules(input: StyleRules | undefined, debugId?: string) {
 	const flatInput = flattenArray(input)
+	if (process.env.NODE_ENV === "development") {
+		for (const item of flatInput) {
+			if (typeof item === "string" && /[;:{]/.test(item)) {
+				throw new Error(
+					`[styled] Raw CSS string passed as style rules — wrap in fresponsive(), f.unresponsive(), etc.:\n\n"${item}"`,
+				)
+			}
+		}
+	}
 	return style(flatInput.filter(Boolean), debugId)
 }
 


### PR DESCRIPTION
## Summary
- Throws a clear build error when a raw `css` template literal is passed directly to `styled()` as a style rule without being wrapped in `fresponsive()`, `f.unresponsive()`, or another `f.*()` utility
- Fires at VE build time (inside `classFromStyleRules`) so mistakes are caught immediately, not silently producing broken/empty styles in production
- Only runs in `development` — zero cost in production builds

## Test plan
- [ ] Pass a raw `css\`display: none;\`` string as a variant value in `styled()` and confirm the build throws with the descriptive error message
- [ ] Confirm a correctly wrapped `f.unresponsive(css\`display: none;\`)` builds without error

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dev-time error for raw CSS strings in `styled()` style rules
> In development, `classFromStyleRules` in [styled/core.ts](https://github.com/reformcollective/library/pull/471/files#diff-0fc95143fbf5d7560e9d44344cf425c8d8a9a860ee4efce41720f46323074dc0) now throws an `Error` if any flattened style rule is a string containing `;`, `:`, or `{`. This catches accidental raw CSS strings passed to `styled()` that would otherwise be silently ignored.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9457f28.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->