### PR TITLE
tweak proxy revalidation

### DIFF
--- a/sanity/SanityLiveProxy.tsx
+++ b/sanity/SanityLiveProxy.tsx
@@ -1,8 +1,5 @@
 "use client"
 
-import type { LiveEvent } from "@sanity/client"
-import { useRouter } from "next/navigation"
-import { revalidateSyncTags } from "next-sanity/live/server-actions"
 import { useEffect } from "react"
 
 /**
@@ -12,22 +9,10 @@ import { useEffect } from "react"
  * - works event without CORS configuration (although you should still configure it for the studio)
  */
 export function SanityLiveProxy() {
-	const router = useRouter()
-
 	useEffect(() => {
 		const eventSource = new EventSource("/api/live")
-
-		eventSource.onmessage = (e) => {
-			const event = JSON.parse(e.data) as LiveEvent
-			if (event.type === "message") {
-				revalidateSyncTags(event.tags)
-			} else if (event.type === "restart" || event.type === "reconnect") {
-				router.refresh()
-			}
-		}
-
 		return () => eventSource.close()
-	}, [router])
+	}, [])
 
 	return null
 }

--- a/sanity/SanityLiveProxy.tsx
+++ b/sanity/SanityLiveProxy.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+import type { LiveEvent } from "@sanity/client"
+import { useRouter } from "next/navigation"
+import { revalidateSyncTags } from "next-sanity/live/server-actions"
 import { useEffect } from "react"
 
 /**
@@ -9,10 +12,22 @@ import { useEffect } from "react"
  * - works event without CORS configuration (although you should still configure it for the studio)
  */
 export function SanityLiveProxy() {
+	const router = useRouter()
+
 	useEffect(() => {
 		const eventSource = new EventSource("/api/live")
+
+		eventSource.onmessage = (e) => {
+			const event = JSON.parse(e.data) as LiveEvent
+			if (event.type === "message") {
+				revalidateSyncTags(event.tags)
+			} else if (event.type === "restart" || event.type === "reconnect") {
+				router.refresh()
+			}
+		}
+
 		return () => eventSource.close()
-	}, [])
+	}, [router])
 
 	return null
 }

--- a/sanity/liveProxy.ts
+++ b/sanity/liveProxy.ts
@@ -1,5 +1,6 @@
 // app/api/live/route.ts
 
+import { revalidateSyncTags } from "next-sanity/live/server-actions"
 import { client } from "sanity/lib/client"
 
 export const dynamic = "force-dynamic"
