### PR TITLE
tweak proxy revalidation v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,26 @@
 
+# 2026-04-21
+
+## Live proxy now requires POST to be exported
+
+`liveProxy.ts` now exports both `GET` (SSE) and `POST` (revalidation). The POST handler is how the proxy revalidates the Next.js Data Cache in a proper request context — without it, tag revalidation silently does nothing.
+
+**Migration Advice**
+
+If your `app/(sanity)/api/live/route.ts` explicitly forwards only `GET`:
+
+```ts
+// before
+export { GET } from "library/sanity/liveProxy"
+```
+
+Change it to re-export everything:
+
+```ts
+// after
+export * from "library/sanity/liveProxy"
+```
+
 # 2026-04-17
 
 ## Removed extra built-in `f.*` utilities

--- a/defaultConfig.ts
+++ b/defaultConfig.ts
@@ -18,7 +18,7 @@ export type UtilityConfig = Record<string, readonly BreakpointRule[]>
 type Config<
 	TransitionNames = never,
 	GroupNames = never,
-	Utilities extends UtilityConfig = {},
+	Utilities extends UtilityConfig = Record<string, never>,
 > = {
 	/**
 	 * if true, f.responsive will scale on fullWidth breakpoints
@@ -87,7 +87,7 @@ type ConfigInput<
 export const defineLibraryConfig = <
 	const TransitionNames,
 	const GroupNames,
-	const Utilities extends UtilityConfig = {},
+	const Utilities extends UtilityConfig = Record<string, never>,
 >(
 	config: ConfigInput<TransitionNames, GroupNames, Utilities>,
 ): Config<TransitionNames, GroupNames, Utilities> =>

--- a/sanity/SanityLiveProxy.tsx
+++ b/sanity/SanityLiveProxy.tsx
@@ -1,8 +1,5 @@
 "use client"
 
-import type { LiveEvent } from "@sanity/client"
-import { useRouter } from "next/navigation"
-import { revalidateSyncTags } from "next-sanity/live/server-actions"
 import { useEffect } from "react"
 
 /**
@@ -12,22 +9,10 @@ import { useEffect } from "react"
  * - works event without CORS configuration (although you should still configure it for the studio)
  */
 export function SanityLiveProxy() {
-	const router = useRouter()
-
 	useEffect(() => {
 		const eventSource = new EventSource("/api/live")
-
-		eventSource.onmessage = (e) => {
-			const event = JSON.parse(e.data) as LiveEvent
-			if (event.type === "message") {
-				revalidateSyncTags(event.tags)
-			} else if (event.type === "restart" || event.type === "reconnect") {
-				router.refresh()
-			}
-		}
-
 		return () => eventSource.close()
-	}, [router])
+	}, [])
 
 	return null
 }

--- a/sanity/SanityLiveProxy.tsx
+++ b/sanity/SanityLiveProxy.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+import type { LiveEvent } from "@sanity/client"
+import { useRouter } from "next/navigation"
+import { revalidateSyncTags } from "next-sanity/live/server-actions"
 import { useEffect } from "react"
 
 /**
@@ -9,10 +12,22 @@ import { useEffect } from "react"
  * - works event without CORS configuration (although you should still configure it for the studio)
  */
 export function SanityLiveProxy() {
+	const router = useRouter()
+
 	useEffect(() => {
 		const eventSource = new EventSource("/api/live")
+
+		eventSource.onmessage = (e) => {
+			const event = JSON.parse(e.data) as LiveEvent
+			if (event.type === "message") {
+				revalidateSyncTags(event.tags)
+			} else if (event.type === "restart" || event.type === "reconnect") {
+				router.refresh()
+			}
+		}
+
 		return () => eventSource.close()
-	}, [])
+	}, [router])
 
 	return null
 }

