### PR TITLE
Remove cropType; always use CSS hotspot cropping

### DIFF
--- a/sanity/SanityImage.tsx
+++ b/sanity/SanityImage.tsx
@@ -20,49 +20,32 @@ import {
 	objectPositionVar,
 } from "../StaticImage.css"
 
-export type SanityImageData<CropType, WithAlt extends "true" | "false"> = {
+export type SanityImageData<WithAlt extends "true" | "false"> = {
 	asset?: { _ref: string }
 	crop?: SanityImageCrop
 	hotspot?: SanityImageHotspot
 	data?: AssetMeta
 	alt?: string
-	cropType?: CropType
 	willHaveAlt?: WithAlt
 }
 
-type SanityProps<CropType> =
+type SanityProps =
 	| {
-			src: SanityImageData<CropType, "false"> | null | undefined
+			src: SanityImageData<"false"> | null | undefined
 			alt: string | undefined
 	  }
 	| {
-			src: SanityImageData<CropType, "true"> | null | undefined
+			src: SanityImageData<"true"> | null | undefined
 			// the alt should be provided by sanity
 			alt?: undefined
 	  }
 
-export type SanityImageProps =
-	| (SanityProps<"sanity"> & {
-			objectFit?: "contain" | "cover"
-			objectPosition?: undefined
-			loading?: "eager" | "lazy" | "default"
-			width: number
-			height: number
-	  } & DefaultImageProps)
-	| (SanityProps<"uncropped"> & {
-			objectFit?: undefined
-			objectPosition?: undefined
-			loading?: "eager" | "lazy" | "default"
-			width?: undefined
-			height?: undefined
-	  } & DefaultImageProps)
-	| (SanityProps<"css"> & {
-			objectFit?: "contain" | "cover"
-			objectPosition?: string
-			loading?: "eager" | "lazy" | "default"
-			width?: number
-			height?: number
-	  } & DefaultImageProps)
+export type SanityImageProps = SanityProps & {
+	objectFit?: "contain" | "cover"
+	loading?: "eager" | "lazy" | "default"
+	width?: number
+	height?: number
+} & DefaultImageProps
 
 const isStringProps = (
 	props: SanityImageProps | StaticImageProps,
@@ -87,6 +70,18 @@ export default function SanityUniversalImage(
 
 	const { src, ...rest } = props
 	if (!src.asset) return null
+
+	const hasFixedDimensions = !!(props.width && props.height)
+
+	// When no fixed dimensions are provided, derive object-position from the
+	// hotspot focal point so CSS cropping (object-fit: cover) respects the
+	// editor's chosen subject. When dimensions are fixed, sanity-image bakes
+	// the hotspot into the URL via ?rect= instead.
+	const hotspotObjectPosition =
+		!hasFixedDimensions && src.hotspot?.x != null && src.hotspot?.y != null
+			? `${src.hotspot.x * 100}% ${src.hotspot.y * 100}%`
+			: undefined
+
 	return (
 		<DefaultSanityImage
 			{...rest}
@@ -100,15 +95,14 @@ export default function SanityUniversalImage(
 			id={src.asset?._ref}
 			mode={props.objectFit ?? "cover"}
 			objectFit={props.objectFit ?? "cover"}
+			objectPosition={hotspotObjectPosition}
 			projectId={projectId}
 			dataset={dataset}
 			queryParams={{
 				q: 90,
 			}}
 			aspectRatio={
-				props.width && props.height
-					? `${props.width}/${props.height}`
-					: undefined
+				hasFixedDimensions ? `${props.width}/${props.height}` : undefined
 			}
 		/>
 	)

--- a/sanity/reusables.tsx
+++ b/sanity/reusables.tsx
@@ -33,31 +33,14 @@ export const createSectionPreview = (image: StaticImageData) =>
 	)
 
 export const universalImage = <
-	CropType extends "css" | "sanity" | "uncropped" | undefined = undefined,
 	WithAlt extends boolean | undefined = undefined,
 >({
-	cropType,
 	withAlt,
 	...schemaField
 }: Omit<ImageDefinition, "type"> & {
 	/**
-	 * if we're cropping the image, how will we do it?
-	 *
-	 * `css` means we'll crop the image in the CSS.
-	 * this is the safest and easiest, but we don't get hotspots.
-	 * this is the default
-	 *
-	 * `sanity` means we'll crop the image at build time using sanity's CMS.
-	 * this gets us hotspots and cropping, but we have to specify the aspect ratio in our props.
-	 *
-	 * `uncropped` means we'll not crop the image at all.
-	 * this is ideal for images we won't know the size of, like inline blog images
-	 *
-	 * @default css
-	 */
-	cropType?: CropType
-	/**
-	 * if you need to omit the alt text field - sometimes it's not needed
+	 * Pass `false` to hide and skip validation on the alt text field.
+	 * Omit (or pass `true`) to show and require it.
 	 */
 	withAlt?: WithAlt
 }) =>
@@ -72,15 +55,6 @@ export const universalImage = <
 				rows: 2,
 				validation: withAlt === false ? undefined : (rule) => rule.required(),
 				hidden: withAlt === false,
-			}),
-			defineField({
-				type: "string",
-				name: "cropType",
-				options: {
-					list: [cropType ?? "css"],
-				},
-				hidden: true,
-				readOnly: true,
 			}),
 			defineField({
 				type: "string",
@@ -99,8 +73,7 @@ export const universalImage = <
 				imageDescriptionField: "alt",
 				...schemaField.options?.aiAssist,
 			},
-			// if we're manually cropping, we don't want hotspots (they will be ignored front-end)
-			hotspot: cropType && cropType !== "css",
+			hotspot: true,
 			...schemaField.options,
 		},
 		preview: {

--- a/videos/BackgroundVideo.tsx
+++ b/videos/BackgroundVideo.tsx
@@ -25,7 +25,6 @@ type SanityPosterImage = {
 	hotspot?: SanityImageHotspot
 	crop?: SanityImageCrop
 	alt?: string
-	cropType?: "sanity"
 	willHaveAlt?: "true"
 	data?: AssetMeta
 }


### PR DESCRIPTION
## Summary
- Removes the `cropType` distinction from the image system — all images now use CSS cropping (`object-fit`) with hotspot-derived `object-position`
- Simplifies callsites: no more `cropType="css"` / `cropType="sanity"` / `cropType="uncropped"` to think about
- Hotspot focal point is now automatically respected on all images without fixed dimensions

## Changes
- **`SanityImageData`** — drop `CropType` generic and `cropType` field
- **`SanityImageProps`** — collapse three union branches into one flat type
- **`SanityUniversalImage`** — derive `objectPosition` from hotspot `x/y` when no fixed dimensions are given; when dimensions are fixed, sanity-image handles cropping via `?rect=` URL params
- **`universalImage()`** — remove `cropType` param, enable `hotspot: true` by default, drop hidden `cropType` schema field
- **`BackgroundVideo`** — remove `cropType` from `SanityPosterImage` type

## Test plan
- [ ] Images with hotspot set in Studio render with correct focal point framing
- [ ] Images with explicit `width`/`height` still crop via URL params as before
- [ ] No TypeScript errors from removed `cropType` prop on existing callsites

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `cropType` and always apply CSS hotspot cropping in `SanityUniversalImage`
> - Removes the `cropType` generic and field from `SanityImageData`, `SanityProps`, and `SanityImageProps` in [SanityImage.tsx](https://github.com/reformcollective/library/pull/472/files#diff-59a4c4cb3eacb0e5a370aa0ec01497fbfbda9760d252ebe0d4062f0a14d51a92), replacing the three-way discriminated union with a single unified props shape.
> - When `width` and `height` are omitted, `SanityUniversalImage` now computes `objectPosition` from the Sanity hotspot `x`/`y` values and applies it with `object-fit: cover`. Fixed-dimension images skip this and rely on URL-based cropping.
> - The `universalImage` schema factory in [reusables.tsx](https://github.com/reformcollective/library/pull/472/files#diff-af3333fa4277abc21a3bd183fe4da894bee29450ff3eedc36778034f39822557) unconditionally enables hotspot editing and no longer writes a hidden `cropType` field to documents.
> - Behavioral Change: callers can no longer pass `objectPosition` or `cropType` props; any previously supplied `objectPosition` is silently ignored and hotspot-based positioning takes over.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d016779.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->