### PR TITLE
add clip option to autoanimate

### DIFF
--- a/AutoAnimate.tsx
+++ b/AutoAnimate.tsx
@@ -68,6 +68,7 @@ export default function AutoAnimate({
 	toParameters,
 	alignment = "start",
 	className = "",
+	clip = true,
 }: {
 	/**
 	 * A react element to display. We'll smoothly animate this into view when its key changes
@@ -109,6 +110,11 @@ export default function AutoAnimate({
 	 * @default start
 	 */
 	alignment?: AutoAnimateAlignment
+	/**
+	 * pass false to disable clipping on the container
+	 * @default true
+	 */
+	clip?: boolean
 	/**
 	 * if you need to style this, you can. be careful though. be very careful.
 	 */
@@ -303,15 +309,16 @@ export default function AutoAnimate({
 	})
 
 	return (
-		<Wrapper className={className}>
+		<Wrapper className={className} clip={clip}>
 			<AnimationWrapper
 				ref={sizer}
 				alignment={alignment}
+				clip={clip}
 				style={{ display: "none" }}
 			>
 				<div>{getNodeFromKey(currentKey)}</div>
 			</AnimationWrapper>
-			<AnimationWrapper ref={wrapper} alignment={alignment}>
+			<AnimationWrapper ref={wrapper} alignment={alignment} clip={clip}>
 				<div ref={wrapperA}>{getNodeFromKey(slotA)}</div>
 				<div ref={wrapperB}>{getNodeFromKey(slotB)}</div>
 			</AnimationWrapper>
@@ -320,10 +327,23 @@ export default function AutoAnimate({
 }
 
 const Wrapper = styled("div", {
-	"@layer": {
-		[library]: unresponsive(css`
-			overflow: clip;
-		`),
+	variants: {
+		clip: {
+			true: {
+				"@layer": {
+					[library]: unresponsive(css`
+						overflow: clip;
+					`),
+				},
+			},
+			false: {
+				"@layer": {
+					[library]: unresponsive(css`
+						overflow: visible;
+					`),
+				},
+			},
+		},
 	},
 })
 
@@ -350,6 +370,24 @@ const AnimationWrapper = styled("div", {
 					}
 				}
 			`),
+		},
+	},
+	variants: {
+		clip: {
+			true: {
+				"@layer": {
+					[library]: unresponsive(css`
+						overflow: clip;
+					`),
+				},
+			},
+			false: {
+				"@layer": {
+					[library]: unresponsive(css`
+						overflow: visible;
+					`),
+				},
+			},
 		},
 	},
 	tokens: { alignment },


### PR DESCRIPTION
often helpful to disable clipping

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `clip` prop to `AutoAnimate` to control overflow visibility during animations
> Adds a boolean `clip` prop (default `true`) to the `AutoAnimate` component in [AutoAnimate.tsx](https://github.com/reformcollective/library/pull/495/files#diff-c430f57cc8938addeaee4a9d912effde51749ff22c8f432e75c0d7a2f5ce8d77). When `false`, both `Wrapper` and `AnimationWrapper` set `overflow: visible` instead of `overflow: clip`, allowing animated content to overflow its container boundaries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0a822b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->