### PR TITLE
init

### DIFF
--- a/sanity/singletonPlugin.tsx
+++ b/sanity/singletonPlugin.tsx
@@ -3,7 +3,7 @@
  */
 
 import { type DocumentDefinition, definePlugin } from "sanity"
-import type { StructureResolver } from "sanity/structure"
+import type { ListItemBuilder, StructureBuilder, StructureResolver } from "sanity/structure"
 
 export const singletonPlugin = definePlugin((types: string[]) => {
 	return {
@@ -32,10 +32,16 @@ export const singletonPlugin = definePlugin((types: string[]) => {
 	}
 })
 
+type GroupItem = {
+	item: (S: StructureBuilder) => ListItemBuilder
+	hiddenTypes: string[]
+}
+
 // The StructureResolver is how we're changing the DeskTool structure to linking to document (named Singleton)
 // like how "Home" is handled.
 export const pageStructure = (
 	typeDefArray: DocumentDefinition[],
+	groups?: GroupItem[],
 ): StructureResolver => {
 	return (S) => {
 		// Goes through all of the singletons that were provided and translates them into something the
@@ -52,10 +58,14 @@ export const pageStructure = (
 				)
 		})
 
+		const hiddenTypes = [
+			...typeDefArray.map((s) => s.name),
+			...(groups?.flatMap((g) => g.hiddenTypes) ?? []),
+		]
+
 		// The default root list items (except custom ones)
 		const nonSingletonItems = S.documentTypeListItems().filter(
-			(listItem) =>
-				!typeDefArray.find((singleton) => singleton.name === listItem.getId()),
+			(listItem) => !hiddenTypes.includes(listItem.getId() ?? ""),
 		)
 		const middleItems = ["media.tag", "assist.instruction.context"]
 			.map((id) => nonSingletonItems.find((item) => item.getId() === id))
@@ -68,10 +78,13 @@ export const pageStructure = (
 			(item) => !middleItems.includes(item) && !hiddenItems.includes(item),
 		)
 
+		const groupItems = groups?.map((g) => g.item(S)) ?? []
+
 		return S.list()
 			.title("Content Types")
 			.items([
 				...singletonItems,
+				...groupItems,
 				S.divider(),
 				...middleItems,
 				S.divider(),

--- a/sanity/singletonPlugin.tsx
+++ b/sanity/singletonPlugin.tsx
@@ -3,7 +3,11 @@
  */
 
 import { type DocumentDefinition, definePlugin } from "sanity"
-import type { ListItemBuilder, StructureBuilder, StructureResolver } from "sanity/structure"
+import type {
+	ListItemBuilder,
+	StructureBuilder,
+	StructureResolver,
+} from "sanity/structure"
 
 export const singletonPlugin = definePlugin((types: string[]) => {
 	return {


### PR DESCRIPTION
Moving Blog Singleton to library. 

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add group support to `pageStructure` in the singleton plugin
> - Extends `pageStructure` in [singletonPlugin.tsx](https://github.com/reformcollective/library/pull/478/files#diff-2e779049e887021e9fb35738a544e7e1fd95c254fd2a13cf41fd39576663a2f6) to accept an optional `groups` array, where each entry pairs a list item builder function with an array of schema type names to hide.
> - Computes a combined `hiddenTypes` set from both singleton type names and group-provided hidden types, broadening the exclusion filter on the default document list.
> - Inserts the built group list items into the desk structure immediately after singleton items.
> - Behavioral Change: when groups are provided, more schema types are hidden from the default document list than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7f738b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->