### PR TITLE
Support static route link options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,38 @@
 
 # 2026-05-04
 
+## `compileTime` is now exported from `library/compile-time`
+
+`compileTime` has moved out of `library/styled` because it is not part of the styled API. Import it from `library/compile-time` instead.
+
+The vanilla splitter now requires every `compileTime(...)` call to be awaited. This keeps sync and async build-time values using the same call shape, and prevents async values from being emitted into the bundle before they resolve.
+
+```ts
+import { compileTime } from "library/compile-time"
+
+export const syncValue = await compileTime(() => "serialized at build time")
+export const asyncValue = await compileTime(async () => {
+	return await fetchBuildTimeValue()
+})
+```
+
+`compileTime` still returns the callback result directly. The required `await` is intentional because awaiting a non-Promise value is a no-op, while awaiting a Promise ensures it resolves before bundling continues.
+
+**Migration Advice**
+
+```ts
+// before
+import { compileTime, css } from "library/styled"
+
+const value = compileTime(() => "build-time value")
+
+// after
+import { compileTime } from "library/compile-time"
+import { css } from "library/styled"
+
+const value = await compileTime(() => "build-time value")
+```
+
 ## Sanity data attribute helper now uses serializable context
 
 `createSanityDataAttribute` has been replaced by `getSanityDataAttribute`.

--- a/compile-time.ts
+++ b/compile-time.ts
@@ -1,0 +1,3 @@
+export function compileTime<T>(getValue: () => T): T {
+	return getValue()
+}

--- a/link/resolve.ts
+++ b/link/resolve.ts
@@ -1,6 +1,8 @@
 import { stegaClean } from "next-sanity"
 import { linkIsInternal } from "../functions"
 
+export const staticPageLinkType = "static-page"
+
 export type CMSLink = {
 	_type: "link"
 	text?: string
@@ -63,6 +65,15 @@ export const resolveRoute = (
 		return {
 			url: `tel:${stegaClean(link.phone || "")}`,
 			newTab: true,
+		}
+	}
+
+	if (link.type === staticPageLinkType && link.value) {
+		const url = `${stegaClean(link.value)}${stegaClean(link.parameters || "")}${stegaClean(link.anchor || "")}`
+
+		return {
+			url,
+			newTab: link.blank ?? !linkIsInternal(url),
 		}
 	}
 

--- a/link/staticLinkType.ts
+++ b/link/staticLinkType.ts
@@ -1,0 +1,24 @@
+import { LinkIcon } from "@sanity/icons"
+import { compileTime } from "library/compile-time"
+import { listStaticRoutes } from "library/list-pages"
+import type { CustomLinkType } from "sanity-plugin-link-field"
+import { staticPageLinkType } from "./resolve"
+
+const staticPageOptions = await compileTime(async () => {
+	const routes = await listStaticRoutes()
+
+	return routes.map((route) => ({
+		title: route,
+		value: route,
+	}))
+})
+
+export function staticLinkType(): CustomLinkType {
+	return {
+		title: "Static Page",
+		value: staticPageLinkType,
+		icon: LinkIcon,
+		description: "Link to a hardcoded route in the app.",
+		options: staticPageOptions,
+	}
+}

--- a/list-pages.ts
+++ b/list-pages.ts
@@ -1,0 +1,47 @@
+import { glob } from "node:fs/promises"
+
+const pageFileGlob = "app/**/page.{js,jsx,ts,tsx}"
+const pageFilePattern = /^page\.(js|jsx|ts|tsx)$/
+
+export function normalizeRoutePath(path: string) {
+	let normalizedPath = path.startsWith("/") ? path : `/${path}`
+	normalizedPath = normalizedPath.replace(/\/{2,}/g, "/")
+
+	if (normalizedPath.length > 1 && normalizedPath.endsWith("/"))
+		normalizedPath = normalizedPath.slice(0, -1)
+
+	return normalizedPath
+}
+
+export function isDynamicRoutePath(path: string) {
+	return path
+		.replaceAll("\\", "/")
+		.split("/")
+		.some((segment) => /\[.+\]/.test(segment))
+}
+
+export function pageFilePathToRoute(path: string) {
+	const parts = path.replaceAll("\\", "/").split("/").filter(Boolean)
+	const withoutApp = parts[0] === "app" ? parts.slice(1) : parts
+	const withoutPageFile = pageFilePattern.test(withoutApp.at(-1) ?? "")
+		? withoutApp.slice(0, -1)
+		: withoutApp
+
+	const routeParts = withoutPageFile.filter(
+		(segment) => !(segment.startsWith("(") && segment.endsWith(")")),
+	)
+
+	return normalizeRoutePath(`/${routeParts.join("/")}`)
+}
+
+export async function listStaticRoutes() {
+	const routes = new Set<string>()
+
+	for await (const entry of glob(pageFileGlob)) {
+		if (isDynamicRoutePath(entry)) continue
+
+		routes.add(pageFilePathToRoute(entry))
+	}
+
+	return Array.from(routes).sort()
+}

--- a/reset.tsx
+++ b/reset.tsx
@@ -1,4 +1,5 @@
-import { compileTime, css } from "library/styled"
+import { compileTime } from "library/compile-time"
+import { css } from "library/styled"
 import { reset } from "./layers.css"
 
 const style = css`
@@ -286,6 +287,6 @@ display:revert; revert to element instead of attribute */
 	}
 `
 
-const builtStyle = compileTime(() => style)
+const builtStyle = await compileTime(() => style)
 
 export const ResetStyles = () => <style>{builtStyle}</style>

--- a/sanity/reusableFetch.tsx
+++ b/sanity/reusableFetch.tsx
@@ -72,7 +72,7 @@ export async function libraryFetch<const QueryString extends string>({
 	})
 }
 
