### PR TITLE
tweak data attribute uti

### DIFF
--- a/sanity/getSanityDataAttribute.ts
+++ b/sanity/getSanityDataAttribute.ts
@@ -22,6 +22,6 @@ export const getSanityDataAttribute = (
 		baseUrl: `${siteURL}${studioUrl}`,
 		id: documentId,
 		type: documentType,
-		path: `${pathPrefix}.${path}`,
+		path: [pathPrefix, path].filter(Boolean).join("."),
 	}).toString()
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix `getSanityDataAttribute` path construction to avoid spurious dots and `undefined` segments
Replaces the template literal `${pathPrefix}.${path}` with an array of segments that filters out falsy values before joining with a dot. This prevents paths like `undefined.foo` or `.foo` when `pathPrefix` or `path` is falsy.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f7701a.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->