--- a/sanity/liveProxy.ts
+++ b/sanity/liveProxy.ts
@@ -17,10 +17,6 @@ const encoder = new TextEncoder()
 const internalSecret = env.SANITY_AUTH_TOKEN
 
 function revalidate(tags?: string[]) {
-	console.log(
-		"[liveProxy] revalidate →",
-		tags?.length ? `tags: ${tags.join(", ")}` : "full revalidatePath",
-	)
 	fetch(`${siteURL}/api/live`, {
 		method: "POST",
 		headers: {
@@ -29,12 +25,6 @@ function revalidate(tags?: string[]) {
 		},
 		body: JSON.stringify({ tags }),
 	})
-		.then((res) => {
-			console.log("[liveProxy] revalidate ← status", res.status)
-		})
-		.catch((err) => {
-			console.error("[liveProxy] revalidate fetch error:", err)
-		})
 }
 
 function broadcast(data: string) {
@@ -71,13 +61,6 @@ function startUpstreamSubscription() {
 	// what we want for public cache invalidation.
 	sanitySubscription = client.live.events().subscribe({
 		next: (event) => {
-			console.log(
-				"[liveProxy] sanity event:",
-				event.type,
-				event.type === "message"
-					? `tags: ${(event.tags ?? []).join(", ") || "(none)"}`
-					: "",
-			)
 			if (event.type === "message") {
 				revalidate(event.tags)
 			}
@@ -108,15 +91,10 @@ export async function POST(request: Request) {
 	const { tags } = (await request.json()) as { tags?: string[] }
 
 	if (tags?.length) {
-		console.log(
-			"[liveProxy] POST revalidateTag:",
-			tags.map((t) => `sanity:${t}`).join(", "),
-		)
 		for (const tag of tags) {
 			revalidateTag(`sanity:${tag}`, "max")
 		}
 	} else {
-		console.log("[liveProxy] POST revalidatePath: / (layout)")
 		revalidatePath("/", "layout")
 	}
 

--- a/sanity/liveProxy.ts
+++ b/sanity/liveProxy.ts
@@ -74,7 +74,9 @@ function startUpstreamSubscription() {
 			console.log(
 				"[liveProxy] sanity event:",
 				event.type,
-				event.type === "message" ? `tags: ${(event.tags ?? []).join(", ") || "(none)"}` : "",
+				event.type === "message"
+					? `tags: ${(event.tags ?? []).join(", ") || "(none)"}`
+					: "",
 			)
 			if (event.type === "message") {
 				revalidate(event.tags)
@@ -106,7 +108,10 @@ export async function POST(request: Request) {
 	const { tags } = (await request.json()) as { tags?: string[] }
 
 	if (tags?.length) {
-		console.log("[liveProxy] POST revalidateTag:", tags.map((t) => `sanity:${t}`).join(", "))
+		console.log(
+			"[liveProxy] POST revalidateTag:",
+			tags.map((t) => `sanity:${t}`).join(", "),
+		)
 		for (const tag of tags) {
 			revalidateTag(`sanity:${tag}`, "max")
 		}

--- a/sanity/liveProxy.ts
+++ b/sanity/liveProxy.ts
@@ -17,6 +17,10 @@ const encoder = new TextEncoder()
 const internalSecret = crypto.randomBytes(32).toString("base64url")
 
 function revalidate(tags?: string[]) {
+	console.log(
+		"[liveProxy] revalidate →",
+		tags?.length ? `tags: ${tags.join(", ")}` : "full revalidatePath",
+	)
 	fetch(`${siteURL}/api/live`, {
 		method: "POST",
 		headers: {
@@ -25,6 +29,12 @@ function revalidate(tags?: string[]) {
 		},
 		body: JSON.stringify({ tags }),
 	})
+		.then((res) => {
+			console.log("[liveProxy] revalidate ← status", res.status)
+		})
+		.catch((err) => {
+			console.error("[liveProxy] revalidate fetch error:", err)
+		})
 }
 
 function broadcast(data: string) {
@@ -61,6 +71,11 @@ function startUpstreamSubscription() {
 	// what we want for public cache invalidation.
 	sanitySubscription = client.live.events().subscribe({
 		next: (event) => {
+			console.log(
+				"[liveProxy] sanity event:",
+				event.type,
+				event.type === "message" ? `tags: ${(event.tags ?? []).join(", ") || "(none)"}` : "",
+			)
 			if (event.type === "message") {
 				revalidate(event.tags)
 			}
@@ -91,10 +106,12 @@ export async function POST(request: Request) {
 	const { tags } = (await request.json()) as { tags?: string[] }
 
 	if (tags?.length) {
+		console.log("[liveProxy] POST revalidateTag:", tags.map((t) => `sanity:${t}`).join(", "))
 		for (const tag of tags) {
 			revalidateTag(`sanity:${tag}`, "max")
 		}
 	} else {
+		console.log("[liveProxy] POST revalidatePath: / (layout)")
 		revalidatePath("/", "layout")
 	}
 

--- a/sanity/liveProxy.ts
+++ b/sanity/liveProxy.ts
@@ -1,5 +1,6 @@
 // app/api/live/route.ts
 
+import { revalidateSyncTags } from "next-sanity/live/server-actions"
 import { client } from "sanity/lib/client"
 
 export const dynamic = "force-dynamic"
@@ -42,7 +43,11 @@ function startUpstreamSubscription() {
 	// what we want for public cache invalidation.
 	sanitySubscription = client.live.events().subscribe({
 		next: (event) => {
-			broadcast(JSON.stringify(event))
+			if (event.type === "message") {
+				revalidateSyncTags(event.tags)
+			} else {
+				broadcast(JSON.stringify(event))
+			}
 		},
 		error: (err) => {
 			console.error("Sanity upstream error:", err)

--- a/sanity/liveProxy.ts
+++ b/sanity/liveProxy.ts
@@ -1,6 +1,8 @@
 // app/api/live/route.ts
 
-import { revalidateSyncTags } from "next-sanity/live/server-actions"
+import crypto from "node:crypto"
+import { siteURL } from "library/siteURL"
+import { revalidatePath, revalidateTag } from "next/cache"
 import { client } from "sanity/lib/client"
 
 export const dynamic = "force-dynamic"
@@ -12,6 +14,18 @@ const connectedClients = new Set<WritableStreamDefaultWriter<Uint8Array>>()
 let sanitySubscription: { unsubscribe: () => void } | null = null
 let cachedWelcomeEvent: string | null = null
 const encoder = new TextEncoder()
+const internalSecret = crypto.randomBytes(32).toString("base64url")
+
+function revalidate(tags?: string[]) {
+	fetch(`${siteURL}/api/live`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${internalSecret}`,
+		},
+		body: JSON.stringify({ tags }),
+	})
+}
 
 function broadcast(data: string) {
 	// cache welcome events to replay to new clients
@@ -38,13 +52,17 @@ function startUpstreamSubscription() {
 
 	console.log("⚡️ Opening shared upstream connection to Sanity...")
 
+	// Cold start: bust the entire cache in case events were missed while
+	// the serverless instance was recycled.
+	revalidate()
+
 	// We rely on the default behavior: includeAllDocuments=false
 	// This means we only receive events for PUBLISHED content, which is exactly
 	// what we want for public cache invalidation.
 	sanitySubscription = client.live.events().subscribe({
 		next: (event) => {
 			if (event.type === "message") {
-				revalidateSyncTags(event.tags)
+				revalidate(event.tags)
 			}
 			broadcast(JSON.stringify(event))
 		},
@@ -63,6 +81,25 @@ function startUpstreamSubscription() {
 // close connections before vercel's hard timeout (300s on pro, 60s on hobby)
 // this lets the client's native EventSource auto-reconnect handle it gracefully
 const MAX_CONNECTION_MS = 280_000
+
+export async function POST(request: Request) {
+	const bearer = request.headers.get("Authorization")?.replace("Bearer ", "")
+	if (bearer !== internalSecret) {
+		return Response.json({ error: "unauthorized" }, { status: 401 })
+	}
+
+	const { tags } = (await request.json()) as { tags?: string[] }
+
+	if (tags?.length) {
+		for (const tag of tags) {
+			revalidateTag(`sanity:${tag}`, "max")
+		}
+	} else {
+		revalidatePath("/", "layout")
+	}
+
+	return Response.json({ revalidated: true })
+}
 
 export async function GET(request: Request) {
 	const responseStream = new TransformStream()

--- a/sanity/liveProxy.ts
+++ b/sanity/liveProxy.ts
@@ -1,6 +1,6 @@
 // app/api/live/route.ts
 
-import crypto from "node:crypto"
+import { env } from "app/env"
 import { siteURL } from "library/siteURL"
 import { revalidatePath, revalidateTag } from "next/cache"
 import { client } from "sanity/lib/client"
@@ -14,7 +14,7 @@ const connectedClients = new Set<WritableStreamDefaultWriter<Uint8Array>>()
 let sanitySubscription: { unsubscribe: () => void } | null = null
 let cachedWelcomeEvent: string | null = null
 const encoder = new TextEncoder()
-const internalSecret = crypto.randomBytes(32).toString("base64url")
+const internalSecret = env.SANITY_AUTH_TOKEN
 
 function revalidate(tags?: string[]) {
 	console.log(

--- a/sanity/liveProxy.ts
+++ b/sanity/liveProxy.ts
@@ -45,9 +45,8 @@ function startUpstreamSubscription() {
 		next: (event) => {
 			if (event.type === "message") {
 				revalidateSyncTags(event.tags)
-			} else {
-				broadcast(JSON.stringify(event))
 			}
+			broadcast(JSON.stringify(event))
 		},
 		error: (err) => {
 			console.error("Sanity upstream error:", err)

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -82,8 +82,9 @@ export async function libraryFetch<const QueryString extends string>({
 
 const useProxy =
 	// vercel has fluid compute baybeeee
+	// local obviously is persistent too
 	// other providers should be tested and evaluated as needed
-	!!process.env.VERCEL
+	!!process.env.VERCEL || process.env.NODE_ENV === "development"
 
 export const LibraryLive = async () => {
 	const { isEnabled: isDraftMode } = await draftMode()

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -1,6 +1,5 @@
 import { fetchAssetMeta } from "library/sanity/assetMetadata"
 import DraftModeOverlay from "library/sanity/DraftModeOverlay"
-import { siteURL } from "library/siteURL"
 import { draftMode } from "next/headers"
 import type { ClientPerspective, QueryParams } from "next-sanity"
 import { defineLive } from "next-sanity/live"

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -1,5 +1,6 @@
 import { fetchAssetMeta } from "library/sanity/assetMetadata"
 import DraftModeOverlay from "library/sanity/DraftModeOverlay"
+import { siteURL } from "library/siteURL"
 import { draftMode } from "next/headers"
 import type { ClientPerspective, QueryParams } from "next-sanity"
 import { defineLive } from "next-sanity/live"
@@ -75,33 +76,34 @@ export async function libraryFetch<const QueryString extends string>({
 	}
 }
 
+const useProxyInDev = false
 const allowProxy =
 	// vercel has fluid compute baybeeee
 	// other providers should be tested and evaluated as needed
-	!!process.env.VERCEL
+	!!process.env.VERCEL ||
+	(process.env.NODE_ENV === "development" && useProxyInDev)
 
 export const LibraryLive = async () => {
 	const { isEnabled: isDraftMode } = await draftMode()
 
-	const useProxy = isDraftMode ? false : allowProxy
-
 	return (
-		<LiveWrapper>
+		<>
+			{allowProxy && <SanityLiveProxy />}
 			<Toaster />
-			{isDraftMode && <FirefoxFix />}
-			{isDraftMode && <DraftModeOverlay />}
-			{useProxy ? (
-				<SanityLiveProxy />
-			) : (
-				<InternalLive
-					onError={handleError}
-					refreshOnFocus={false}
-					refreshOnMount={true}
-					refreshOnReconnect={true}
-					intervalOnGoAway={false}
-				/>
+			{isDraftMode && (
+				<LiveWrapper>
+					<DraftModeOverlay />
+					<FirefoxFix />
+					<InternalLive
+						onError={handleError}
+						refreshOnFocus={false}
+						refreshOnMount={true}
+						refreshOnReconnect={true}
+						intervalOnGoAway={false}
+					/>
+				</LiveWrapper>
 			)}
-		</LiveWrapper>
+		</>
 	)
 }
 

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -102,8 +102,7 @@ export const LibraryLive = async () => {
 						refreshOnMount={true}
 						refreshOnReconnect={true}
 						intervalOnGoAway={false}
-
-          />
+					/>
 				)}
 			</LiveWrapper>
 		</>

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -80,33 +80,32 @@ export async function libraryFetch<const QueryString extends string>({
 	}
 }
 
-const useProxyInDev = false
-const allowProxy =
+const useProxy =
 	// vercel has fluid compute baybeeee
 	// other providers should be tested and evaluated as needed
-	!!process.env.VERCEL ||
-	(process.env.NODE_ENV === "development" && useProxyInDev)
+	!!process.env.VERCEL
 
 export const LibraryLive = async () => {
 	const { isEnabled: isDraftMode } = await draftMode()
 
 	return (
 		<>
-			{allowProxy && <SanityLiveProxy />}
+			{useProxy && <SanityLiveProxy />}
 			<Toaster />
-			{isDraftMode && (
-				<LiveWrapper>
-					<DraftModeOverlay />
-					<FirefoxFix />
+			{isDraftMode && <DraftModeOverlay />}
+			{isDraftMode && <FirefoxFix />}
+			<LiveWrapper>
+				{(isDraftMode || !useProxy) && (
 					<InternalLive
 						onError={handleError}
 						refreshOnFocus={false}
 						refreshOnMount={true}
 						refreshOnReconnect={true}
 						intervalOnGoAway={false}
-					/>
-				</LiveWrapper>
-			)}
+
+          />
+				)}
+			</LiveWrapper>
 		</>
 	)
 }

--- a/styled/vanilla.ts
+++ b/styled/vanilla.ts
@@ -29,7 +29,6 @@ if (isBrowser && process.env.NODE_ENV === "development")
 
 type BreakpointCombo = "small" | "large" | "all"
 
-type OutputType = "fluid" | "pixel" | "scaleFullyConfig"
 type ResponsiveEngine = "calc" | "media"
 
 type FOptions = {


### PR DESCRIPTION
how to test
open https://reform-next-starter-git-proxy-reform-collective.vercel.app in a private tab
open https://reform-next-starter.vercel.app/studio and edit content in structure (not presentation)
you should see the deploy preview update in real time
close the deploy preview
open https://reform-next-starter.vercel.app/studio and edit content
open https://reform-next-starter-git-proxy-reform-collective.vercel.app in a private tab
you will see the old content on the first visit while the page rerenders (stale while revalidate) (if you immediately see the new content, that means the page was open in a tab somewhere)
you should see the correct latest content even if there were no tabs on the site during the publish! 


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add POST revalidation handler to `liveProxy.ts` and enable proxy in development
> - Adds a `POST` route to [sanity/liveProxy.ts](https://github.com/reformcollective/library/pull/484/files#diff-244288ad1411977584a688fbc6b013763c32f4bf695471d37314a3c41959c6ab) that accepts authenticated revalidation requests; requests with tags call `revalidateTag`, otherwise `revalidatePath('/', 'layout')`.
> - Adds a `revalidate()` helper that POSTs to `/api/live` with a Bearer token, called on cold start and on each incoming `message` event before broadcasting.
> - Updates [sanity/reusableFetch.tsx](https://github.com/reformcollective/library/pull/484/files#diff-133b49b7bb8d0ef32f864830fdb361dabf4df3cce6c82c54835099255a9458aa) to enable the proxy in `NODE_ENV === 'development'` in addition to Vercel; also mounts `SanityLiveProxy` even in draft mode when proxy is active, and concurrently mounts `InternalLive` when draft mode is enabled.
> - Tightens the default `Utilities` generic in `Config` and `defineLibraryConfig` from `{}` to `Record<string, never>`.
> - Behavioral Change: `InternalLive` is no longer mounted when `useProxy` is true and draft mode is off; previously it was always mounted alongside the proxy.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #484 opened
>
> - Removed `.then`/`.catch` handling from the `revalidate` function's fetch call, converting it to a fire-and-forget operation [d3cf6fe]
> - Removed console logging from `revalidate` function, `startUpstreamSubscription` next callback, and POST route handler [d3cf6fe]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8361592.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->