### PR TITLE
AutoAnimate sizing fix

### DIFF
--- a/AutoAnimate.tsx
+++ b/AutoAnimate.tsx
@@ -54,6 +54,11 @@ const getSize = (element: React.RefObject<HTMLElement | null>) => {
 	return { width: offsetWidth + 1, height: offsetHeight }
 }
 
+type AutoAnimateAlignmentKeyword = "start" | "center" | "end" | "stretch"
+type AutoAnimateAlignment =
+	| AutoAnimateAlignmentKeyword
+	| `${AutoAnimateAlignmentKeyword} ${AutoAnimateAlignmentKeyword}`
+
 export default function AutoAnimate({
 	children,
 	duration = 1,
@@ -99,9 +104,11 @@ export default function AutoAnimate({
 	 *
 	 * if left, content will only overflow on the right during the animation.
 	 * this is ideal when the container itself is left-aligned
+	 *
+	 * You can also pass two-axis values like "stretch center" or "start end".
 	 * @default start
 	 */
-	alignment?: "start" | "center" | "end"
+	alignment?: AutoAnimateAlignment
 	/**
 	 * if you need to style this, you can. be careful though. be very careful.
 	 */

--- a/AutoAnimate.tsx
+++ b/AutoAnimate.tsx
@@ -297,9 +297,13 @@ export default function AutoAnimate({
 
 	return (
 		<Wrapper className={className}>
-			<div ref={sizer} style={{ display: "none" }}>
-				{getNodeFromKey(currentKey)}
-			</div>
+			<AnimationWrapper
+				ref={sizer}
+				alignment={alignment}
+				style={{ display: "none" }}
+			>
+				<div>{getNodeFromKey(currentKey)}</div>
+			</AnimationWrapper>
 			<AnimationWrapper ref={wrapper} alignment={alignment}>
 				<div ref={wrapperA}>{getNodeFromKey(slotA)}</div>
 				<div ref={wrapperB}>{getNodeFromKey(slotB)}</div>


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix AutoAnimate sizing by wrapping the hidden sizer in an `AnimationWrapper`
The hidden sizing element in [AutoAnimate.tsx](https://github.com/reformcollective/library/pull/488/files#diff-c430f57cc8938addeaee4a9d912effde51749ff22c8f432e75c0d7a2f5ce8d77) was a plain `div`, which caused size/alignment to be computed differently than the visible element during animations. It is now an `AnimationWrapper` that receives the same `alignment` prop, with the measured node inside an inner `div`.

The `alignment` prop type is also widened to accept a space-delimited two-axis value (e.g. `"start end"`) in addition to a single keyword.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1efcd61.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->