### PR TITLE
use standalone pnpm in workflows

### DIFF
--- a/.github/workflows/check-this-repo.yml
+++ b/.github/workflows/check-this-repo.yml
@@ -7,15 +7,16 @@ jobs:
   Check_Linting:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
           submodules: recursive
-      - uses: pnpm/action-setup@v4
+          lfs: true
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: true
+          cache: true
+          standalone: true
       - name: Lint
         run: pnpm run lint
         continue-on-error: true

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -22,21 +22,16 @@ jobs:
         uses: oNaiPs/secrets-to-env-action@v1.5
         with:
           secrets: ${{ secrets.SECRETS_JSON }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           lfs: true
-          fetch-depth: 0
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          run_install: false
-      - name: Ensure Git LFS objects are present
-        run: |
-          git lfs install --local
-          git lfs pull || true
-      - name: Install dependencies
-        run: pnpm install || echo 'Looks like your lockfile is out of date. Run "pnpm install" to fix it.'
+          run_install: true
+          cache: true
+          standalone: true
       - run: pnpm run lint
         continue-on-error: true
       - run: git status
@@ -58,11 +53,10 @@ jobs:
         uses: oNaiPs/secrets-to-env-action@v1.5
         with:
           secrets: ${{ secrets.SECRETS_JSON }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           lfs: true
-          fetch-depth: 0
       - uses: useblacksmith/cache@v5
         with:
           path: |
@@ -72,11 +66,12 @@ jobs:
           # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          run_install: false
-      - run: pnpm install
+          run_install: true
+          cache: true
+          standalone: true
       - run: pnpm run lint
       # running a build will also check types
       - run: pnpm run build

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -34,22 +34,16 @@ jobs:
           secrets: ${{ secrets.SECRETS_JSON }}
 
       # BEGIN INSTALLATION
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           lfs: true
-          fetch-depth: 0
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          run_install: false
-      - name: Ensure Git LFS objects are present
-        run: |
-          git lfs install --local
-          git lfs pull || true
-      - name: Install dependencies
-        if: github.event.action != 'closed'
-        run: pnpm install
+          run_install: true
+          cache: true
+          standalone: true
       - uses: useblacksmith/cache@v5
         with:
           path: |


### PR DESCRIPTION
so that we don't have to worry about which node version is installed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use standalone pnpm with caching in CI workflows
> Updates all three CI workflows to use `pnpm/action-setup@v6` with `standalone: true`, `cache: true`, and `run_install: true`, replacing separate `pnpm install` and Git LFS steps. Also upgrades `actions/checkout` from v4 to v6 across [check-this-repo.yml](.github/workflows/check-this-repo.yml), [code-checks.yml](.github/workflows/code-checks.yml), and [lighthouse.yml](.github/workflows/lighthouse.yml).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6100cbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->