### PR TITLE
Trim default f utility surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,90 @@
 
+# 2026-04-17
+
+## Removed extra built-in `f.*` utilities
+
+The default `f` utility surface is now limited to:
+
+- `f.responsive`
+- `f.unresponsive`
+- `f.fullWidth`
+- `f.desktop`
+- `f.tablet`
+- `f.mobile`
+- `f.large`
+- `f.small`
+
+The older built-ins `f.scaledResponsive`, `f.allFullWidth`, `f.allDesktop`, `f.allTablet`, and `f.allMobile` are no longer provided by default.
+
+If you want additional utilities, add them in `app/libraryConfig.ts` under `utilities`. These custom utilities are merged into the default `f` set.
+
+**Migration Advice**
+
+If you were using the removed built-ins, paste this into `app/libraryConfig.ts` to restore the previous behavior:
+
+```ts
+import { defineLibraryConfig } from "library/defaultConfig"
+
+const tabletBreakpoint = "largeMobile" as const
+
+const tabletRule =
+	tabletBreakpoint === "tablet"
+		? { breakpoint: "tablet", designSize: "tablet", output: "fluid" }
+		: { breakpoint: "tablet", designSize: "mobile", output: "pixel" }
+
+export default defineLibraryConfig({
+	tabletBreakpoint,
+	utilities: {
+		scaledResponsive: [
+			{ breakpoint: "mobile", designSize: "mobile", output: "fluid" },
+			tabletRule,
+			{ breakpoint: "desktop", designSize: "desktop", output: "fluid" },
+			{ breakpoint: "fullWidth", designSize: "desktop", output: "fluid" },
+		],
+		allFullWidth: [
+			{
+				breakpoint: "mobile",
+				designSize: "desktop",
+				output: "scaleFullyConfig",
+			},
+			{
+				breakpoint: "tablet",
+				designSize: "desktop",
+				output: "scaleFullyConfig",
+			},
+			{
+				breakpoint: "desktop",
+				designSize: "desktop",
+				output: "scaleFullyConfig",
+			},
+			{
+				breakpoint: "fullWidth",
+				designSize: "desktop",
+				output: "scaleFullyConfig",
+			},
+		],
+		allDesktop: [
+			{ breakpoint: "mobile", designSize: "desktop", output: "fluid" },
+			{ breakpoint: "tablet", designSize: "desktop", output: "fluid" },
+			{ breakpoint: "desktop", designSize: "desktop", output: "fluid" },
+			{ breakpoint: "fullWidth", designSize: "desktop", output: "fluid" },
+		],
+		allTablet: [
+			{ ...tabletRule, breakpoint: "mobile" },
+			{ ...tabletRule, breakpoint: "tablet" },
+			{ ...tabletRule, breakpoint: "desktop" },
+			{ ...tabletRule, breakpoint: "fullWidth" },
+		],
+		allMobile: [
+			{ breakpoint: "mobile", designSize: "mobile", output: "fluid" },
+			{ breakpoint: "tablet", designSize: "mobile", output: "fluid" },
+			{ breakpoint: "desktop", designSize: "mobile", output: "fluid" },
+			{ breakpoint: "fullWidth", designSize: "mobile", output: "fluid" },
+		],
+	},
+})
+```
+
 # 2026-04-16
 
 ## Removed legacy styled system

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,11 +19,13 @@ Import `css`, `f`, `styled` from `"library/styled"`.
 `f` converts px values from the design file into fluid responsive values automatically. Available utilities:
 
 - `f.responsive` — all breakpoints (mobile → tablet → desktop → fullWidth). Use this by default.
+- `f.unresponsive` — passes CSS through with no transformation
+- `f.fullWidth` — full width only
 - `f.small` — mobile + tablet only
 - `f.large` — desktop + fullWidth only
 - `f.desktop` / `f.tablet` / `f.mobile` — single breakpoint
-- `f.allDesktop` — all breakpoints, desktop design size
-- `f.unresponsive` — passes CSS through with no transformation
+
+If you need extra `f.*` utilities beyond that default set, define them in `app/libraryConfig.ts` under `utilities`.
 
 Write px values as they appear in Figma — the system converts them. Styled components go at the bottom of the file.
 

--- a/defaultConfig.ts
+++ b/defaultConfig.ts
@@ -3,9 +3,25 @@
  * see libraryConfig.ts for the actual config
  */
 
