### PR TITLE
Removing `<body>` from a comment. To remove potential false positive …

### DIFF
--- a/reset.tsx
+++ b/reset.tsx
@@ -172,7 +172,7 @@ const style = css`
 			border-collapse: collapse;
 		}
 
-		/* Safari - solving issue when using user-select:none on the <body> text input doesn't working */
+		/* Safari - solving issue when using user-select:none on the body element, text input doesn't working */
 		input,
 		textarea {
 			-webkit-user-select: auto;


### PR DESCRIPTION
…from an SEO tool

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `<body>` tag from comment in reset.tsx to avoid false positives
> Updates a comment in [reset.tsx](https://github.com/reformcollective/library/pull/475/files#diff-bd3b44933e38358d4601e24d3ac08e92737286977b818b00315d58af0950bd1d) to replace the literal `<body>` tag reference with plain text, avoiding potential false positives from HTML parsers or linters that may interpret the tag as markup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a84bfe3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->