### PR TITLE
prevent widening to any if typegen fails

### DIFF
--- a/sanity/assetMetadata.ts
+++ b/sanity/assetMetadata.ts
@@ -75,7 +75,7 @@ export type LinkField = {
 const internalSlugField = `"internalSlug": select(
 		type != "internal" => null,
 		${documentPathProjection("internalLink->")}
-	)`
+	)` as const
 
 const imageDataProjection = `{
 		"lqip": asset->metadata.lqip,
@@ -93,7 +93,7 @@ const imageDataProjection = `{
 				(1 - coalesce(crop.top, 0) - coalesce(crop.bottom, 0))),
 			asset->metadata.dimensions.aspectRatio
 		)
-	}`
+	}` as const
 
 const muxVideoDataProjection = `{
 		"playbackId": asset->playbackId,
@@ -108,22 +108,22 @@ const muxVideoDataProjection = `{
 				string::split(asset->data.aspect_ratio, ":")[0] + "/" + string::split(asset->data.aspect_ratio, ":")[1]
 		),
 		"videoDuration": asset->data.duration
-	}`
+	}` as const
 
-const linkProjection = `{ ..., ${internalSlugField} }`
+const linkProjection = `{ ..., ${internalSlugField} }` as const
 
 const imageProjection = `{
 		...,
 		"data": ${imageDataProjection}
-	}`
+	}` as const
 
 const muxVideoProjection = `{
 		...,
 		"data": ${muxVideoDataProjection}
 	}
-`
+` as const
 
-const videoProjection = `{ ..., muxVideo ${muxVideoProjection} }`
+const videoProjection = `{ ..., muxVideo ${muxVideoProjection} }` as const
 
 export const linkField = <T extends string>(name: T) =>
 	`${name} ${linkProjection}` as const

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -1,13 +1,13 @@
 import DraftModeOverlay from "library/sanity/DraftModeOverlay"
+import { draftMode } from "next/headers"
 import type {
-    ClientPerspective,
-    ClientReturn,
-    ContentSourceMap,
-    QueryParams
+	ClientPerspective,
+	ClientReturn,
+	ContentSourceMap,
+	QueryParams,
 } from "next-sanity"
 import { defineLive } from "next-sanity/live"
 import { version as nextSanityVersion } from "next-sanity/package.json"
-import { draftMode } from "next/headers"
 import { client } from "sanity/lib/client"
 import { token } from "sanity/lib/token"
 import { version as sanityVersion } from "sanity/package.json"

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -1,8 +1,13 @@
 import DraftModeOverlay from "library/sanity/DraftModeOverlay"
-import { draftMode } from "next/headers"
-import type { ClientPerspective, QueryParams } from "next-sanity"
+import type {
+    ClientPerspective,
+    ClientReturn,
+    ContentSourceMap,
+    QueryParams
+} from "next-sanity"
 import { defineLive } from "next-sanity/live"
 import { version as nextSanityVersion } from "next-sanity/package.json"
+import { draftMode } from "next/headers"
 import { client } from "sanity/lib/client"
 import { token } from "sanity/lib/token"
 import { version as sanityVersion } from "sanity/package.json"
@@ -22,6 +27,14 @@ const { sanityFetch: internalFetch, SanityLive: InternalLive } = defineLive({
 	browserToken: token,
 	fetchOptions: { revalidate: Infinity },
 })
+
+type IsAny<T> = 0 extends 1 & T ? true : false
+type UnknownIfAny<T> = IsAny<T> extends true ? unknown : T
+type LibraryFetchResult<QueryString extends string> = {
+	data: UnknownIfAny<ClientReturn<QueryString>>
+	sourceMap: ContentSourceMap | null
+	tags: string[]
+}
 
 /**
  * Used to fetch data in Server Components, it has built in support for handling Draft Mode and perspectives.
@@ -49,7 +62,7 @@ export async function libraryFetch<const QueryString extends string>({
 	 * otherwise, stega should be undefined
 	 */
 	disableStega?: boolean
-}) {
+}): Promise<LibraryFetchResult<QueryString>> {
 	return await internalFetch({
 		query,
 		params,


### PR DESCRIPTION
if a fragment isn't marked `as const` it might widen the type of the query to `string`



this means that the queried type doesn't match the generated type, and sanityFetch previously would widen the type to `any`

we force the type to `unknown` in this case so that callers are forced to correctly type their query.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent `libraryFetch` return type from widening to `any` when typegen fails
> - Adds `IsAny` and `UnknownIfAny` utility types in [`sanity/reusableFetch.tsx`](https://github.com/reformcollective/library/pull/493/files#diff-133b49b7bb8d0ef32f864830fdb361dabf4df3cce6c82c54835099255a9458aa) to detect when `ClientReturn<QueryString>` resolves to `any` (e.g. when Sanity typegen hasn't run) and substitutes `unknown` instead.
> - Introduces `LibraryFetchResult<QueryString>` to explicitly type the return value of `libraryFetch`, using `UnknownIfAny` to guard the `data` field.
> - Adds `as const` assertions to GROQ projection string constants in [`sanity/assetMetadata.ts`](https://github.com/reformcollective/library/pull/493/files#diff-21a1b0cf75903ec16dfab0236a2aae247d372e72ae08fc09cdeaef578cbc34b8) so they retain their literal types and produce accurate `ClientReturn` inference.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a11bd2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->