### PR TITLE
Allow static routes to substitute segments

### DIFF
--- a/list-pages.test.ts
+++ b/list-pages.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest"
+import { isDynamicRoutePath, pageFilePathToRoute } from "./list-pages"
+
+describe("static route listing helpers", () => {
+	test("treats dynamic segments as dynamic unless a segment value is provided", () => {
+		expect(isDynamicRoutePath("app/[site]/text-demo/page.tsx")).toBe(true)
+	})
+
+	test("keeps catch-all and document dynamic routes out of static routes", () => {
+		expect(isDynamicRoutePath("app/[site]/[[...slug]]/page.tsx")).toBe(true)
+		expect(isDynamicRoutePath("app/[site]/products/[slug]/page.tsx")).toBe(true)
+	})
+
+	test("substitutes configured dynamic segment values", () => {
+		const segments = { site: "temple" }
+
+		expect(isDynamicRoutePath("app/[site]/text-demo/page.tsx", segments)).toBe(
+			false,
+		)
+		expect(pageFilePathToRoute("app/[site]/text-demo/page.tsx", segments)).toBe(
+			"/temple/text-demo",
+		)
+	})
+})

--- a/list-pages.ts
+++ b/list-pages.ts
@@ -3,6 +3,18 @@ import { glob } from "node:fs/promises"
 const pageFileGlob = "app/**/page.{js,jsx,ts,tsx}"
 const pageFilePattern = /^page\.(js|jsx|ts|tsx)$/
 
+type StaticRouteSegments = Record<string, string | undefined>
+
+function getDynamicSegmentName(segment: string) {
+	const match = segment.match(/^\[([^.[\]]+)\]$/)
+	return match?.[1]
+}
+
+function hasSegmentValue(segment: string, segments: StaticRouteSegments) {
+	const segmentName = getDynamicSegmentName(segment)
+	return segmentName ? segments[segmentName] != null : false
+}
+
 export function normalizeRoutePath(path: string) {
 	let normalizedPath = path.startsWith("/") ? path : `/${path}`
 	normalizedPath = normalizedPath.replace(/\/{2,}/g, "/")
@@ -13,34 +25,46 @@ export function normalizeRoutePath(path: string) {
 	return normalizedPath
 }
 
-export function isDynamicRoutePath(path: string) {
+export function isDynamicRoutePath(
+	path: string,
+	segments: StaticRouteSegments = {},
+) {
 	return path
 		.replaceAll("\\", "/")
 		.split("/")
-		.some((segment) => /\[.+\]/.test(segment))
+		.some(
+			(segment) =>
+				/\[.+\]/.test(segment) && !hasSegmentValue(segment, segments),
+		)
 }
 
-export function pageFilePathToRoute(path: string) {
+export function pageFilePathToRoute(
+	path: string,
+	segments: StaticRouteSegments = {},
+) {
 	const parts = path.replaceAll("\\", "/").split("/").filter(Boolean)
 	const withoutApp = parts[0] === "app" ? parts.slice(1) : parts
 	const withoutPageFile = pageFilePattern.test(withoutApp.at(-1) ?? "")
 		? withoutApp.slice(0, -1)
 		: withoutApp
 
-	const routeParts = withoutPageFile.filter(
-		(segment) => !(segment.startsWith("(") && segment.endsWith(")")),
-	)
+	const routeParts = withoutPageFile
+		.filter((segment) => !(segment.startsWith("(") && segment.endsWith(")")))
+		.map((segment) => {
+			const segmentName = getDynamicSegmentName(segment)
+			return segmentName ? (segments[segmentName] ?? segment) : segment
+		})
 
 	return normalizeRoutePath(`/${routeParts.join("/")}`)
 }
 
-export async function listStaticRoutes() {
+export async function listStaticRoutes(segments: StaticRouteSegments = {}) {
 	const routes = new Set<string>()
 
 	for await (const entry of glob(pageFileGlob)) {
-		if (isDynamicRoutePath(entry)) continue
+		if (isDynamicRoutePath(entry, segments)) continue
 
-		routes.add(pageFilePathToRoute(entry))
+		routes.add(pageFilePathToRoute(entry, segments))
 	}
 
 	return Array.from(routes).sort()


### PR DESCRIPTION
## Summary
- add segment substitution support to listStaticRoutes
- keep existing no-argument behavior for static route discovery
- add tests for dynamic segment substitution and unresolved dynamic routes

## Validation
- pnpm --dir library format
- pnpm --dir library lint
- pnpm --dir library test

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow `listStaticRoutes` to substitute dynamic route segments with concrete values
> - Adds an optional `segments` map parameter to `isDynamicRoutePath`, `pageFilePathToRoute`, and `listStaticRoutes` in [list-pages.ts](https://github.com/reformcollective/library/pull/515/files#diff-3ee1911f8de9ab71875f85b0b64aa7d6069fd5886bffa535c2826c5aa785325b).
> - When a segment map is provided, paths whose dynamic segments are all satisfied are treated as static, with segment tokens replaced by their concrete values in the output route.
> - Unsatisfied dynamic segments retain their original `[name]` token form.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41ccf5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->