### PR TITLE
simpler slug resolvers, asset metadata cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,55 @@
 
+# 2026-05-01
+
+## Simpler slug resolvers
+
+The library now expects each project `sanity/lib/slug-resolver.ts` to export two project-specific route representations:
+
+- `documentPaths`: JavaScript document-to-path/title rules for already-fetched Sanity documents
+- `documentPathProjection`: a GROQ expression that resolves paths at query time
+
+Shared document helper plumbing now lives in `library/sanity/document-helpers`. Project slug resolver files define route behavior, while document helpers provide linkable type extraction, production URL creation, and Presentation location resolution.
+
+**Migration Advice**
+
+Update `sanity/lib/slug-resolver.ts` to this shape:
+
+```ts
+import { defineDocumentPaths } from "library/sanity/define-document-paths"
+
+export const documentPaths = defineDocumentPaths({
+	page: (document) => ({
+		path: document.slug?.current === "home" ? "/" : `/${document.slug?.current}`,
+		title: document.title ?? "Untitled Page",
+	}),
+})
+
+export const documentPathProjection = <T>(document: T) =>
+	`
+	select(
+	  !defined(${document}) => null,
+		${document}._type == "page" => select(
+			${document}.slug.current == "home" => "/",
+			"/" + ${document}.slug.current
+		)
+	)
+` as const
+
+```
+
+Update sanity config to import utilities from `library/sanity/document-helpers`
+
+# 2026-04-30
+
+## removed `fetchAssetMeta` / `enrichAssets`
+
+`fetchAssetMeta` and the `enrichAssets` option on `libraryFetch` / `sanityFetch` have been removed. Asset, video, and link metadata should be resolved inline with `imageField`, `videoField`, or `linkField`.
+
+**Migration Advice**
+
+See 2026-04-13
+
+
 # 2026-04-29
 
 ## `useHMR` event types renamed; `useSteadyHotScroll` replaced by `SteadyHotScroll`

