### PR TITLE
Asset meta tweak

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,173 @@
+# Reform Next Starter — Claude Notes
+
+## Project
+
+Marketing site starter built by Reform Collective. Next.js app router, Sanity CMS, TypeScript.
+
+## Package Manager
+
+`pnpm` only. Never use npm or yarn.
+
+## Styling System
+
+Import `css`, `f`, `styled` from `"library/styled/alpha"`.
+
+`css` is just `String.raw` — a tagged template literal for CSS strings.
+
+`styled(tag, [StyleRules])` wraps any HTML tag or component with scoped styles. Always use the array `[]` form. this can be either the standard array form or the version using base: []. Always wrap CSS with an `f.*` function — never pass a bare `css` string directly unless specifically asked by the human.
+
+`f` converts px values from the design file into fluid responsive values automatically. Available utilities:
+
+- `f.responsive` — all breakpoints (mobile → tablet → desktop → fullWidth). Use this by default.
+- `f.small` — mobile + tablet only
+- `f.large` — desktop + fullWidth only
+- `f.desktop` / `f.tablet` / `f.mobile` — single breakpoint
+- `f.allDesktop` — all breakpoints, desktop design size
+- `f.unresponsive` — passes CSS through with no transformation
+
+Write px values as they appear in Figma — the system converts them. Styled components go at the bottom of the file.
+
+Colors: `import { colors } from "app/styles/colors.css"` → use as `${colors.blog1Evergreen800}`
+Text styles: `import textStyles from "app/styles/text"` → use as `${textStyles.p4}`
+
+Never use inline styles.
+
+Always use modern CSS color notation: `rgb(0 0 0 / 80%)` — never `rgba(0, 0, 0, 0.8)` or `rgba`.
+
+## useMedia
+
+`import { useMedia } from "library/useMedia"`
+
+Argument order: `useMedia(fullWidth, desktop, tablet, mobile)`
+
+`f.small` encompasses mobile + tablet. `useMedia(false, false, true, true)` is the JS equivalent — anything styled with `f.small` behaves the same across both breakpoints (mobile values are scaled up proportionally on tablet). So a single `responsive = useMedia(false, false, true, true)` check is sufficient to branch between desktop and f.small behavior.
+
+## Animations (GSAP)
+
+- `import { useAnimation } from "library/useAnimation"`
+- Register plugins at file top: `gsap.registerPlugin(MorphSVGPlugin)`
+- `useAnimation(createFn, deps, options?)` — handles context, cleanup, HMR, Lenis integration
+  - `createFn` receives `{ context, contextSafe }` — use `contextSafe` to wrap GSAP event handlers
+  - Return a cleanup function from `createFn` for event listeners and manual kills
+  - `options.scope` — `RefObject<Element>` for GSAP context scope
+  - `options.recreateOnResize` — recreate animations on resize
+  - `options.updateBehavior` — `"kill" | "revert" | "none"` (default: `"revert"`)
+  - `options.unmountBehavior` — `"kill" | "revert" | "none"` (default: `"kill"`)
+- Only runs client-side after hydration — safe to use refs directly
+
+## Components
+
+- `"use client"` required for any file using GSAP, refs, or event listeners
+- `.inline.svg` files are imported as React components via SVGR
+- Raster images use `StaticImage` from `"library/StaticImage"`
+- The `images/` alias (`app/images/`) is for global assets only — brand marks, icons, SVGs used across multiple components
+- Component-specific images live next to the component: convert `Hero.tsx` to `Hero/index.tsx` and place images alongside it (or in `Hero/images/` if there are many). Import them with relative paths.
+
+## Library
+
+`library/` is a git submodule shared across projects. We have full control over it and can make changes via PRs. Be careful when modifying it since changes affect other projects, but don't treat it as off-limits.
+
+## Linter
+
+`oxfmt` runs on save and may reformat files. Always re-read a file before editing if it may have changed since the last read.
+
+## Editing Files
+
+This codebase uses tabs for indentation. The Edit tool's `old_string` matching is sensitive to exact whitespace. If an Edit fails to match, use Write to rewrite the whole file rather than retrying with adjusted indentation — retrying Edit rarely works and wastes time.
+
+## Git
+
+Never auto-commit. Never amend without being asked.
+
+## Working Style
+
+Do exactly what is asked. No extra refactors, comments, or features. Implement directly when asked — don't restate the plan first.
+
+- If confidence in a solution is below ~100%, say so upfront. Don't spend tokens on an approach that likely won't work — ask a clarifying question or flag the uncertainty first.
+- Prefer attempting a solution and iterating based on real results over pre-emptive "but what if..." hedging. Try it, then adjust.
+- Before using any existing component, grep for real call sites in the codebase and read one — don't rely solely on the component definition. The definition shows what props exist; actual usage shows the correct calling convention.
+
+## Blog Templates
+
+This starter contains multiple blog template presets housed in `app/(blog-templates)/(blog-template-1)/[blogSlug]/`, etc. and matching Sanity schemas in `sanity/schemas/blog/blog-1/`, etc.
+
+The public URL for each blog is driven by the hub singleton slug in Sanity — no route folder renaming is needed.
+
+Full adoption instructions are in `sanity/schemas/blog/blog-1/README.md`.
+
+**To adopt a template for a project:**
+
+1. Set the hub slug in Sanity Studio — this controls the public URL
+2. Replace `blog1*` placeholder colors in `app/styles/colors.css.ts` with project brand colors
+3. Update the grid values in `app/(blog-templates)/(blog-template-1)/[blogSlug]/layout.tsx` to match the design
+4. Delete unused template folders under `app/(blog-templates)/` and `sanity/schemas/blog/`
+
+## Image Co-location
+
+The `app/images/` folder (aliased as `images/*`) is for **global assets only** — brand marks, icons, and SVGs used across multiple components.
+
+Images that belong to a specific component or section should live next to that component, not in `app/images/`.
+
+### Structure
+
+If a component or section has its own images, convert it from a single file to a folder:
+
+```
+sections/
+  Hero/
+    index.tsx        ← was Hero.tsx
+    hero-bg.jpg      ← co-located image
+    diagram.svg
+
+  Sample.tsx         ← no images, stays a single file
+```
+
+If a component needs many images, group them in an `images/` subfolder:
+
+```
+sections/
+  Hero/
+    index.tsx
+    images/
+      bg-desktop.jpg
+      bg-mobile.jpg
+      diagram.svg
+```
+
+### Importing
+
+Co-located images use relative imports:
+
+```ts
+import HeroBg from "./hero-bg.jpg"
+import HeroBg from "./images/bg-desktop.jpg"
+```
+
+Global images use the `images/` alias:
+
+```ts
+import LogoMark from "images/LogoMark.svg"
+import ArrowIcon from "images/icons/Arrow.inline.svg"
+```
+
+## Sanity Image Queries
+
+Any image field in a GROQ query that will be rendered with `SanityImage` / `UniversalImage` must include an inline `data` projection for LQIP and aspect ratio. `enrichAssets` defaults to `false` — do not rely on post-query enrichment.
+
+```groq
+mainImage {
+  ...,
+  "data": {
+    "lqip": asset->metadata.lqip,
+    "aspectRatio": asset->metadata.dimensions.aspectRatio
+  }
+}
+```
+
+This applies to every image field in every query — `mainImage`, `image`, `photo`, etc. — wherever the result is passed to `SanityImage` / `UniversalImage`.
+
+If inline projection is not feasible for a specific call-site, you can opt into legacy post-query enrichment as a temporary measure by passing `enrichAssets: true` to `sanityFetch`. This is deprecated and should not be used for new code.
+
+```ts
+const { data } = await sanityFetch({ query, enrichAssets: true })
+```

