### PR TITLE
fix dependency analysis for JSX

### DIFF
--- a/vanilla/dependency-graph.ts
+++ b/vanilla/dependency-graph.ts
@@ -120,6 +120,9 @@ export function analyzeDependencies(
 				// against imports/variables defined in this file.
 				visit(n.expression)
 				return
+			} else if (ts.isJsxAttribute(n)) {
+				if (n.initializer) visit(n.initializer)
+				return
 			}
 			ts.forEachChild(n, visit)
 		}

--- a/vanilla/vanilla-split-loader.test.ts
+++ b/vanilla/vanilla-split-loader.test.ts
@@ -918,6 +918,57 @@ const StyledComboboxInput = styled(Combobox.Input, { color: "red" })`
 		})
 	})
 
+	describe("JSX attribute false dependency bug", () => {
+		it("collectDependencies should not treat JSX attribute names as standalone refs", () => {
+			// Bug: collectDependencies walks the JSX attribute name `style` in
+			// `<div style={...} />`. If this file also imports `style` from
+			// @vanilla-extract/css, the React component is incorrectly marked as
+			// depending on the vanilla-extract style function and rejected.
+			const source = `import { style } from "@vanilla-extract/css"
+import { styled } from "library/styled"
+
+function Panel() {
+	return <div style={{ transform: "translateX(0%)" }} />
+}
+
+const PanelWrap = styled("div", { color: "red" })
+const captionClass = style({ color: "blue" })`
+
+			const graph = analyzeDependencies(source)
+			const node = graph.nodes.get("Panel")
+
+			assert(node !== undefined)
+			expect(node.dependsOn).not.toContain("style")
+		})
+
+		it("should allow React components with inline style attributes when vanilla style is imported", async () => {
+			await using tmpDir = new TempDir()
+			const source = `import { style } from "@vanilla-extract/css"
+import { styled } from "library/styled"
+
+function Panel() {
+	return (
+		<PanelWrap>
+			<div style={{ transform: "translateX(0%)" }} />
+		</PanelWrap>
+	)
+}
+
+const PanelWrap = styled("div", { color: "red" })
+const captionClass = style({ color: "blue" })`
+			const ctx = createMockContext(
+				path.join(await tmpDir.getPath(), "app/test.tsx"),
+				await tmpDir.getPath(),
+			)
+
+			const result = await vanillaSplitLoader.call(ctx, source)
+			expectValidTypeScript(result)
+
+			expect(result).toContain("function Panel")
+			expect(result).toContain("<PanelWrap>")
+		})
+	})
+
 	describe("debug output", () => {
 		it("should write pre-process and final debug files", async () => {
 			await using tmpDir = new TempDir()


### PR DESCRIPTION
```
<div style={{}} />
```

was incorrectly reporting a dependency on `style`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix JSX attribute names being treated as identifier dependencies in `analyzeDependencies`
> In the dependency graph traversal, JSX attribute names (e.g., `style` in `<div style={...} />`) were being collected as identifier references, causing false dependencies on imported symbols with the same name. Adds a branch in [vanilla/dependency-graph.ts](https://github.com/reformcollective/library/pull/487/files#diff-4afe9968546499763aa94c21868188ba4bf1759e3709a95b0425207b682c9b50) to detect `ts.isJsxAttribute` nodes, skip the attribute name, and only traverse the initializer expression.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 039409f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->