### PR TITLE
disable library action caching

### DIFF
--- a/.github/workflows/check-this-repo.yml
+++ b/.github/workflows/check-this-repo.yml
@@ -15,7 +15,6 @@ jobs:
         name: Install pnpm
         with:
           run_install: true
-          cache: true
           standalone: true
       - name: Lint
         run: pnpm run lint


### PR DESCRIPTION
causes check failures for some reason

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable library action caching in `pnpm/action-setup` for the linting workflow
> Removes the explicit `cache: true` option from the `pnpm/action-setup@v6` step in [check-this-repo.yml](.github/workflows/check-this-repo.yml), reverting to the action's default caching behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e6f15b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->