### PR TITLE
Filter link new-tab prop

### DIFF
--- a/link/index.tsx
+++ b/link/index.tsx
@@ -66,6 +66,7 @@ export default function UniversalLink({
 	ref,
 	onNavigate,
 	onBeforeNavigate,
+	openInNewTab,
 	...props
 }: UniversalLinkProps) {
 	const transitioner = useTransitioner()
@@ -86,7 +87,7 @@ export default function UniversalLink({
 	}
 
 	const { url, newTab: routeNewTab } = resolveRoute(props.href)
-	const newTab = props.openInNewTab ?? routeNewTab
+	const newTab = openInNewTab ?? routeNewTab
 	const internal = url ? linkIsInternal(url) : false
 
 	const onClick = (e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary
- Prevent UniversalLink from forwarding the internal openInNewTab prop to rendered anchor and Next Link elements.
- Preserve existing new-tab behavior while removing the React unknown DOM prop warning.

## Validation
- WIREIT_LOGGER=metrics pnpm format
- WIREIT_LOGGER=metrics pnpm typecheck
- WIREIT_LOGGER=metrics pnpm lint
- WIREIT_LOGGER=metrics pnpm build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter `openInNewTab` prop from DOM element spread in `UniversalLink`
> Destructures `openInNewTab` explicitly in [UniversalLink](https://github.com/reformcollective/library/pull/511/files#diff-d5d0542ad486ee976c47463d8359f6e73550a5d99b9833bc66123de4a58f04ac) so it is no longer forwarded to the underlying `<a>` or `<button>` elements via props spread. Navigation behavior is unchanged — `newTab` is still derived from `openInNewTab ?? routeNewTab`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb1cdbe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->