### PR TITLE
aspect ratio fix

### DIFF
--- a/sanity/assetMetadata.ts
+++ b/sanity/assetMetadata.ts
@@ -61,6 +61,7 @@ type ImageAssetMeta = {
 	extension?: string | null
 	url?: string | null
 	aspectRatio?: number | null
+	originalAspectRatio?: number | null
 }
 
 export type AssetMeta = VideoAssetMeta & ImageAssetMeta
@@ -73,6 +74,7 @@ export type ResolvedVideo = Omit<Video, "muxVideo"> & {
 	muxVideo?: ResolvedMuxVideo | null
 }
 
+// todo: move link resolution logic to project slug resolver?
 export const internalSlugField = `"internalSlug": select(
 		type != "internal" => null,
 		!defined(internalLink) => null,
@@ -91,7 +93,15 @@ export const imageDataProjection = `{
 		"size": asset->size,
 		"extension": asset->extension,
 		"url": asset->url,
-		"aspectRatio": asset->metadata.dimensions.aspectRatio
+		"originalAspectRatio": asset->metadata.dimensions.aspectRatio,
+		"aspectRatio": select(
+			(1 - coalesce(crop.left, 0) - coalesce(crop.right, 0)) > 0 &&
+			(1 - coalesce(crop.top, 0) - coalesce(crop.bottom, 0)) > 0 =>
+				asset->metadata.dimensions.aspectRatio *
+				((1 - coalesce(crop.left, 0) - coalesce(crop.right, 0)) /
+				(1 - coalesce(crop.top, 0) - coalesce(crop.bottom, 0))),
+			asset->metadata.dimensions.aspectRatio
+		)
 	}`
 
 // Matches fetchAssetMeta as closely as GROQ can. `videoBlurUrl` is kept as a


### PR DESCRIPTION
aspect ratio should respect cropping

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix aspect ratio calculation in `imageDataProjection` to account for crop dimensions
> - Adds `originalAspectRatio` to the `ImageAssetMeta` type and includes it in the `imageDataProjection` in [assetMetadata.ts](https://github.com/reformcollective/library/pull/490/files#diff-21a1b0cf75903ec16dfab0236a2aae247d372e72ae08fc09cdeaef578cbc34b8).
> - When a valid crop exists (cropped width and height are both positive), `aspectRatio` is now computed by multiplying `originalAspectRatio` by the crop's remaining width/height ratio; otherwise it falls back to `originalAspectRatio`.
> - Behavioral Change: `aspectRatio` previously always reflected the original asset dimensions; it now reflects cropped dimensions when a crop is applied.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c439cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->