### PR TITLE
scroll refresh improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,33 @@
 
+# 2026-04-29
+
+## `useHMR` event types renamed; `useSteadyHotScroll` replaced by `SteadyHotScroll`
+
+`useHMR` no longer uses a WebSocket — it hooks into Next.js's internal dispatcher. The event type strings changed and two new types were added:
+
+| Before | After |
+|--------|-------|
+| `"prebuild"` | `"beforeRefresh"` |
+| `"postbuild"` | `"afterRefresh"` |
+| — | `"beforeReload"` *(new)* |
+| — | `"afterReload"` *(new)* |
+
+`useSteadyHotScroll` is no longer exported. Use the `SteadyHotScroll` component instead:
+
+```tsx
+// before
+useSteadyHotScroll()
+
+// after
+<SteadyHotScroll />
+```
+
+**Migration Advice**
+
+Update any `useHMR` call sites to use the new event type strings. Replace any `useSteadyHotScroll()` hook calls with a rendered `<SteadyHotScroll />` component (imported from `library/useHMR`).
+
+Note that `SteadyHotScroll` MUST be *below* ScreenContext to work.
+
 # 2026-04-21
 
 ## Live proxy now requires POST to be exported

--- a/sanity/FirefoxFix.tsx
+++ b/sanity/FirefoxFix.tsx
@@ -46,7 +46,7 @@ export const FirefoxFix = () => {
 	useInterval(() => {
 		if (browserData.isFireFox) checkZeroWidthChars()
 	}, 1000)
-	useHMR("postbuild", () => {
+	useHMR("afterRefresh", () => {
 		if (browserData.isFireFox) {
 			checkZeroWidthChars()
 		}

--- a/useAnimation.ts
+++ b/useAnimation.ts
@@ -237,7 +237,7 @@ export const useAnimation = <InputFn extends Creation>(
 		}
 	}, finalDeps)
 
-	useHMR("postbuild", (hash) => {
+	useHMR("afterRefresh", (hash) => {
 		setHmrHash(hash)
 		context.revert()
 	})

--- a/useHMR.ts
+++ b/useHMR.ts
@@ -1,7 +1,7 @@
 import { useEventListener } from "ahooks"
 import { dispatcher } from "next/dist/compiled/next-devtools"
 import type { Dispatcher } from "next/dist/next-devtools/dev-overlay.browser"
-import { use, useEffect, useEffectEvent } from "react"
+import { use, useEffect, useEffectEvent, useRef } from "react"
 import { ScreenContext } from "./ScreenContext"
 import TypedEventEmitter from "./TypedEventEmitter"
 
@@ -94,18 +94,18 @@ export const useHMR =
 const useSteadyHotScroll =
 	process.env.NODE_ENV === "development"
 		? () => {
-				let refreshRaf: number | null = null
-				let reloadRaf: number | null = null
+				const refreshRaf = useRef<number | null>(null)
+				const reloadRaf = useRef<number | null>(null)
 
 				useHMR("beforeRefresh", () => {
-					if (refreshRaf) cancelAnimationFrame(refreshRaf)
+					if (refreshRaf.current) cancelAnimationFrame(refreshRaf.current)
 					setSavedScroll(refreshScrollStorageKey, window.scrollY)
 				})
 
 				useHMR("afterRefresh", () => {
 					const savedScroll = getSavedScroll(refreshScrollStorageKey)
 					if (savedScroll !== null) {
-						refreshRaf = requestAnimationFrame(() => {
+						refreshRaf.current = requestAnimationFrame(() => {
 							window.scrollTo(0, savedScroll)
 							setSavedScroll(refreshScrollStorageKey, null)
 						})
@@ -113,14 +113,14 @@ const useSteadyHotScroll =
 				})
 
 				useHMR("beforeReload", () => {
-					if (reloadRaf) cancelAnimationFrame(reloadRaf)
+					if (reloadRaf.current) cancelAnimationFrame(reloadRaf.current)
 					setSavedScroll(reloadScrollStorageKey, window.scrollY)
 				})
 
 				useHMR("afterReload", () => {
 					const savedScroll = getSavedScroll(reloadScrollStorageKey)
 					if (savedScroll !== null) {
-						reloadRaf = requestAnimationFrame(() => {
+						reloadRaf.current = requestAnimationFrame(() => {
 							window.scrollTo(0, savedScroll)
 							setSavedScroll(reloadScrollStorageKey, null)
 						})

--- a/useHMR.ts
+++ b/useHMR.ts
@@ -1,94 +1,144 @@
-import { useEffect, useEffectEvent, useRef } from "react"
-import { z } from "zod"
+import { useEventListener } from "ahooks"
+import { dispatcher } from "next/dist/compiled/next-devtools"
+import type { Dispatcher } from "next/dist/next-devtools/dev-overlay.browser"
+import { use, useEffect, useEffectEvent } from "react"
+import { ScreenContext } from "./ScreenContext"
+import TypedEventEmitter from "./TypedEventEmitter"
 
-const socket =
-	process.env.NODE_ENV === "development"
-		? new WebSocket("ws://localhost:3000/_next/webpack-hmr")
-		: null
+const nextDispatcher = dispatcher as Dispatcher
 
-const messageSchema = z.union([
-	z.strictObject({
-		type: z.literal("built"),
-		hash: z.string(),
-		errors: z.array(z.unknown()),
-		warnings: z.array(z.unknown()),
-	}),
-	z.strictObject({
-		type: z.literal("building"),
-	}),
-	// unused messages
-	z.object({
-		type: z.enum([
-			"serverComponentChanges",
-			"turbopack-connected",
-			"turbopack-message",
-			"isrManifest",
-			"sync",
-		]),
-	}),
-])
+const refreshScrollStorageKey = "__reformSteadyHotScrollLatestScroll"
+const reloadScrollStorageKey = "__reformSteadyHotScrollLatestScrollBeforeReload"
+const refreshedAtStorageKey = "__reformSteadyHotScrollRefreshedAt"
+
+const emitter = new TypedEventEmitter<{
+	beforeRefresh: [string]
+	afterRefresh: [string]
+}>()
+
+const previousOnBeforeRefresh = nextDispatcher.onBeforeRefresh
+const previousOnRefresh = nextDispatcher.onRefresh
+nextDispatcher.onBeforeRefresh = () => {
+	previousOnBeforeRefresh()
+	emitter.dispatchEvent("beforeRefresh", crypto.randomUUID())
+}
+nextDispatcher.onRefresh = () => {
+	previousOnRefresh()
+	emitter.dispatchEvent("afterRefresh", crypto.randomUUID())
+}
+
+const setSavedScroll = (key: string, scroll: number | null) => {
+		if (scroll === null) sessionStorage.removeItem(key)
+		else sessionStorage.setItem(key, String(scroll))
+
+}
+
+const getSavedScroll = (key: string) => {
+	const scroll = sessionStorage.getItem(key)
+	if (scroll === null) return null
+	return Number.parseInt(scroll, 10)
+}
+
+const setRefreshedAt = () => {
+	sessionStorage.setItem(refreshedAtStorageKey, String(Date.now()))
+}
+
+const getRefreshedAt = () => {
+	const refreshedAt = sessionStorage.getItem(refreshedAtStorageKey)
+	if (refreshedAt === null) return null
+	return Number.parseInt(refreshedAt, 10)
+}
 
 export const useHMR =
 	process.env.NODE_ENV === "development"
-		? (type: "prebuild" | "postbuild", callback: (hash: string) => void) => {
+		? (
+				type: "beforeRefresh" | "afterRefresh" | "beforeReload" | "afterReload",
+				callback: (hash: string) => void,
+				debug?: string,
+			) => {
 				const sendMessage = useEffectEvent(callback)
+				const { initComplete } = use(ScreenContext)
 
 				useEffect(() => {
-					if (process.env.NODE_ENV === "development") {
-						const handler = (event: MessageEvent) => {
-							const message = JSON.parse(event.data)
-							const result = messageSchema.safeParse(message)
-							if (!result.success) {
-								throw new Error(
-									`useHMR (library/useHMR.ts): WebSocket message from Next.js HMR does not match the expected schema.
-` +
-										`This usually means the Next.js version changed the HMR message format.
-` +
-										`Update the messageSchema in library/useHMR.ts to match the new format.
-` +
-										`Received message: ${JSON.stringify(message)}
-` +
-										`Original error: ${result.error}`,
-								)
-							}
-							const parsedMessage = result.data
+					const before = () => {
+						previousOnBeforeRefresh()
+						if (type === "beforeRefresh") sendMessage(crypto.randomUUID())
+					}
+					const after = () => {
+						previousOnRefresh()
+						if (type === "afterRefresh") sendMessage(crypto.randomUUID())
+					}
 
-							if (type === "prebuild" && parsedMessage.type === "building") {
-								sendMessage("building")
-							}
-							if (type === "postbuild" && parsedMessage.type === "built") {
-								sendMessage(parsedMessage.hash)
-							}
-						}
-						socket?.addEventListener("message", handler)
-						return () => {
-							socket?.removeEventListener("message", handler)
-						}
+					if (type === "beforeRefresh")
+						emitter.addEventListener("beforeRefresh", before)
+					if (type === "afterRefresh")
+						emitter.addEventListener("afterRefresh", after)
+					return () => {
+						emitter.removeEventListener("beforeRefresh", before)
+						emitter.removeEventListener("afterRefresh", after)
 					}
 				}, [type])
+
+				useEventListener("beforeunload", () => {
+					setRefreshedAt()
+					if (type === "beforeReload") sendMessage(crypto.randomUUID())
+				})
+
+				useEffect(() => {
+					if (type !== "afterReload") return
+					const refreshedAt = getRefreshedAt()
+					// if refreshed in last 10 seconds, assume it's from an HMR-triggered reload and emit
+					if (initComplete && refreshedAt && Date.now() - refreshedAt < 10000) {
+						sendMessage(crypto.randomUUID())
+					}
+				}, [type, initComplete])
 			}
 		: () => {}
 
-export const useSteadyHotScroll =
+const useSteadyHotScroll =
 	process.env.NODE_ENV === "development"
 		? () => {
-				const latestScroll = useRef(0)
-				let rafId: number | null = null
+				let refreshRaf: number | null = null
+				let reloadRaf: number | null = null
 
-				useHMR("prebuild", () => {
-					if (rafId) cancelAnimationFrame(rafId)
-					latestScroll.current = window.scrollY
+				useHMR(
+					"beforeRefresh",
+					() => {
+						if (refreshRaf) cancelAnimationFrame(refreshRaf)
+						setSavedScroll(refreshScrollStorageKey, window.scrollY)
+					},
+					"use steady",
+				)
+
+				useHMR("afterRefresh", () => {
+					const savedScroll = getSavedScroll(refreshScrollStorageKey)
+					if (savedScroll !== null) {
+						refreshRaf = requestAnimationFrame(() => {
+							window.scrollTo(0, savedScroll)
+							setSavedScroll(refreshScrollStorageKey, null)
+						})
+					}
 				})
 
-				useHMR("postbuild", () => {
-					const startTime = performance.now()
-					const scrollEveryFrame = () => {
-						window.scrollTo({ top: latestScroll.current, behavior: "instant" })
-						if (performance.now() - startTime < 1000) {
-							rafId = requestAnimationFrame(scrollEveryFrame)
-						}
+				useHMR("beforeReload", () => {
+					if (reloadRaf) cancelAnimationFrame(reloadRaf)
+					setSavedScroll(reloadScrollStorageKey, window.scrollY)
+				})
+
+				useHMR("afterReload", () => {
+
+					const savedScroll = getSavedScroll(reloadScrollStorageKey)
+					if (savedScroll !== null) {
+						reloadRaf = requestAnimationFrame(() => {
+							window.scrollTo(0, savedScroll)
+							setSavedScroll(refreshScrollStorageKey, null)
+						})
 					}
-					scrollEveryFrame()
 				})
 			}
 		: () => {}
+
+export function SteadyHotScroll() {
+	useSteadyHotScroll()
+	return null
+}

--- a/useHMR.ts
+++ b/useHMR.ts
@@ -122,7 +122,7 @@ const useSteadyHotScroll =
 					if (savedScroll !== null) {
 						reloadRaf = requestAnimationFrame(() => {
 							window.scrollTo(0, savedScroll)
-							setSavedScroll(refreshScrollStorageKey, null)
+							setSavedScroll(reloadScrollStorageKey, null)
 						})
 					}
 				})

--- a/useHMR.ts
+++ b/useHMR.ts
@@ -59,11 +59,9 @@ export const useHMR =
 
 				useEffect(() => {
 					const before = () => {
-						previousOnBeforeRefresh()
 						if (type === "beforeRefresh") sendMessage(crypto.randomUUID())
 					}
 					const after = () => {
-						previousOnRefresh()
 						if (type === "afterRefresh") sendMessage(crypto.randomUUID())
 					}
 

--- a/useHMR.ts
+++ b/useHMR.ts
@@ -28,9 +28,8 @@ nextDispatcher.onRefresh = () => {
 }
 
 const setSavedScroll = (key: string, scroll: number | null) => {
-		if (scroll === null) sessionStorage.removeItem(key)
-		else sessionStorage.setItem(key, String(scroll))
-
+	if (scroll === null) sessionStorage.removeItem(key)
+	else sessionStorage.setItem(key, String(scroll))
 }
 
 const getSavedScroll = (key: string) => {
@@ -54,7 +53,6 @@ export const useHMR =
 		? (
 				type: "beforeRefresh" | "afterRefresh" | "beforeReload" | "afterReload",
 				callback: (hash: string) => void,
-				debug?: string,
 			) => {
 				const sendMessage = useEffectEvent(callback)
 				const { initComplete } = use(ScreenContext)
@@ -101,14 +99,10 @@ const useSteadyHotScroll =
 				let refreshRaf: number | null = null
 				let reloadRaf: number | null = null
 
-				useHMR(
-					"beforeRefresh",
-					() => {
-						if (refreshRaf) cancelAnimationFrame(refreshRaf)
-						setSavedScroll(refreshScrollStorageKey, window.scrollY)
-					},
-					"use steady",
-				)
+				useHMR("beforeRefresh", () => {
+					if (refreshRaf) cancelAnimationFrame(refreshRaf)
+					setSavedScroll(refreshScrollStorageKey, window.scrollY)
+				})
 
 				useHMR("afterRefresh", () => {
 					const savedScroll = getSavedScroll(refreshScrollStorageKey)
@@ -126,7 +120,6 @@ const useSteadyHotScroll =
 				})
 
 				useHMR("afterReload", () => {
-
 					const savedScroll = getSavedScroll(reloadScrollStorageKey)
 					if (savedScroll !== null) {
 						reloadRaf = requestAnimationFrame(() => {


### PR DESCRIPTION
preserves scroll positions across hot reloads AND full refreshes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `useSteadyHotScroll` hook with `SteadyHotScroll` component and update HMR event types
> - Replaces WebSocket-based HMR detection in [`useHMR.ts`](https://github.com/reformcollective/library/pull/489/files#diff-a096d3dd194ade15e40049b4971c967989ba9f3e68937632c02dfb5a2b6d21b9) with Next.js internal dispatcher hooks, emitting typed events: `beforeRefresh`, `afterRefresh`, `beforeReload`, and `afterReload`.
> - Renames old event strings: `prebuild` → `beforeRefresh` and `postbuild` → `afterRefresh`; updates call sites in [`FirefoxFix.tsx`](https://github.com/reformcollective/library/pull/489/files#diff-8fa468a74cf871e09b98479faf729ba62210794d91ba1cb66cabde01222d84e3) and [`useAnimation.ts`](https://github.com/reformcollective/library/pull/489/files#diff-ebc83b44f3b8872d53cb1bea1d4091df0fb47318874d9f07c71fea454aa788ec).
> - Replaces the `useSteadyHotScroll` hook with a `SteadyHotScroll` component that must be rendered below `ScreenContext`; scroll position is now saved to `sessionStorage` on `beforeRefresh`/`beforeReload` and restored in a single `requestAnimationFrame` instead of being forced every frame for 1 second.
> - Behavioral Change: callers using `useHMR` with `"prebuild"` or `"postbuild"` event strings will no longer receive callbacks and must migrate to the new event names; `useSteadyHotScroll` must be replaced with the `SteadyHotScroll` component.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #489 opened
>
> - Replaced local variables with `useRef` hooks in `useSteadyHotScroll` to persist `requestAnimationFrame` IDs across renders [fa33cbe]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1876e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->