-type Config<TransitionNames = never, GroupNames = never> = {
+export type Breakpoint = "mobile" | "tablet" | "desktop" | "fullWidth"
+export type DesignSize = "mobile" | "tablet" | "desktop"
+export type UtilityOutput = "fluid" | "pixel" | "scaleFullyConfig"
+
+export type BreakpointRule = {
+	breakpoint: Breakpoint
+	designSize: DesignSize
+	output: UtilityOutput
+}
+
+export type UtilityConfig = Record<string, readonly BreakpointRule[]>
+
+type Config<
+	TransitionNames = never,
+	GroupNames = never,
+	Utilities extends UtilityConfig = {},
+> = {
 	/**
-	 * if true, the fresponsive util will scale on fullWidth breakpoints
+	 * if true, f.responsive will scale on fullWidth breakpoints
 	 */
 	scaleFully: boolean
 	/**
@@ -40,6 +56,10 @@ type Config<TransitionNames = never, GroupNames = never> = {
 	 * in most cases you won't want to use this
 	 */
 	overridePreloaderResolvers?: boolean
+	/**
+	 * additional responsive utilities to merge into the default f.* set
+	 */
+	utilities: Utilities
 }
 
 const defaultConfig = {
@@ -51,11 +71,28 @@ const defaultConfig = {
 	pageSectionGroups: [],
 	vanillaExtractEngine: "calc",
 	overridePreloaderResolvers: false,
+	utilities: {},
 } as const satisfies Config
 
-export const defineLibraryConfig = <const TransitionNames, const GroupNames>(
-	config: Partial<Config<TransitionNames, GroupNames>>,
-): Config<TransitionNames, GroupNames> => ({
-	...defaultConfig,
-	...config,
-})
+type ConfigInput<
+	TransitionNames,
+	GroupNames,
+	Utilities extends UtilityConfig,
+> = Partial<
+	Omit<Config<TransitionNames, GroupNames, Utilities>, "utilities">
+> & {
+	utilities?: Utilities
+}
+
+export const defineLibraryConfig = <
+	const TransitionNames,
+	const GroupNames,
+	const Utilities extends UtilityConfig = {},
+>(
+	config: ConfigInput<TransitionNames, GroupNames, Utilities>,
+): Config<TransitionNames, GroupNames, Utilities> =>
+	({
+		...defaultConfig,
+		...config,
+		utilities: config.utilities ?? defaultConfig.utilities,
+	}) as Config<TransitionNames, GroupNames, Utilities>

--- a/styled/README.md
+++ b/styled/README.md
@@ -101,6 +101,17 @@ const Card = styled("article", {
 
 the `f` object is your best friend. it handles unit conversion (px to vw), breakpoint isolation, and fluid scaling logic.
 
+default built-ins:
+
+- `f.responsive(...)`
+- `f.unresponsive(...)`
+- `f.fullWidth(...)`
+- `f.desktop(...)`
+- `f.tablet(...)`
+- `f.mobile(...)`
+- `f.large(...)`
+- `f.small(...)`
+
 ### `f.responsive` (the magic one)
 
 takes standard css with pixel values and converts them into a responsive `calc()` expression that switches based on the viewport.
@@ -125,9 +136,22 @@ target specific ranges. these wrap your styles in `@media` queries.
 - `f.small(...)`: mobile + tablet
 - `f.large(...)`: desktop + full width
 
-### `f.scaledResponsive`
+### custom utilities via `app/libraryConfig.ts`
 
-forces `vw` scaling across _all_ breakpoints, ignoring the step-based switching of standard responsive mode.
+if you want project-specific `f.*` helpers, add them in `app/libraryConfig.ts`:
+
+```ts
+import { defineLibraryConfig } from "library/defaultConfig"
+
+export default defineLibraryConfig({
+	utilities: {
+		marketingOnly: [
+			{ breakpoint: "desktop", designSize: "desktop", output: "fluid" },
+			{ breakpoint: "fullWidth", designSize: "desktop", output: "fluid" },
+		],
+	},
+})
+```
 
 ---
 

--- a/styled/styled-gen.test-d.tsx
+++ b/styled/styled-gen.test-d.tsx
@@ -1,5 +1,5 @@
 import { style } from "@vanilla-extract/css"
-import { styled } from "library/styled"
+import { f, styled } from "library/styled"
 import { Component, type ComponentProps, type FC } from "react"
 import { expectTypeOf, test } from "vitest"
 
@@ -8,6 +8,20 @@ test("vanilla extract should be strict", () => {
 		// @ts-expect-error not a css property
 		skibidi: "toilet",
 	})
+})
+
+test("default f utility surface is intentionally small", () => {
+	expectTypeOf(f.responsive).toBeFunction()
+	expectTypeOf(f.unresponsive).toBeFunction()
+	expectTypeOf(f.fullWidth).toBeFunction()
+	expectTypeOf(f.desktop).toBeFunction()
+	expectTypeOf(f.tablet).toBeFunction()
+	expectTypeOf(f.mobile).toBeFunction()
+	expectTypeOf(f.large).toBeFunction()
+	expectTypeOf(f.small).toBeFunction()
+
+	// @ts-expect-error not part of the api surface
+	f.skibidiToilet("")
 })
 
 test("basic component type is preserved", () => {

--- a/styled/vanilla.ts
+++ b/styled/vanilla.ts
@@ -9,6 +9,12 @@ import {
 	tabletBreakpoint,
 	tabletDesignSize,
 } from "app/styles/media"
+import type {
+	Breakpoint,
+	BreakpointRule,
+	DesignSize,
+	UtilityConfig,
+} from "../defaultConfig"
 import { isBrowser } from "../deviceDetection"
 import { isDesktop, isFull, isMobile, isTablet } from "./breakpoints.css"
 
@@ -21,18 +27,10 @@ if (isBrowser && process.env.NODE_ENV === "development")
 // Types
 // =============================================================================
 
-type Breakpoint = "mobile" | "tablet" | "desktop" | "fullWidth"
-type DesignSize = "mobile" | "tablet" | "desktop"
 type BreakpointCombo = "small" | "large" | "all"
 
 type OutputType = "fluid" | "pixel" | "scaleFullyConfig"
 type ResponsiveEngine = "calc" | "media"
-
-type BreakpointRule = {
-	breakpoint: Breakpoint
-	designSize: DesignSize
-	output: OutputType
-}
 
 type FOptions = {
 	engine?: ResponsiveEngine
@@ -55,7 +53,7 @@ const TABLET_RULE: BreakpointRule =
 		? { breakpoint: "tablet", designSize: "tablet", output: "fluid" }
 		: { breakpoint: "tablet", designSize: "mobile", output: "pixel" }
 
-const UTILITIES = {
+const DEFAULT_UTILITIES = {
 	responsive: [
 		{ breakpoint: "mobile", designSize: "mobile", output: "fluid" },
 		TABLET_RULE,
@@ -65,13 +63,6 @@ const UTILITIES = {
 			designSize: "desktop",
 			output: "scaleFullyConfig",
 		},
-	],
-
-	scaledResponsive: [
-		{ breakpoint: "mobile", designSize: "mobile", output: "fluid" },
-		TABLET_RULE,
-		{ breakpoint: "desktop", designSize: "desktop", output: "fluid" },
-		{ breakpoint: "fullWidth", designSize: "desktop", output: "fluid" },
 	],
 
 	large: [
@@ -101,43 +92,12 @@ const UTILITIES = {
 	tablet: [TABLET_RULE],
 
 	mobile: [{ breakpoint: "mobile", designSize: "mobile", output: "fluid" }],
+} satisfies UtilityConfig
 
-	allFullWidth: [
-		{ breakpoint: "mobile", designSize: "desktop", output: "scaleFullyConfig" },
-		{ breakpoint: "tablet", designSize: "desktop", output: "scaleFullyConfig" },
-		{
-			breakpoint: "desktop",
-			designSize: "desktop",
-			output: "scaleFullyConfig",
-		},
-		{
-			breakpoint: "fullWidth",
-			designSize: "desktop",
-			output: "scaleFullyConfig",
-		},
-	],
-
-	allDesktop: [
-		{ breakpoint: "mobile", designSize: "desktop", output: "fluid" },
-		{ breakpoint: "tablet", designSize: "desktop", output: "fluid" },
-		{ breakpoint: "desktop", designSize: "desktop", output: "fluid" },
-		{ breakpoint: "fullWidth", designSize: "desktop", output: "fluid" },
-	],
-
-	allTablet: [
-		{ ...TABLET_RULE, breakpoint: "mobile" },
-		{ ...TABLET_RULE, breakpoint: "tablet" },
-		{ ...TABLET_RULE, breakpoint: "desktop" },
-		{ ...TABLET_RULE, breakpoint: "fullWidth" },
-	],
-
-	allMobile: [
-		{ breakpoint: "mobile", designSize: "mobile", output: "fluid" },
-		{ breakpoint: "tablet", designSize: "mobile", output: "fluid" },
-		{ breakpoint: "desktop", designSize: "mobile", output: "fluid" },
-		{ breakpoint: "fullWidth", designSize: "mobile", output: "fluid" },
-	],
-} satisfies Record<string, BreakpointRule[]>
+const UTILITIES = {
+	...DEFAULT_UTILITIES,
+	...config.utilities,
+} as const satisfies UtilityConfig
 
 // =============================================================================
 // Config
@@ -238,7 +198,7 @@ const computeResponsiveValue = (
 }
 
 const getBreakpointCombo = (
-	rules: BreakpointRule[],
+	rules: readonly BreakpointRule[],
 ): BreakpointCombo | null => {
 	const breakpoints = new Set(rules.map((r) => r.breakpoint))
 	if (breakpoints.size === 4) return "all"
@@ -250,7 +210,7 @@ const getBreakpointCombo = (
 	return null
 }
 
-const hasUniformOutput = (rules: BreakpointRule[]): boolean =>
+const hasUniformOutput = (rules: readonly BreakpointRule[]): boolean =>
 	rules.every(
 		(r) =>
 			r.designSize === rules[0]?.designSize && r.output === rules[0]?.output,
@@ -314,7 +274,7 @@ const toInjectedStyleRule = (cssText: string): StyleRule => ({
 
 const getCalcExpression = (
 	px: number,
-	rules: BreakpointRule[],
+	rules: readonly BreakpointRule[],
 	options?: FOptions,
 ): string => {
 	const uniform = hasUniformOutput(rules)
@@ -332,7 +292,7 @@ const getCalcExpression = (
 
 const wrapWithMediaQueries = (
 	cssText: string,
-	rules: BreakpointRule[],
+	rules: readonly BreakpointRule[],
 ): string => {
 	const combo = getBreakpointCombo(rules)
 
@@ -350,7 +310,7 @@ const wrapWithMediaQueries = (
 
 const calcEngine = (
 	cssText: string,
-	rules: BreakpointRule[],
+	rules: readonly BreakpointRule[],
 	options?: FOptions,
 ): string => {
 	const ast = parseWrappedCss(cssText)
@@ -367,7 +327,7 @@ const calcEngine = (
 
 const mediaEngine = (
 	cssText: string,
-	rules: BreakpointRule[],
+	rules: readonly BreakpointRule[],
 	options?: FOptions,
 ): string => {
 	const ast = parseWrappedCss(cssText)
@@ -399,7 +359,7 @@ const mediaEngine = (
 
 const generateStyle = (
 	cssText: string,
-	rules: BreakpointRule[],
+	rules: readonly BreakpointRule[],
 	options?: FOptions,
 ): StyleRule => {
 	const engine = options?.engine ?? DEFAULT_ENGINE


### PR DESCRIPTION
## Summary
- reduce the default `f` built-ins to the supported core utility set
- allow projects to add extra `f.*` utilities through `app/libraryConfig.ts`
- document the breaking change and include a ready-to-paste migration snippet

## Validation
- pnpm --filter ./library test
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trim default `f` utility surface and support custom utilities via config
> - Reduces the default `f.*` utilities to: `responsive`, `unresponsive`, `fullWidth`, `desktop`, `tablet`, `mobile`, `large`, and `small`. Removes `scaledResponsive`, `allDesktop`, `allTablet`, `allMobile`, and `allFullWidth` from the default set.
> - Adds a `utilities` field to `defineLibraryConfig` in [defaultConfig.ts](https://github.com/reformcollective/library/pull/480/files#diff-ad501c6efd0360fbcb653a7ecc86ca2d64525d3d4608c23e0fd8bff961099aef), allowing apps to define custom `f.*` utilities in `app/libraryConfig.ts` that are merged into the available set.
> - Adds type-level tests in [styled/styled-gen.test-d.tsx](https://github.com/reformcollective/library/pull/480/files#diff-fd52e71eeca02803303add5934ec61a2e9c6f614c11f8cb9dbdbd33bba7dfc1a) to enforce the intended default surface.
> - Behavioral Change: any code using removed utilities (`scaledResponsive`, `allDesktop`, etc.) will break; they must be restored via `app/libraryConfig.ts` using the migration snippet in [CHANGELOG.md](https://github.com/reformcollective/library/pull/480/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ad3ae8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->