### PR TITLE
Add Studio hotspot cover previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"@sanity/image-url": "^2",
 		"@types/semver": "^7",
 		"@vanilla-extract/css": "^1.20.1",
+		"@vanilla-extract/dynamic": "^2",
 		"@vanilla-extract/next-plugin": "^2.5.1",
 		"@vanilla-extract/turbopack-plugin": "^0.1.3",
 		"ahooks": "^3",

--- a/sanity/StudioHotspotCoverPreviews.css
+++ b/sanity/StudioHotspotCoverPreviews.css
@@ -1,0 +1,11 @@
+/*
+	Sanity's hotspot preview thumbnails prioritize keeping the selected hotspot
+	fully visible, so the generated crop box can letterbox inside the preview
+	ratio. Scale that crop box up to cover the preview tile, which better matches
+	site object-fit: cover image rendering.
+*/
+[class^="HotspotImageContainer-sc-"][data-hotspot-cover-preview] > div > div:nth-child(2),
+[class*=" HotspotImageContainer-sc-"][data-hotspot-cover-preview] > div > div:nth-child(2) {
+	transform: scale(var(--studio-hotspot-cover-scale, 1));
+	transform-origin: center;
+}

--- a/sanity/StudioHotspotCoverPreviews.css
+++ b/sanity/StudioHotspotCoverPreviews.css
@@ -4,8 +4,12 @@
 	ratio. Scale that crop box up to cover the preview tile, which better matches
 	site object-fit: cover image rendering.
 */
-[class^="HotspotImageContainer-sc-"][data-hotspot-cover-preview] > div > div:nth-child(2),
-[class*=" HotspotImageContainer-sc-"][data-hotspot-cover-preview] > div > div:nth-child(2) {
+[class^="HotspotImageContainer-sc-"][data-hotspot-cover-preview]
+	> div
+	> div:nth-child(2),
+[class*=" HotspotImageContainer-sc-"][data-hotspot-cover-preview]
+	> div
+	> div:nth-child(2) {
 	transform: scale(var(--studio-hotspot-cover-scale, 1));
 	transform-origin: center;
 }

--- a/sanity/StudioHotspotCoverPreviews.tsx
+++ b/sanity/StudioHotspotCoverPreviews.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { useEffect } from "react"
+
+const HOTSPOT_CONTAINER_SELECTOR =
+	'[class^="HotspotImageContainer-sc-"], [class*=" HotspotImageContainer-sc-"]'
+
+function updateHotspotPreviewScale(container: Element) {
+	const frame = container.firstElementChild
+	const cropBox = frame?.children.item(1)
+	if (!(container instanceof HTMLElement) || !(cropBox instanceof HTMLElement)) return
+
+	const width = Number.parseFloat(cropBox.style.width)
+	const height = Number.parseFloat(cropBox.style.height)
+	if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+		return
+	}
+
+	const scale = Math.max(100 / width, 100 / height)
+	container.dataset.hotspotCoverPreview = ""
+	container.style.setProperty("--studio-hotspot-cover-scale", scale.toString())
+}
+
+function updateHotspotPreviewScales(root: ParentNode = document) {
+	root.querySelectorAll(HOTSPOT_CONTAINER_SELECTOR).forEach(updateHotspotPreviewScale)
+}
+
+export function StudioHotspotCoverPreviews() {
+	useEffect(() => {
+		updateHotspotPreviewScales()
+
+		const observer = new MutationObserver((mutations) => {
+			for (const mutation of mutations) {
+				if (mutation.type === "attributes") {
+					updateHotspotPreviewScales()
+					return
+				}
+
+				for (const node of mutation.addedNodes) {
+					if (!(node instanceof Element)) continue
+
+					if (node.matches(HOTSPOT_CONTAINER_SELECTOR)) {
+						updateHotspotPreviewScale(node)
+					}
+					updateHotspotPreviewScales(node)
+				}
+			}
+		})
+
+		observer.observe(document.body, {
+			attributes: true,
+			attributeFilter: ["style"],
+			childList: true,
+			subtree: true,
+		})
+
+		return () => observer.disconnect()
+	}, [])
+
+	return null
+}

--- a/sanity/StudioHotspotCoverPreviews.tsx
+++ b/sanity/StudioHotspotCoverPreviews.tsx
@@ -8,11 +8,17 @@ const HOTSPOT_CONTAINER_SELECTOR =
 function updateHotspotPreviewScale(container: Element) {
 	const frame = container.firstElementChild
 	const cropBox = frame?.children.item(1)
-	if (!(container instanceof HTMLElement) || !(cropBox instanceof HTMLElement)) return
+	if (!(container instanceof HTMLElement) || !(cropBox instanceof HTMLElement))
+		return
 
 	const width = Number.parseFloat(cropBox.style.width)
 	const height = Number.parseFloat(cropBox.style.height)
-	if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+	if (
+		!Number.isFinite(width) ||
+		!Number.isFinite(height) ||
+		width <= 0 ||
+		height <= 0
+	) {
 		return
 	}
 
@@ -22,7 +28,9 @@ function updateHotspotPreviewScale(container: Element) {
 }
 
 function updateHotspotPreviewScales(root: ParentNode = document) {
-	root.querySelectorAll(HOTSPOT_CONTAINER_SELECTOR).forEach(updateHotspotPreviewScale)
+	root
+		.querySelectorAll(HOTSPOT_CONTAINER_SELECTOR)
+		.forEach(updateHotspotPreviewScale)
 }
 
 export function StudioHotspotCoverPreviews() {


### PR DESCRIPTION
## Summary
- add a reusable StudioHotspotCoverPreviews helper for Sanity Studio
- add shared CSS to scale Sanity hotspot preview crop boxes to cover their preview tiles
- declare @vanilla-extract/dynamic because SanityImage imports it

## Verification
- pnpm lint

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Studio hotspot cover previews to scale crop boxes within preview tiles
> - Adds [StudioHotspotCoverPreviews.tsx](https://github.com/reformcollective/library/pull/507/files#diff-96ef396e8e3e4c1c07fb206c3c58e32faeaebeab7375e63e141ef6f51bc8984b), a client-side React component that computes a cover scale (`Math.max(100/width, 100/height)`) for each hotspot crop box and writes it to a `--studio-hotspot-cover-scale` CSS variable on the container.
> - A `MutationObserver` on `document.body` watches for style and DOM changes, re-running scale computation when hotspot containers are added or modified.
> - [StudioHotspotCoverPreviews.css](https://github.com/reformcollective/library/pull/507/files#diff-7a53758600cec32658238e7b67aab05a252f56ccfc96bf94c1612c4bf73b5b3b) applies the scale transform to the crop box element inside containers marked with `data-hotspot-cover-preview`.
> - Risk: targets Sanity Studio internals via a class-name prefix selector (`HotspotImageContainer-sc-`), which may break on Studio upgrades.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #507 opened
>
> - Reformatted code formatting in `StudioHotspotCoverPreviews.css` and `StudioHotspotCoverPreviews.tsx` [8380366]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d9418f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->