### PR TITLE
sanity helper swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,32 @@
 
+# 2026-05-04
+
+## Sanity data attribute helper now uses serializable context
+
+`createSanityDataAttribute` has been replaced by `getSanityDataAttribute`.
+
+**Migration Advice**
+
+Attribute context includes document id, type, and a path to the relevant section on the page:
+
+```tsx
+const sectionContext = {
+	sanityDataAttribute: {
+		documentId: relevantPage._id,
+		documentType: relevantPage._type,
+		pathPrefix: `sections[${index}]`,
+	},
+}
+```
+
+Then update section call sites:
+
+```tsx
+import { getSanityDataAttribute } from "library/sanity/getSanityDataAttribute"
+
+<div data-sanity={getSanityDataAttribute(sanityDataAttribute, "title")} />
+```
+
 # 2026-05-01
 
 ## Simpler slug resolvers

--- a/sanity/getSanityDataAttribute.ts
+++ b/sanity/getSanityDataAttribute.ts
@@ -3,24 +3,25 @@ import { siteURL } from "library/siteURL"
 import { createDataAttribute } from "next-sanity"
 import { studioUrl } from "sanity/lib/api"
 
-export const createSanityDataAttribute = ({
-	documentId,
-	path,
-	documentType,
-}: {
+export type SanityDataAttributeContext = {
 	documentId: string
 	documentType: string
+	pathPrefix: string
+}
+
+export const getSanityDataAttribute = (
+	{ documentId, documentType, pathPrefix }: SanityDataAttributeContext,
 	/**
 	 * this is NOT the pathname, but rather a path to the property you want click-to-edit to go to
 	 */
-	path: string
-}) => {
+	path: string,
+) => {
 	return createDataAttribute({
 		projectId: env.NEXT_PUBLIC_SANITY_PROJECT_ID,
 		dataset: env.NEXT_PUBLIC_SANITY_DATASET,
 		baseUrl: `${siteURL}${studioUrl}`,
 		id: documentId,
 		type: documentType,
-		path,
+		path: `${pathPrefix}.${path}`,
 	}).toString()
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Replace `createSanityDataAttribute` with `getSanityDataAttribute` in sanity helper
- Renames the exported function in [getSanityDataAttribute.ts](https://github.com/reformcollective/library/pull/496/files#diff-d2821410902c476575b50b713f1097c77fcca39bd4291b95f28e1a73e70a0b6f) from `createSanityDataAttribute` to `getSanityDataAttribute`.
- The new signature accepts a `SanityDataAttributeContext` object (`documentId`, `documentType`, `pathPrefix`) and a separate `path` string, replacing the previous single-argument shape.
- The generated data attribute path now includes a prefix segment in the form `<pathPrefix>.<path>`.
- Exports a new `SanityDataAttributeContext` type for callers to pass a serializable context.
- Behavioral Change: all existing callers must update to the new function name and split context/path into separate arguments.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca4ab87.</sup>
<!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->