--- a/link/resolve.ts
+++ b/link/resolve.ts
@@ -21,7 +21,9 @@ export type LinkHref = string | null | undefined | CMSLink
 
 const normalizeInternalPath = (path: string) => {
 	const cleanPath = stegaClean(path)
-	return cleanPath.startsWith("/") ? cleanPath.replace(/^\/+/, "/") : `/${cleanPath}`
+	return cleanPath.startsWith("/")
+		? cleanPath.replace(/^\/+/, "/")
+		: `/${cleanPath}`
 }
 
 export const resolveRoute = (

--- a/link/resolve.ts
+++ b/link/resolve.ts
@@ -19,6 +19,11 @@ export type CMSLink = {
 /** All values accepted by resolveRoute / isRouteDefined. */
 export type LinkHref = string | null | undefined | CMSLink
 
+const normalizeInternalPath = (path: string) => {
+	const cleanPath = stegaClean(path)
+	return cleanPath.startsWith("/") ? cleanPath.replace(/^\/+/, "/") : `/${cleanPath}`
+}
+
 export const resolveRoute = (
 	link: LinkHref,
 ): { url: string | undefined; newTab: boolean } => {
@@ -34,12 +39,8 @@ export const resolveRoute = (
 		}
 
 	if (link.type === "internal" && link.internalSlug) {
-		const slugToUse =
-			link.internalSlug === "home" || link.internalSlug === "/"
-				? ""
-				: link.internalSlug
 		return {
-			url: `/${stegaClean(slugToUse || "")}${stegaClean(link.parameters || "")}${stegaClean(link.anchor || "")}`,
+			url: `${normalizeInternalPath(link.internalSlug)}${stegaClean(link.parameters || "")}${stegaClean(link.anchor || "")}`,
 			// default to same tab if not specified
 			newTab: link.blank ?? false,
 		}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
 	"//": "anything that the supermodule may also install should use the ^major syntax. this is so that pnpm can combine duplicate versions to prevent inflating the bundle. this doesn't apply to dev dependencies (e.g. biome)",
 	"dependencies": {
 		"@eslint/css-tree": "^3",
-		"@mux/blurup": "^1",
 		"@mux/mux-video-react": "^0.29",
 		"@sanity/image-url": "^2",
 		"@types/semver": "^7",

--- a/sanity/SanityImage.tsx
+++ b/sanity/SanityImage.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { createImageUrlBuilder } from "@sanity/image-url"
-import type { AssetMeta } from "library/sanity/assetMetadata"
+import type { ImageField } from "library/sanity/assetMetadata"
 import { styled } from "library/styled"
 import { stegaClean } from "next-sanity"
 import { use, useEffect, useId, useLayoutEffect, useState } from "react"
@@ -26,11 +26,12 @@ import {
 	lqipVar,
 } from "./SanityImage.css"
 
+// todo: ImageField and SanityImageData are the same shape?
 export type SanityImageData<WithAlt extends "true" | "false"> = {
 	asset?: { _ref: string }
 	crop?: SanityImageCrop
 	hotspot?: SanityImageHotspot
-	data: AssetMeta | null
+	data: ImageField['data'] | null
 	alt?: string
 	willHaveAlt?: WithAlt
 }

--- a/sanity/SanityImage.tsx
+++ b/sanity/SanityImage.tsx
@@ -31,7 +31,7 @@ export type SanityImageData<WithAlt extends "true" | "false"> = {
 	asset?: { _ref: string }
 	crop?: SanityImageCrop
 	hotspot?: SanityImageHotspot
-	data: ImageField['data'] | null
+	data: ImageField["data"] | null
 	alt?: string
 	willHaveAlt?: WithAlt
 }

--- a/sanity/assetMetadata.ts
+++ b/sanity/assetMetadata.ts
@@ -1,4 +1,76 @@
 import { documentPathProjection } from "sanity/lib/slug-resolver"
+import type {
+	MuxVideoAssetReference,
+	SanityImageAssetReference,
+	SanityImageCrop,
+	SanityImageHotspot,
+} from "sanity.types"
+
+// the three types below were directly copied from the starter's generated types
+
+export type ImageField = {
+	asset?: SanityImageAssetReference
+	media?: unknown
+	hotspot?: SanityImageHotspot
+	crop?: SanityImageCrop
+	alt?: string
+	willHaveAlt?: "true" | "false"
+	_type: "image"
+	data: {
+		lqip: string | null
+		dominantColor: string | null
+		originalFilename: string | null
+		size: number | null
+		extension: string | null
+		url: string | null
+		originalAspectRatio: number | null
+		aspectRatio: number | null
+	}
+}
+
+export type VideoField = {
+	_type: "video"
+	sourceType?:
+		| "mux"
+		| "spotify"
+		| "tiktok"
+		| "twitch"
+		| "url"
+		| "vimeo"
+		| "wistia"
+		| "youtube"
+	url?: string
+	muxVideo: {
+		_type: "mux.video"
+		asset?: MuxVideoAssetReference
+		data: {
+			playbackId: string | null
+			videoThumbnailUrl: string | null
+			videoBlurUrl: string | null
+			videoAspectRatio: string | null
+			videoDuration: number | null
+		}
+	} | null
+}
+
+export type LinkField = {
+	_type: "link"
+	text?: string
+	type?: string
+	internalLink?: {
+		_ref: string
+		_type: "reference"
+		_weak?: boolean
+	}
+	url?: string
+	email?: string
+	phone?: string
+	value?: string
+	blank?: boolean
+	parameters?: string
+	anchor?: string
+	internalSlug: null | string | "/"
+}
 
 const internalSlugField = `"internalSlug": select(
 		type != "internal" => null,

--- a/sanity/assetMetadata.ts
+++ b/sanity/assetMetadata.ts
@@ -1,85 +1,11 @@
-import { createBlurUp } from "@mux/blurup"
-import { sleep } from "library/functions"
-import { defineQuery, stegaClean } from "next-sanity"
-import { cache } from "react"
-import { sanityFetch } from "sanity/lib/live"
-import { internalLinkPathProjection, resolveLink } from "sanity/lib/slug-resolver"
-import type { Video } from "sanity.types"
-import { z } from "zod"
+import { documentPathProjection } from "sanity/lib/slug-resolver"
 
-export const getBlurUp = cache(async (playbackId: string) =>
-	Promise.race([
-		// this call may hang, so add a timeout
-		sleep(1000).then(() => ({
-			blurDataURL: undefined,
-			aspectRatio: undefined,
-		})),
-		createBlurUp(playbackId, {
-			time: 0,
-			quality: 2,
-		}),
-	]).catch(() => ({
-		blurDataURL: undefined,
-		aspectRatio: undefined,
-	})),
-)
-
-const assetSchema = z.object({
-	asset: z.object({
-		_ref: z.string(),
-	}),
-})
-
-const linkSchema = z.object({
-	internalLink: z.object({
-		_ref: z.string(),
-	}),
-	_type: z.string(),
-	text: z.optional(z.string()),
-	type: z.optional(z.string()),
-	url: z.optional(z.string()),
-	email: z.optional(z.string()),
-	phone: z.optional(z.string()),
-	value: z.optional(z.string()),
-	blank: z.optional(z.boolean()),
-	parameters: z.optional(z.string()),
-	anchor: z.optional(z.string()),
-})
-
-type VideoAssetMeta = {
-	playbackId?: string | null
-	videoThumbnailUrl?: string | null
-	videoBlurUrl?: string | null
-	videoAspectRatio?: string | null
-	videoDuration?: number | null
-}
-type ImageAssetMeta = {
-	lqip?: string | null
-	dominantColor?: string | null
-	originalFilename?: string | null
-	size?: number | null
-	extension?: string | null
-	url?: string | null
-	aspectRatio?: number | null
-	originalAspectRatio?: number | null
-}
-
-export type AssetMeta = VideoAssetMeta & ImageAssetMeta
-
-export type ResolvedMuxVideo = NonNullable<Video["muxVideo"]> & {
-	data: AssetMeta | null
-}
-
-export type ResolvedVideo = Omit<Video, "muxVideo"> & {
-	muxVideo?: ResolvedMuxVideo | null
-}
-
-export const internalSlugField = `"internalSlug": select(
+const internalSlugField = `"internalSlug": select(
 		type != "internal" => null,
-		${internalLinkPathProjection("internalLink->")}
+		${documentPathProjection("internalLink->")}
 	)`
 
-export const imageDataProjection = `{
+const imageDataProjection = `{
 		"lqip": asset->metadata.lqip,
 		"dominantColor": asset->metadata.palette.dominant.background,
 		"originalFilename": asset->originalFilename,
@@ -97,9 +23,7 @@ export const imageDataProjection = `{
 		)
 	}`
 
-// Matches fetchAssetMeta as closely as GROQ can. `videoBlurUrl` is kept as a
-// lightweight thumbnail URL rather than the old blur-up fetch step.
-export const muxVideoDataProjection = `{
+const muxVideoDataProjection = `{
 		"playbackId": asset->playbackId,
 		"videoThumbnailUrl": select(
 			defined(asset->thumbTime) =>
@@ -114,148 +38,26 @@ export const muxVideoDataProjection = `{
 		"videoDuration": asset->data.duration
 	}`
 
-export const linkProjection = `{ ..., ${internalSlugField} }`
+const linkProjection = `{ ..., ${internalSlugField} }`
 
-export const imageProjection = `{
+const imageProjection = `{
 		...,
 		"data": ${imageDataProjection}
 	}`
 
-export const muxVideoProjection = `{
+const muxVideoProjection = `{
 		...,
 		"data": ${muxVideoDataProjection}
-	}`
-
-export const videoProjection = `{ ..., muxVideo ${muxVideoProjection} }`
-
-export const linkField = (name: string) => `${name} ${linkProjection}`
-
-export const imageField = (name: string) => `${name} ${imageProjection}`
-
-export const videoField = (name: string) => `${name} ${videoProjection}`
-
-const assetQuery = defineQuery(`
-	*[_id == $asset && _type in [
-		"sanity.imageAsset",
-		"sanity.fileAsset",
-		"mux.videoAsset"
-	]][0]
-`)
-
-const linkQuery = defineQuery(`
-	*[_id == $asset && defined(slug.current)][0]
-`)
-
-/**
- * @deprecated Use query result types or explicit resolved aliases like
- * `ResolvedVideo` instead. `DeepAssetMeta` models the old `fetchAssetMeta`
- * post-processing step and is not the right abstraction for GROQ-resolved data.
- */
-export type DeepAssetMeta<T> = T extends { asset?: { _ref?: string } }
-	? T & { data: AssetMeta | null }
-	: T extends { _type: "link"; internalLink?: { _ref?: string } }
-		? T & { internalSlug?: string | null }
-		: T extends object
-			? { [K in keyof T]: DeepAssetMeta<T[K]> }
-			: T
-
-/**
- * @deprecated Enrich assets inline in your GROQ query instead using the provided helpers in this file
- */
-export const fetchAssetMeta = async <InputType>(
-	input: InputType,
-): Promise<DeepAssetMeta<InputType>> => {
-	type Output = DeepAssetMeta<InputType>
-
-	if (Array.isArray(input)) {
-		return (await Promise.all(input.map((i) => fetchAssetMeta(i)))) as Output
 	}
+`
 
-	if (typeof input === "object" && input !== null) {
-		const { data: assetParse, success: isAsset } = z.safeParse(
-			assetSchema,
-			input,
-		)
-		const { data: linkParse, success: isLink } = z.safeParse(linkSchema, input)
+const videoProjection = `{ ..., muxVideo ${muxVideoProjection} }`
 
-		if (isAsset) {
-			const { data: asset } = await sanityFetch({
-				query: assetQuery,
-				params: {
-					asset: assetParse.asset._ref,
-				},
-				enrichAssets: false,
-			})
-			if (!asset) {
-				return {
-					...input,
-					data: null,
-				} as Output
-			}
+export const linkField = <T extends string>(name: T) =>
+	`${name} ${linkProjection}` as const
 
-			const { blurDataURL } =
-				asset?._type === "mux.videoAsset" && asset.playbackId
-					? await getBlurUp(stegaClean(asset.playbackId))
-					: {}
+export const imageField = <T extends string>(name: T) =>
+	`${name} ${imageProjection}` as const
 
-			const meta = "metadata" in asset ? asset.metadata : null
-
-			const cleanPlaybackId =
-				asset?._type === "mux.videoAsset" && asset.playbackId
-					? stegaClean(asset.playbackId)
-					: undefined
-			const thumbTime =
-				asset?._type === "mux.videoAsset" ? asset.thumbTime : undefined
-			const videoThumbnailUrl = cleanPlaybackId
-				? `https://image.mux.com/${cleanPlaybackId}/thumbnail.jpg${thumbTime != null ? `?time=${thumbTime}` : ""}`
-				: undefined
-
-			const data =
-				asset._type === "mux.videoAsset"
-					? ({
-							playbackId: asset?.playbackId,
-							videoThumbnailUrl,
-							videoBlurUrl: blurDataURL,
-							videoAspectRatio: asset.data?.aspect_ratio?.replace(":", "/"),
-							videoDuration: asset?.data?.duration,
-						} satisfies VideoAssetMeta)
-					: ({
-							lqip: meta?.lqip,
-							dominantColor: meta?.palette?.dominant?.background,
-							originalFilename: asset?.originalFilename,
-							size: asset?.size,
-							extension: asset?.extension,
-							url: asset?.url,
-							aspectRatio: meta?.dimensions?.aspectRatio,
-						} satisfies ImageAssetMeta)
-
-			return {
-				...input,
-				data,
-			} as Output
-		}
-
-		if (isLink) {
-			const { data: linkedItem } = await sanityFetch({
-				query: linkQuery,
-				params: { asset: linkParse.internalLink._ref },
-				enrichAssets: false,
-			})
-
-			return {
-				...input,
-				internalSlug: resolveLink(linkedItem),
-			} as Output
-		}
-
-		return Object.fromEntries(
-			await Promise.all(
-				Object.entries(input).map(
-					async ([key, value]) => [key, await fetchAssetMeta(value)] as const,
-				),
-			),
-		) as Output
-	}
-
-	return input as Output
-}
+export const videoField = <T extends string>(name: T) =>
+	`${name} ${videoProjection}` as const

--- a/sanity/assetMetadata.ts
+++ b/sanity/assetMetadata.ts
@@ -3,7 +3,7 @@ import { sleep } from "library/functions"
 import { defineQuery, stegaClean } from "next-sanity"
 import { cache } from "react"
 import { sanityFetch } from "sanity/lib/live"
-import { resolveLink } from "sanity/lib/slug-resolver"
+import { internalLinkPathProjection, resolveLink } from "sanity/lib/slug-resolver"
 import type { Video } from "sanity.types"
 import { z } from "zod"
 
@@ -74,16 +74,9 @@ export type ResolvedVideo = Omit<Video, "muxVideo"> & {
 	muxVideo?: ResolvedMuxVideo | null
 }
 
-// todo: move link resolution logic to project slug resolver?
 export const internalSlugField = `"internalSlug": select(
 		type != "internal" => null,
-		!defined(internalLink) => null,
-		internalLink->._type == "page" => select(
-			internalLink->slug.current == "home" => "/",
-			internalLink->slug.current
-		),
-		internalLink->._type == "product" => "/products/" + internalLink->store.slug.current,
-		internalLink->._type == "collection" => "/collections/" + internalLink->store.slug.current
+		${internalLinkPathProjection("internalLink->")}
 	)`
 
 export const imageDataProjection = `{

--- a/sanity/backgroundImage.ts
+++ b/sanity/backgroundImage.ts
@@ -1,15 +1,12 @@
 import { css } from "library/styled"
 import { dataset, projectId } from "sanity/lib/api"
 import { buildSrcSet } from "sanity-image"
-import type { AssetMeta } from "./assetMetadata"
+import type { ImageField } from "./assetMetadata"
 
 const baseUrl = `https://cdn.sanity.io/images/${projectId}/${dataset}/`
 
 export const sanityImageToBackgroundImage = (
-	image: {
-		asset: { _ref: string }
-		data?: AssetMeta
-	},
+	image: ImageField,
 	/**
 	 * if your image is likely to be displayed larger than the screen,
 	 * you can increase this value to improve the quality

--- a/sanity/createSanityDataAttribute.ts
+++ b/sanity/createSanityDataAttribute.ts
@@ -10,6 +10,9 @@ export const createSanityDataAttribute = ({
 }: {
 	documentId: string
 	documentType: string
+	/**
+	 * this is NOT the pathname, but rather a path to the property you want click-to-edit to go to
+	 */
 	path: string
 }) => {
 	return createDataAttribute({

--- a/sanity/define-document-paths.ts
+++ b/sanity/define-document-paths.ts
@@ -1,0 +1,21 @@
+import type { AllSanitySchemaTypes } from "sanity.types"
+
+type Schemas = Extract<AllSanitySchemaTypes, { _type: string }>
+
+export type DocumentPath = {
+	path: string | null | undefined
+	title: string | null | undefined
+}
+
+export type DocumentPathResult = null | undefined | DocumentPath
+
+export type DocumentPathResolver<U extends { _type: string } = Schemas> = {
+	[K in U["_type"]]?: (document: Extract<U, { _type: K }>) => DocumentPathResult
+}
+
+/**
+ * Typing helper for project-owned document path declarations.
+ */
+export const defineDocumentPaths = <U extends { _type: string } = Schemas>(
+	resolver: DocumentPathResolver<U>,
+) => resolver

--- a/sanity/document-helpers.ts
+++ b/sanity/document-helpers.ts
@@ -1,29 +1,13 @@
 import { siteURL } from "library/siteURL"
 import { map } from "rxjs"
 import { documentPaths } from "sanity/lib/slug-resolver"
-import type { DocumentLocationResolver } from "sanity/presentation"
+import type {
+	DocumentLocationResolver,
+	DocumentLocationsState,
+} from "sanity/presentation"
 
 type SanityDocument = {
 	_type?: string
-}
-
-type DocumentLocation = {
-	href: string
-	title: string
-}
-
-const normalizeLocation = (
-	route:
-		| { path: string | null | undefined; title: string | null | undefined }
-		| null
-		| undefined,
-): DocumentLocation | undefined => {
-	if (!route?.path || !route.title) return undefined
-
-	return {
-		href: route.path,
-		title: route.title,
-	}
 }
 
 const resolveDocumentRoute = (document: unknown) => {
@@ -41,14 +25,14 @@ const resolveDocumentRoute = (document: unknown) => {
  * Resolves a fetched Sanity document to its canonical public pathname
  */
 export const resolveDocumentPathname = (document: unknown) => {
-	return normalizeLocation(resolveDocumentRoute(document))?.href
+	return resolveDocumentRoute(document)?.path || null
 }
 
 /**
  * Resolves a fetched Sanity document to its canonical public title
  */
 export const resolveDocumentTitle = (document: unknown) => {
-	return normalizeLocation(resolveDocumentRoute(document))?.title
+	return resolveDocumentRoute(document)?.title || null
 }
 
 /**
@@ -69,16 +53,9 @@ export const getLinkableTypes = () => {
 }
 
 /**
- * Resolves a fetched Sanity document to the Presentation location shape
- */
-export const resolveDocumentLocation = (document: unknown) => {
-	return normalizeLocation(resolveDocumentRoute(document))
-}
-
-/**
  * Adapts document path declarations to Sanity Presentation's locations API
  */
-export const documentLocationsResolver: DocumentLocationResolver = (
+export const resolveDocumentLocations: DocumentLocationResolver = (
 	{ id },
 	context,
 ) => {
@@ -91,13 +68,14 @@ export const documentLocationsResolver: DocumentLocationResolver = (
 	return doc$.pipe(
 		map((document: SanityDocument | null) => {
 			if (!document) return { locations: [] }
-
-			const location = resolveDocumentLocation(document)
-			if (!location) return { locations: [] }
+			const href = resolveDocumentPathname(document)
+			if (!href) return { locations: [] }
 
 			return {
-				locations: [location],
-			}
+				locations: [
+					{ href, title: resolveDocumentTitle(document) || "No Title" },
+				],
+			} satisfies DocumentLocationsState
 		}),
 	)
 }

--- a/sanity/document-helpers.ts
+++ b/sanity/document-helpers.ts
@@ -1,0 +1,103 @@
+import { siteURL } from "library/siteURL"
+import { map } from "rxjs"
+import { documentPaths } from "sanity/lib/slug-resolver"
+import type { DocumentLocationResolver } from "sanity/presentation"
+
+type SanityDocument = {
+	_type?: string
+}
+
+type DocumentLocation = {
+	href: string
+	title: string
+}
+
+const normalizeLocation = (
+	route:
+		| { path: string | null | undefined; title: string | null | undefined }
+		| null
+		| undefined,
+): DocumentLocation | undefined => {
+	if (!route?.path || !route.title) return undefined
+
+	return {
+		href: route.path,
+		title: route.title,
+	}
+}
+
+const resolveDocumentRoute = (document: unknown) => {
+	const sanityDocument = document as SanityDocument | null | undefined
+	if (!sanityDocument?._type) return undefined
+
+	const resolver =
+		documentPaths[sanityDocument._type as keyof typeof documentPaths]
+	if (!resolver) return undefined
+
+	return resolver(sanityDocument as never)
+}
+
+/**
+ * Resolves a fetched Sanity document to its canonical public pathname
+ */
+export const resolveDocumentPathname = (document: unknown) => {
+	return normalizeLocation(resolveDocumentRoute(document))?.href
+}
+
+/**
+ * Resolves a fetched Sanity document to its canonical public title
+ */
+export const resolveDocumentTitle = (document: unknown) => {
+	return normalizeLocation(resolveDocumentRoute(document))?.title
+}
+
+/**
+ * Resolves a fetched Sanity document to its absolute production URL
+ */
+export const resolveProductionUrl = (document: unknown) => {
+	const path = resolveDocumentPathname(document)
+	if (!path) return undefined
+
+	return `${siteURL}${path}`
+}
+
+/**
+ * Returns the schema types that have document path declarations.
+ */
+export const getLinkableTypes = () => {
+	return Object.keys(documentPaths)
+}
+
+/**
+ * Resolves a fetched Sanity document to the Presentation location shape
+ */
+export const resolveDocumentLocation = (document: unknown) => {
+	return normalizeLocation(resolveDocumentRoute(document))
+}
+
+/**
+ * Adapts document path declarations to Sanity Presentation's locations API
+ */
+export const documentLocationsResolver: DocumentLocationResolver = (
+	{ id },
+	context,
+) => {
+	const doc$ = context.documentStore.listenQuery(
+		`*[_id==$id][0]`,
+		{ id },
+		{ perspective: "previewDrafts" },
+	)
+
+	return doc$.pipe(
+		map((document: SanityDocument | null) => {
+			if (!document) return { locations: [] }
+
+			const location = resolveDocumentLocation(document)
+			if (!location) return { locations: [] }
+
+			return {
+				locations: [location],
+			}
+		}),
+	)
+}

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -1,7 +1,9 @@
-import { fetchAssetMeta } from "library/sanity/assetMetadata"
 import DraftModeOverlay from "library/sanity/DraftModeOverlay"
 import { draftMode } from "next/headers"
-import type { ClientPerspective, QueryParams } from "next-sanity"
+import type {
+    ClientPerspective,
+    QueryParams
+} from "next-sanity"
 import { defineLive } from "next-sanity/live"
 import { version as nextSanityVersion } from "next-sanity/package.json"
 import { client } from "sanity/lib/client"
@@ -35,7 +37,6 @@ export async function libraryFetch<const QueryString extends string>({
 	params = {},
 	perspective,
 	disableStega,
-	enrichAssets = false,
 }: {
 	query: QueryString
 	params?: QueryParams | Promise<QueryParams>
@@ -51,32 +52,13 @@ export async function libraryFetch<const QueryString extends string>({
 	 * otherwise, stega should be undefined
 	 */
 	disableStega?: boolean
-	/**
-	 * Opt-in to legacy post-query asset enrichment via `fetchAssetMeta`.
-	 * Prefer resolving asset data inline in your GROQ query using the helpers in
-	 * `library/sanity/assetMetadata.ts` such as `imageField`, `imageProjection`,
-	 * `videoField`, `videoProjection`, and related data projections.
-	 *
-	 * Any image data passed to `SanityImage` / `UniversalImage` should include
-	 * the inline metadata it needs rather than relying on post-query enrichment.
-	 *
-	 * @deprecated Set `enrichAssets: true` only on legacy call-sites that have
-	 * not yet been migrated to inline GROQ projections.
-	 */
-	enrichAssets?: boolean
 }) {
-	const { data, sourceMap, tags } = await internalFetch({
+	return await internalFetch({
 		query,
 		params,
 		stega: disableStega ? false : undefined,
 		perspective,
 	})
-
-	return {
-		data: enrichAssets ? await fetchAssetMeta(data) : data,
-		sourceMap,
-		tags,
-	}
 }
 
 const useProxy =

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -1,9 +1,6 @@
 import DraftModeOverlay from "library/sanity/DraftModeOverlay"
 import { draftMode } from "next/headers"
-import type {
-    ClientPerspective,
-    QueryParams
-} from "next-sanity"
+import type { ClientPerspective, QueryParams } from "next-sanity"
 import { defineLive } from "next-sanity/live"
 import { version as nextSanityVersion } from "next-sanity/package.json"
 import { client } from "sanity/lib/client"

--- a/sanity/rxjs.ts
+++ b/sanity/rxjs.ts
@@ -1,1 +1,0 @@
-export * from "rxjs"

--- a/videos/BackgroundVideo.tsx
+++ b/videos/BackgroundVideo.tsx
@@ -7,27 +7,9 @@ import { ScreenContext } from "library/ScreenContext"
 import { css, f, styled } from "library/styled"
 import SanityUniversalImage from "library/UniversalImage"
 import { use, useEffect, useRef, useState } from "react"
-import type {
-	internalGroqTypeReferenceTo,
-	SanityImageCrop,
-	SanityImageHotspot,
-} from "sanity.types"
-import type { AssetMeta } from "../sanity/assetMetadata"
+import type { ImageField } from "../sanity/assetMetadata"
 
-type SanityPosterImage = {
-	asset?: {
-		_ref: string
-		_type: "reference"
-		_weak?: boolean
-		[internalGroqTypeReferenceTo]?: "sanity.imageAsset"
-	}
-	media?: unknown
-	hotspot?: SanityImageHotspot
-	crop?: SanityImageCrop
-	alt?: string
-	willHaveAlt?: "true"
-	data?: AssetMeta
-}
+type SanityPosterImage = ImageField
 
 export function BackgroundVideo({
 	playbackId,

--- a/videos/VideoEmbed.tsx
+++ b/videos/VideoEmbed.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import ClientOnly from "library/ClientOnly"
-import type { ResolvedVideo } from "library/sanity/assetMetadata"
+import type { VideoField } from "library/sanity/assetMetadata"
 import { css, f, styled } from "library/styled"
 import { useCombinedRefs } from "library/useCombinedRefs"
 import { stegaClean } from "next-sanity"
@@ -14,13 +14,13 @@ type VideoEmbedProps = Omit<
 > & {
 	ref?: React.Ref<HTMLVideoElement>
 	className?: string
-	video: ResolvedVideo
+	video: VideoField
 	controls?: boolean
 	/** When true, seeks to 0 each time playback starts */
 	resetOnPlay?: boolean
 }
 
-function getVideoSrc(video: ResolvedVideo) {
+function getVideoSrc(video: VideoField) {
 	if (stegaClean(video.sourceType) === "mux") {
 		const playbackId = video.muxVideo?.data?.playbackId
 		return {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Replace `fetchAssetMeta`/`enrichAssets` with inline GROQ field helpers and simplify slug resolution
- Removes post-query asset enrichment (`fetchAssetMeta`, `enrichAssets`) from [`assetMetadata.ts`](https://github.com/reformcollective/library/pull/492/files#diff-21a1b0cf75903ec16dfab0236a2aae247d372e72ae08fc09cdeaef578cbc34b8) and [`reusableFetch.tsx`](https://github.com/reformcollective/library/pull/492/files#diff-133b49b7bb8d0ef32f864830fdb361dabf4df3cce6c82c54835099255a9458aa); asset data is now fetched inline via new `imageField`, `videoField`, and `linkField` GROQ projection helpers.
- Adds `ImageField`, `VideoField`, and `LinkField` TypeScript types to replace ad-hoc inline types across [`SanityImage.tsx`](https://github.com/reformcollective/library/pull/492/files#diff-59a4c4cb3eacb0e5a370aa0ec01497fbfbda9760d252ebe0d4062f0a14d51a92), [`BackgroundVideo.tsx`](https://github.com/reformcollective/library/pull/492/files#diff-ac7841958726f7672f19b539a3c48e0025bd46b542551e086a4d081b15bad67d), and [`VideoEmbed.tsx`](https://github.com/reformcollective/library/pull/492/files#diff-042b97c622f16cc850f109bc9e3adcb3693d911d3226374851c7b8e91bc96da4).
- Introduces [`document-helpers.ts`](https://github.com/reformcollective/library/pull/492/files#diff-0c27901ee5d08bae6fa5ad315dfc93c03daf00d1a553ebc570fbdd59d5d59b3f) with `resolveDocumentPathname`, `resolveDocumentTitle`, `resolveProductionUrl`, `getLinkableTypes`, and a Presentation-compatible `resolveDocumentLocations` adapter.
- Simplifies internal slug resolution in [`resolve.ts`](https://github.com/reformcollective/library/pull/492/files#diff-b76a108741b62f04027c6baaedb68c5e9d61e6b482fe9e7a43f385e71615263a) via `normalizeInternalPath`; removes special-casing of `'home'` and `'/'`.
- Risk: `'home'` slugs previously resolved to the site root (`/`) now resolve to `/home`; `enrichAssets` is no longer accepted by `libraryFetch` and the `sanity/rxjs` re-export is removed.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24956cf.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->