### PR TITLE
Resolve "/" home slug to site root in internal links

### DIFF
--- a/link/resolve.ts
+++ b/link/resolve.ts
@@ -34,7 +34,10 @@ export const resolveRoute = (
 		}
 
 	if (link.type === "internal" && link.internalSlug) {
-		const slugToUse = link.internalSlug === "home" ? "" : link.internalSlug
+		const slugToUse =
+			link.internalSlug === "home" || link.internalSlug === "/"
+				? ""
+				: link.internalSlug
 		return {
 			url: `/${stegaClean(slugToUse || "")}${stegaClean(link.parameters || "")}${stegaClean(link.anchor || "")}`,
 			// default to same tab if not specified


### PR DESCRIPTION
resolveRoute was only treating the literal string "home" as the site root (""), but Sanity GROQ projection (in library/sanity/assetMetadata.ts) transforms the home document's slug to "/" before it reaches the resolver. So any internal link to the home page was producing / + / = // in the href - which the browser treats as a protocol-relative URL, sending users to weird places like about#blocked. The fix accepts both "home" and "/" as "root".


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve "/" home slug to site root in internal links
> In [link/resolve.ts](https://github.com/reformcollective/library/pull/485/files#diff-b76a108741b62f04027c6baaedb68c5e9d61e6b482fe9e7a43f385e71615263a), the `resolveRoute` util previously only mapped the `"home"` slug to an empty string (root path). This fix extends that check to also treat `"/"` as an empty slug, preventing internal links with a `"/"` slug from producing a double-slash URL like `"//..."`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 475fee3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->