### PR TITLE
Run pnpm test in reusable CI

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -73,5 +73,6 @@ jobs:
           cache: true
           standalone: true
       - run: pnpm run lint
+      - run: pnpm test
       # running a build will also check types
       - run: pnpm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2026-05-12
+
+## CI now validates `pnpm test`
+
+The reusable code checks workflow now runs `pnpm test` before building. In starter projects, this exercises the root Wireit `test` target and runs the library test script through `./library:test`.
 
 # 2026-05-08
 


### PR DESCRIPTION
## Summary
- run `pnpm test` in the reusable code checks workflow before build
- document that CI now validates `pnpm test`

## Verification
- `pnpm test`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `pnpm test` step to reusable CI code checks workflow
> Adds a `pnpm test` execution step in [code-checks.yml](.github/workflows/code-checks.yml) before the build step, so CI fails fast if tests fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea83fab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->