--- a/sanity/SanityImage.tsx
+++ b/sanity/SanityImage.tsx
@@ -92,7 +92,7 @@ export default function SanityUniversalImage(
 			{...rest}
 			alt={stegaClean(rest.alt ?? src.alt)}
 			loading={prioritizedLoading}
-			preview={src.data?.lqip}
+			preview={src.data?.lqip ?? undefined}
 			// @ts-expect-error library type mismatch
 			hotspot={src.hotspot}
 			// @ts-expect-error library type mismatch

--- a/sanity/assetMetadata.ts
+++ b/sanity/assetMetadata.ts
@@ -46,20 +46,20 @@ const linkSchema = z.object({
 })
 
 type VideoAssetMeta = {
-	playbackId: string | undefined
-	videoThumbnailUrl: string | undefined
-	videoBlurUrl: string | undefined
-	videoAspectRatio: string | undefined
-	videoDuration: number | undefined
+	playbackId?: string | null
+	videoThumbnailUrl?: string | null
+	videoBlurUrl?: string | null
+	videoAspectRatio?: string | null
+	videoDuration?: number | null
 }
 type ImageAssetMeta = {
-	lqip: string | undefined
-	dominantColor: string | undefined
-	originalFilename: string | undefined
-	size: number | undefined
-	extension: string | undefined
-	url: string | undefined
-	aspectRatio: number | undefined
+	lqip?: string | null
+	dominantColor?: string | null
+	originalFilename?: string | null
+	size?: number | null
+	extension?: string | null
+	url?: string | null
+	aspectRatio?: number | null
 }
 
 export type AssetMeta = VideoAssetMeta & ImageAssetMeta

--- a/videos/VideoEmbed.tsx
+++ b/videos/VideoEmbed.tsx
@@ -16,7 +16,12 @@ type VideoEmbedProps = Omit<
 	ref?: React.Ref<HTMLVideoElement>
 	className?: string
 	video: Omit<DeepAssetMeta<Video>, "muxVideo"> & {
-		muxVideo?: { data?: { playbackId?: string | null; videoThumbnailUrl?: string | null } | null } | null
+		muxVideo?: {
+			data?: {
+				playbackId?: string | null
+				videoThumbnailUrl?: string | null
+			} | null
+		} | null
 	}
 	controls?: boolean
 	/** When true, seeks to 0 each time playback starts */

--- a/videos/VideoEmbed.tsx
+++ b/videos/VideoEmbed.tsx
@@ -15,13 +15,15 @@ type VideoEmbedProps = Omit<
 > & {
 	ref?: React.Ref<HTMLVideoElement>
 	className?: string
-	video: DeepAssetMeta<Video>
+	video: Omit<DeepAssetMeta<Video>, "muxVideo"> & {
+		muxVideo?: { data?: { playbackId?: string | null; videoThumbnailUrl?: string | null } | null } | null
+	}
 	controls?: boolean
 	/** When true, seeks to 0 each time playback starts */
 	resetOnPlay?: boolean
 }
 
-function getVideoSrc(video: DeepAssetMeta<Video>) {
+function getVideoSrc(video: VideoEmbedProps["video"]) {
 	if (stegaClean(video.sourceType) === "mux") {
 		const playbackId = video.muxVideo?.data?.playbackId
 		return {


### PR DESCRIPTION
update Asset Meta to work with starter.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix asset metadata type definitions to allow null values for image and video fields
> - Updates `VideoAssetMeta` and `ImageAssetMeta` in [assetMetadata.ts](https://github.com/reformcollective/library/pull/474/files#diff-21a1b0cf75903ec16dfab0236a2aae247d372e72ae08fc09cdeaef578cbc34b8) to mark fields as optional with `T | null` types instead of required `T | undefined`, aligning types with actual Sanity API responses.
> - Narrows the `video` prop type in [VideoEmbed.tsx](https://github.com/reformcollective/library/pull/474/files#diff-042b97c622f16cc850f109bc9e3adcb3693d911d3226374851c7b8e91bc96da4) so `muxVideo` and its nested fields (`playbackId`, `videoThumbnailUrl`) are explicitly optional and nullable.
> - Coerces null `lqip` values to `undefined` in [SanityImage.tsx](https://github.com/reformcollective/library/pull/474/files#diff-59a4c4cb3eacb0e5a370aa0ec01497fbfbda9760d252ebe0d4062f0a14d51a92) so the `preview` prop is omitted rather than passed as `null`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #474 opened
>
> - Added documentation for asset management conventions including image handling strategies and import patterns [e2f272e]
> - Added documentation for styling system conventions including component styling and responsive design [e2f272e]
> - Added documentation for development tooling and workflow conventions [e2f272e]
> - Added documentation for CMS integration conventions with Sanity [e2f272e]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9428f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->