### PR TITLE
Respect explicit link new-tab option

### DIFF
--- a/InfiniteSideScroll.tsx
+++ b/InfiniteSideScroll.tsx
@@ -225,6 +225,7 @@ export function InfiniteSideScroll({
 			internalLoopRef,
 			centerMode,
 			snapPaddingLeft,
+			latestOnChange.current,
 		],
 		{
 			recreateOnResize: true,

--- a/link/index.tsx
+++ b/link/index.tsx
@@ -85,7 +85,8 @@ export default function UniversalLink({
 		)
 	}
 
-	const { url, newTab } = resolveRoute(props.href)
+	const { url, newTab: routeNewTab } = resolveRoute(props.href)
+	const newTab = props.openInNewTab ?? routeNewTab
 	const internal = url ? linkIsInternal(url) : false
 
 	const onClick = (e: React.MouseEvent) => {


### PR DESCRIPTION
Updates UniversalLink so the existing openInNewTab prop overrides the route-derived new-tab behavior. This lets app-level wrappers preserve CMS link blank settings when they transform hrefs before rendering UniversalLink. The branch also includes the existing InfiniteSideScroll hook dependency fix already present on tsc-fixes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Respect explicit `openInNewTab` prop in `UniversalLink` component
> Previously, `UniversalLink` determined new-tab behavior solely from the route resolver. Now, when `openInNewTab` is passed as a prop, it takes precedence over the route-derived value. Internal navigation via the transitioner is also skipped when `newTab` is true.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba12ba4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->