@@ -42,7 +43,11 @@ function startUpstreamSubscription() {
 	// what we want for public cache invalidation.
 	sanitySubscription = client.live.events().subscribe({
 		next: (event) => {
-			broadcast(JSON.stringify(event))
+			if (event.type === "message") {
+				revalidateSyncTags(event.tags)
+			} else {
+				broadcast(JSON.stringify(event))
+			}
 		},
 		error: (err) => {
 			console.error("Sanity upstream error:", err)

--- a/sanity/liveProxy.ts
+++ b/sanity/liveProxy.ts
@@ -45,9 +45,8 @@ function startUpstreamSubscription() {
 		next: (event) => {
 			if (event.type === "message") {
 				revalidateSyncTags(event.tags)
-			} else {
-				broadcast(JSON.stringify(event))
 			}
+			broadcast(JSON.stringify(event))
 		},
 		error: (err) => {
 			console.error("Sanity upstream error:", err)

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -1,5 +1,6 @@
 import { fetchAssetMeta } from "library/sanity/assetMetadata"
 import DraftModeOverlay from "library/sanity/DraftModeOverlay"
+import { siteURL } from "library/siteURL"
 import { draftMode } from "next/headers"
 import type { ClientPerspective, QueryParams } from "next-sanity"
 import { defineLive } from "next-sanity/live"
@@ -75,33 +76,34 @@ export async function libraryFetch<const QueryString extends string>({
 	}
 }
 
+const useProxyInDev = false
 const allowProxy =
 	// vercel has fluid compute baybeeee
 	// other providers should be tested and evaluated as needed
-	!!process.env.VERCEL
+	!!process.env.VERCEL ||
+	(process.env.NODE_ENV === "development" && useProxyInDev)
 
 export const LibraryLive = async () => {
 	const { isEnabled: isDraftMode } = await draftMode()
 
-	const useProxy = isDraftMode ? false : allowProxy
-
 	return (
-		<LiveWrapper>
+		<>
+			{allowProxy && <SanityLiveProxy />}
 			<Toaster />
-			{isDraftMode && <FirefoxFix />}
-			{isDraftMode && <DraftModeOverlay />}
-			{useProxy ? (
-				<SanityLiveProxy />
-			) : (
-				<InternalLive
-					onError={handleError}
-					refreshOnFocus={false}
-					refreshOnMount={true}
-					refreshOnReconnect={true}
-					intervalOnGoAway={false}
-				/>
+			{isDraftMode && (
+				<LiveWrapper>
+					<DraftModeOverlay />
+					<FirefoxFix />
+					<InternalLive
+						onError={handleError}
+						refreshOnFocus={false}
+						refreshOnMount={true}
+						refreshOnReconnect={true}
+						intervalOnGoAway={false}
+					/>
+				</LiveWrapper>
 			)}
-		</LiveWrapper>
+		</>
 	)
 }
 

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -102,8 +102,7 @@ export const LibraryLive = async () => {
 						refreshOnMount={true}
 						refreshOnReconnect={true}
 						intervalOnGoAway={false}
-
-          />
+					/>
 				)}
 			</LiveWrapper>
 		</>

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -80,33 +80,32 @@ export async function libraryFetch<const QueryString extends string>({
 	}
 }
 
-const useProxyInDev = false
-const allowProxy =
+const useProxy =
 	// vercel has fluid compute baybeeee
 	// other providers should be tested and evaluated as needed
-	!!process.env.VERCEL ||
-	(process.env.NODE_ENV === "development" && useProxyInDev)
+	!!process.env.VERCEL
 
 export const LibraryLive = async () => {
 	const { isEnabled: isDraftMode } = await draftMode()
 
 	return (
 		<>
-			{allowProxy && <SanityLiveProxy />}
+			{useProxy && <SanityLiveProxy />}
 			<Toaster />
-			{isDraftMode && (
-				<LiveWrapper>
-					<DraftModeOverlay />
-					<FirefoxFix />
+			{isDraftMode && <DraftModeOverlay />}
+			{isDraftMode && <FirefoxFix />}
+			<LiveWrapper>
+				{(isDraftMode || !useProxy) && (
 					<InternalLive
 						onError={handleError}
 						refreshOnFocus={false}
 						refreshOnMount={true}
 						refreshOnReconnect={true}
 						intervalOnGoAway={false}
-					/>
-				</LiveWrapper>
-			)}
+
+          />
+				)}
+			</LiveWrapper>
 		</>
 	)
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Tweak proxy revalidation to call `revalidateSyncTags` on live events and fix `SanityLiveProxy` rendering
- In [liveProxy.ts](https://github.com/reformcollective/library/pull/483/files#diff-244288ad1411977584a688fbc6b013763c32f4bf695471d37314a3c41959c6ab), calls `revalidateSyncTags(event.tags)` before broadcasting each `message` event received from the Sanity live event stream.
- In [reusableFetch.tsx](https://github.com/reformcollective/library/pull/483/files#diff-133b49b7bb8d0ef32f864830fdb361dabf4df3cce6c82c54835099255a9458aa), `SanityLiveProxy` now renders whenever `allowProxy` is true, including in draft mode (previously it was conditional on non-draft mode).
- `InternalLive` now only renders in draft mode; in non-draft mode with `allowProxy=false`, only `<Toaster/>` is rendered.
- Adds a `useProxyInDev` flag (default `false`) to enable the proxy path locally without setting `VERCEL`.

<!-- Macroscope's changelog starts here -->
#### Changes since #483 opened

- Modified `LibraryLive` component rendering logic to always render `LiveWrapper`, moved `DraftModeOverlay` and `FirefoxFix` to render independently when draft mode is active, and changed `InternalLive` to render when either draft mode is active or proxy is disabled [4548b3d]
- Replaced `useProxyInDev` and `allowProxy` configuration flags with single `useProxy` flag in `reusableFetch` that enables proxy behavior only when running on Vercel [4548b3d]
- Adjusted whitespace and indentation formatting around the `InternalLive` self-closing JSX tag within the `LibraryLive` React component [b45f5b1]
<!-- Macroscope's changelog ends here -->

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 675a8d0. 2 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues

</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->