### PR TITLE
Add unit tests for functions.ts

### DIFF
--- a/functions.test.ts
+++ b/functions.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+import {
+	getRandomFloat,
+	getRandomInt,
+	linkIsExternal,
+	linkIsInternal,
+	pathnameMatches,
+	sleep,
+} from "./functions"
+
+describe("pathnameMatches", () => {
+	test("identical paths match", () => {
+		expect(pathnameMatches("/about", "/about")).toBe(true)
+	})
+	test("trailing slash matches in both directions", () => {
+		expect(pathnameMatches("/about/", "/about")).toBe(true)
+		expect(pathnameMatches("/about", "/about/")).toBe(true)
+	})
+	test("different paths do not match", () => {
+		expect(pathnameMatches("/about", "/contact")).toBe(false)
+		expect(pathnameMatches("/a/b", "/a")).toBe(false)
+	})
+})
+
+describe("linkIsInternal / linkIsExternal (default site http://localhost:3000)", () => {
+	test("relative paths are internal", () => {
+		expect(linkIsInternal("/about")).toBe(true)
+	})
+	test("hash links are internal", () => {
+		expect(linkIsInternal("#section")).toBe(true)
+	})
+	test("a different host is external", () => {
+		expect(linkIsInternal("https://example.com")).toBe(false)
+	})
+	test("non-http schemes are external", () => {
+		expect(linkIsInternal("mailto:hello@example.com")).toBe(false)
+	})
+	test("linkIsExternal is the strict inverse", () => {
+		for (const to of ["/about", "https://example.com", "mailto:a@b.com"])
+			expect(linkIsExternal(to)).toBe(!linkIsInternal(to))
+	})
+})
+
+describe("linkIsInternal www normalization (custom host)", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs()
+		vi.resetModules()
+	})
+	test("www and apex are the same host", async () => {
+		vi.stubEnv("NEXT_PUBLIC_DEPLOY_URL", "https://example.com")
+		vi.resetModules()
+		const { linkIsInternal: fn } = await import("./functions")
+		expect(fn("https://example.com/p")).toBe(true)
+		expect(fn("https://www.example.com/p")).toBe(true)
+		expect(fn("https://other.com")).toBe(false)
+	})
+})
+
+describe("getRandomInt", () => {
+	test("inclusive bounds over many iterations", () => {
+		for (let i = 0; i < 1000; i++) {
+			const n = getRandomInt(1, 6)
+			expect(n).toBeGreaterThanOrEqual(1)
+			expect(n).toBeLessThanOrEqual(6)
+			expect(Number.isInteger(n)).toBe(true)
+		}
+	})
+	test("min equals max", () => {
+		expect(getRandomInt(5, 5)).toBe(5)
+	})
+})
+
+describe("getRandomFloat", () => {
+	test("within [min, max)", () => {
+		for (let i = 0; i < 1000; i++) {
+			const n = getRandomFloat(0, 10)
+			expect(n).toBeGreaterThanOrEqual(0)
+			expect(n).toBeLessThan(10)
+		}
+	})
+})
+
+describe("sleep", () => {
+	test("resolves after the delay", async () => {
+		vi.useFakeTimers()
+		let done = false
+		const p = sleep(1000).then(() => {
+			done = true
+		})
+		expect(done).toBe(false)
+		await vi.advanceTimersByTimeAsync(1000)
+		await p
+		expect(done).toBe(true)
+		vi.useRealTimers()
+	})
+})


### PR DESCRIPTION
I use this starter regularly and noticed functions.ts had no test coverage, so I wrote some — seemed worth contributing back given the recent test CI addition.

Coverage:
- pathnameMatches — equality and trailing-slash equivalence
- linkIsInternal / linkIsExternal — relative paths, hashes, foreign hosts, non-http schemes, and www. host normalization
- getRandomInt / getRandomFloat — bounds
- sleep — resolves after the delay (fake timers)

No production files modified. Validated locally: `pnpm exec vitest run functions.test.ts` (passing, no type errors) and `pnpm exec biome check functions.test.ts` (clean).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unit tests for utility functions in `functions.ts`
> Adds a [Vitest test suite](https://github.com/reformcollective/library/pull/512/files#diff-68ada2d5e2f128f1c5092c72358067a9a8e13f778358abe5a83948b98418928d) covering the main utility functions. Tests cover `pathnameMatches` (trailing slash equivalence), `linkIsInternal`/`linkIsExternal` (including `NEXT_PUBLIC_DEPLOY_URL`-driven host normalization treating apex and www as the same host), `getRandomInt`/`getRandomFloat` range constraints, and `sleep` timing using fake timers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48536ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->