### PR TITLE
Force Sanity live fetches off CDN

### DIFF
--- a/sanity/live.tsx
+++ b/sanity/live.tsx
@@ -13,12 +13,14 @@ import { version as sanityVersion } from "sanity/package.json"
 import semver from "semver"
 import { handleError, SanityLiveRuntime } from "./live.client"
 
+const libraryClient = client.withConfig({ useCdn: false })
+
 /**
  * Use defineLive to enable automatic revalidation and refreshing of your fetched content
  * Learn more: https://github.com/sanity-io/next-sanity?tab=readme-ov-file#1-configure-definelive
  */
 const { sanityFetch: internalFetch, SanityLive: InternalLive } = defineLive({
-	client,
+	client: libraryClient,
 	serverToken: token,
 	browserToken: token,
 	fetchOptions: { revalidate: Infinity },
@@ -88,13 +90,6 @@ export const LibraryLive = async () => {
 			/>
 		</SanityLiveRuntime>
 	)
-}
-
-/**
- * sanity live handles revalidation
- */
-if (client.config().useCdn !== true) {
-	throw new Error("useCdn must be true!")
 }
 
 /**


### PR DESCRIPTION
## Summary
Forces the Sanity client passed to defineLive to use `useCdn: false` and removes the old `useCdn: true` validator.

## Verification
- `git diff --check` passes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force Sanity live fetches off CDN in `defineLive`
> - Introduces a dedicated `libraryClient` configured with `useCdn: false` in [sanity/live.tsx](https://github.com/reformcollective/library/pull/513/files#diff-e0c43f034731be3d23a5f38dd179ccebf43c8c44fc42efae3894a6eb3a27ee90) and passes it to `defineLive` via the `client` field.
> - Removes the runtime assertion that previously threw when `client.config().useCdn !== true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c18070.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->