-const useProxy =
+const canUseLiveProxy =
 	// vercel has fluid compute baybeeee
 	// local obviously is persistent too
 	// other providers should be tested and evaluated as needed
@@ -80,16 +80,17 @@ const useProxy =
 
 export const LibraryLive = async () => {
 	const { isEnabled: isDraftMode } = await draftMode()
+	const useLiveProxy = canUseLiveProxy && !isDraftMode
 
 	return (
 		<>
-			{useProxy && <SanityLiveProxy />}
+			{useLiveProxy && <SanityLiveProxy />}
 			<Toaster />
 			<SanityPreviewStatusToast isDraftMode={isDraftMode} />
 			<SanityVisualEditingOverlay isDraftMode={isDraftMode} />
 			{isDraftMode && <FirefoxFix />}
 			<LiveWrapper>
-				{(isDraftMode || !useProxy) && (
+				{(isDraftMode || !useLiveProxy) && (
 					<InternalLive
 						onError={handleError}
 						refreshOnFocus={false}

--- a/styled/index.ts
+++ b/styled/index.ts
@@ -16,10 +16,6 @@ export * from "./vanilla"
 
 export const css = String.raw
 
-export function compileTime<T>(getValue: () => T): T {
-	return getValue()
-}
-
 // using a union for the type of Component will cause
 // generic forwarding to fail, so we have overloads for each type
 

--- a/vanilla/vanilla-split-loader.test.ts
+++ b/vanilla/vanilla-split-loader.test.ts
@@ -94,6 +94,50 @@ function expectValidTypeScript(code: string, filename = "test.tsx") {
 	}
 }
 
+function decodeDataUrlModules(code: string) {
+	return [...code.matchAll(/data:text\/javascript;base64,([^"]+)/g)].map(
+		(match) => Buffer.from(match[1] ?? "", "base64").toString("utf8"),
+	)
+}
+
+function hasExportedVariable(code: string, name: string) {
+	const sourceFile = ts.createSourceFile(
+		"generated.ts",
+		code,
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.TS,
+	)
+
+	for (const statement of sourceFile.statements) {
+		if (!ts.isVariableStatement(statement)) continue
+
+		const isExported = statement.modifiers?.some(
+			(modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+		)
+		if (!isExported) continue
+
+		for (const declaration of statement.declarationList.declarations) {
+			if (!ts.isIdentifier(declaration.name)) continue
+			if (declaration.name.text !== name) continue
+
+			return true
+		}
+	}
+
+	return false
+}
+
+async function importVirtualModuleForTest(code: string) {
+	const testableCode = code.replace(
+		/import\s+\{\s*compileTime\s*\}\s+from\s+["']library\/compile-time["'];?/,
+		"function compileTime(getValue) { return getValue() }",
+	)
+	const url = `data:text/javascript;base64,${Buffer.from(testableCode).toString("base64")}`
+
+	return await import(url)
+}
+
 // Mock the turboLoader to return a simple passthrough
 vi.mock("@vanilla-extract/turbopack-plugin", () => ({
 	default: {
@@ -854,6 +898,82 @@ export const button = style({ color: "red" })`
 			// globalStyle is a side-effect that moves to virtual along with other styles
 			expect(result).toContain("data:text/javascript;base64,")
 			expect(result).toContain("import { button }")
+		})
+	})
+
+	describe("compileTime", () => {
+		it("should support awaited async values", async () => {
+			await using tmpDir = new TempDir()
+			const source = `import { compileTime } from "library/compile-time"
+
+export const options = await compileTime(async () => [
+	{ title: "Sample Form", value: "/sample-form" },
+	{ title: "Action Test", value: "/action-test" },
+])`
+			const ctx = createMockContext(
+				path.join(await tmpDir.getPath(), "app/test.tsx"),
+				await tmpDir.getPath(),
+			)
+
+			const result = await vanillaSplitLoader.call(ctx, source)
+			expectValidTypeScript(result)
+
+			const optionsModule = decodeDataUrlModules(result).find((module) => {
+				return hasExportedVariable(module, "options")
+			})
+
+			assert(optionsModule)
+
+			const { options } = await importVirtualModuleForTest(optionsModule)
+			expect(options).toEqual([
+				{ title: "Sample Form", value: "/sample-form" },
+				{ title: "Action Test", value: "/action-test" },
+			])
+		})
+
+		it("should allow awaited compileTime calls wrapped by expressions", async () => {
+			await using tmpDir = new TempDir()
+			const source = `import { compileTime } from "library/compile-time"
+
+export const parenthesizedOptions = await (compileTime(async () => [
+	{ title: "Sample Form", value: "/sample-form" },
+]))
+
+export const assertedOptions = await (compileTime(async () => [
+	{ title: "Action Test", value: "/action-test" },
+]) as Promise<unknown>)
+
+export const nonNullOptions = await (compileTime(async () => [
+	{ title: "Non Null", value: "/non-null" },
+])!)
+
+export const satisfiesOptions = await (compileTime(async () => [
+	{ title: "Satisfies", value: "/satisfies" },
+]) satisfies Promise<unknown>)`
+			const ctx = createMockContext(
+				path.join(await tmpDir.getPath(), "app/test.tsx"),
+				await tmpDir.getPath(),
+			)
+
+			const result = await vanillaSplitLoader.call(ctx, source)
+			expectValidTypeScript(result)
+		})
+
+		it("should require compileTime calls to be awaited", async () => {
+			await using tmpDir = new TempDir()
+			const source = `import { compileTime } from "library/compile-time"
+
+export const options = compileTime(async () => [
+	{ title: "Sample Form", value: "/sample-form" },
+])`
+			const ctx = createMockContext(
+				path.join(await tmpDir.getPath(), "app/test.tsx"),
+				await tmpDir.getPath(),
+			)
+
+			await expect(vanillaSplitLoader.call(ctx, source)).rejects.toThrow(
+				/compileTime must be called with await/,
+			)
 		})
 	})
 

--- a/vanilla/vanilla-split-loader.ts
+++ b/vanilla/vanilla-split-loader.ts
@@ -52,12 +52,14 @@ const TRACKED_MODULES: ModulesConfig = {
 		"globalKeyframes",
 		"globalLayer",
 	],
-	"library/styled": ["styled", "keyframes", "compileTime"],
-	"library/styled/index": ["styled", "keyframes", "compileTime"],
-	"library/styled/alpha": ["styled", "keyframes", "compileTime"],
+	"library/styled": ["styled", "keyframes"],
+	"library/styled/index": ["styled", "keyframes"],
+	"library/styled/alpha": ["styled", "keyframes"],
+	"library/compile-time": ["compileTime"],
 }
 
 const STYLED_IMPORT = "styled"
+const COMPILE_TIME_IMPORT = "compileTime"
 
 const turboLoader =
 	// @ts-expect-error turbopack loader shape has default export in some builds
@@ -169,6 +171,71 @@ function computeTaintedNodes(
 	}
 
 	return { tainted, invalidTainted }
+}
+
+function getTrackedImportLocalNames(
+	registry: TrackedRegistry,
+	importedName: string,
+) {
+	return new Set(
+		[...registry.trackedNames].filter(
+			(name) => registry.localToImported.get(name) === importedName,
+		),
+	)
+}
+
+function isTransparentAwaitWrapper(node: ts.Node) {
+	return (
+		ts.isParenthesizedExpression(node) ||
+		ts.isAsExpression(node) ||
+		ts.isTypeAssertionExpression(node) ||
+		ts.isNonNullExpression(node) ||
+		ts.isSatisfiesExpression(node)
+	)
+}
+
+function isAwaitedExpression(expression: ts.Expression) {
+	let current: ts.Node = expression
+	let parent = current.parent
+
+	while (parent && isTransparentAwaitWrapper(parent)) {
+		current = parent
+		parent = parent.parent
+	}
+
+	return ts.isAwaitExpression(parent) && parent.expression === current
+}
+
+function assertCompileTimeCallsAreAwaited(
+	sourceFile: ts.SourceFile,
+	registry: TrackedRegistry,
+) {
+	const compileTimeLocalNames = getTrackedImportLocalNames(
+		registry,
+		COMPILE_TIME_IMPORT,
+	)
+	if (compileTimeLocalNames.size === 0) return
+
+	function visit(node: ts.Node) {
+		if (
+			ts.isCallExpression(node) &&
+			ts.isIdentifier(node.expression) &&
+			compileTimeLocalNames.has(node.expression.text) &&
+			!isAwaitedExpression(node)
+		) {
+			const { line, character } = sourceFile.getLineAndCharacterOfPosition(
+				node.getStart(sourceFile),
+			)
+			throw new Error(
+				`compileTime must be called with await at ${sourceFile.fileName}:${line + 1}:${character + 1}. ` +
+					`Use "await compileTime(...)" so async values are resolved before the bundle is emitted.`,
+			)
+		}
+
+		ts.forEachChild(node, visit)
+	}
+
+	visit(sourceFile)
 }
 
 // =============================================================================
@@ -868,6 +935,7 @@ async function transform(
 
 	// 2) Build tracked import registry
 	const registry = buildTrackedRegistry(graph)
+	assertCompileTimeCallsAreAwaited(graph.sourceFile, registry)
 
 	// 3) Compute tainted nodes
 	const { tainted, invalidTainted } = computeTaintedNodes(graph, registry)


### PR DESCRIPTION
Adds self-contained helpers for discovering static app routes and exposes a standalone compileTime entrypoint. Updates custom link resolution for static route link values and fixes async compileTime values by awaiting them in the generated virtual module. Also keeps Sanity live proxy usage disabled during draft mode.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add static route link type for selecting static app pages in Sanity
> - Adds a new `staticPageLinkType` custom link type in [link/staticLinkType.ts](https://github.com/reformcollective/library/pull/498/files#diff-08782f4333244826750f279e16c5af0878b1d6c5fc57713767afcb3e32a17f40) that lists all static app routes discovered at build time via `listStaticRoutes()` in [list-pages.ts](https://github.com/reformcollective/library/pull/498/files#diff-3ee1911f8de9ab71875f85b0b64aa7d6069fd5886bffa535c2826c5aa785325b).
> - Extends `resolveRoute` in [link/resolve.ts](https://github.com/reformcollective/library/pull/498/files#diff-b76a108741b62f04027c6baaedb68c5e9d61e6b482fe9e7a43f385e71615263a) to handle `"static-page"` links, building URLs from `link.value` with parameters and anchor, and setting `newTab` based on `link.blank` or external URL detection.
> - Moves `compileTime` from `library/styled` to a dedicated `library/compile-time` module, and adds a build-time assertion in the vanilla split loader that errors if any `compileTime(...)` call is not directly awaited.
> - Behavioral Change: `compileTime` is no longer exported from `library/styled`; existing imports must be updated to `library/compile-time` and calls must be awaited.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 497b964.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->