### PR TITLE
Cache fix attempt

### DIFF
--- a/sanity/live.tsx
+++ b/sanity/live.tsx
@@ -13,7 +13,32 @@ import { version as sanityVersion } from "sanity/package.json"
 import semver from "semver"
 import { handleError, SanityLiveRuntime } from "./live.client"
 
-const libraryClient = client.withConfig({ useCdn: false })
+// defineLive internally overrides useCdn per-request (`useCdn = perspective === "published"`),
+// making the client-level useCdn: false ineffective. In development, this means published
+// content is served from Sanity's API CDN (60s cache) and never updates without webhooks.
+// The proxy below intercepts every .fetch() call to force useCdn: false, and chains through
+// .withConfig() so the intercept survives defineLive's internal _client.withConfig() call.
+type SanityClientLike = typeof client
+function makeNoCdnProxy(target: SanityClientLike): SanityClientLike {
+	return new Proxy(target, {
+		get(t, prop, receiver) {
+			if (prop === "fetch") {
+				type FetchOptions = Parameters<typeof t.fetch>[2]
+				return (query: string, params?: QueryParams, options?: FetchOptions) =>
+					Reflect.get(t, prop, receiver).call(t, query, params, { ...options, useCdn: false } as FetchOptions)
+			}
+			if (prop === "withConfig") {
+				return (...args: Parameters<typeof t.withConfig>) =>
+					makeNoCdnProxy(Reflect.get(t, prop, receiver).call(t, ...args))
+			}
+			const value = Reflect.get(t, prop, receiver)
+			return typeof value === "function" ? (value as (...a: unknown[]) => unknown).bind(t) : value
+		},
+	})
+}
+
+const libraryClient =
+	process.env.NODE_ENV === "development" ? makeNoCdnProxy(client) : client.withConfig({ useCdn: false })
 
 /**
  * Use defineLive to enable automatic revalidation and refreshing of your fetched content

--- a/sanity/live.tsx
+++ b/sanity/live.tsx
@@ -25,20 +25,27 @@ function makeNoCdnProxy(target: SanityClientLike): SanityClientLike {
 			if (prop === "fetch") {
 				type FetchOptions = Parameters<typeof t.fetch>[2]
 				return (query: string, params?: QueryParams, options?: FetchOptions) =>
-					Reflect.get(t, prop, receiver).call(t, query, params, { ...options, useCdn: false } as FetchOptions)
+					Reflect.get(t, prop, receiver).call(t, query, params, {
+						...options,
+						useCdn: false,
+					} as FetchOptions)
 			}
 			if (prop === "withConfig") {
 				return (...args: Parameters<typeof t.withConfig>) =>
 					makeNoCdnProxy(Reflect.get(t, prop, receiver).call(t, ...args))
 			}
 			const value = Reflect.get(t, prop, receiver)
-			return typeof value === "function" ? (value as (...a: unknown[]) => unknown).bind(t) : value
+			return typeof value === "function"
+				? (value as (...a: unknown[]) => unknown).bind(t)
+				: value
 		},
 	})
 }
 
 const libraryClient =
-	process.env.NODE_ENV === "development" ? makeNoCdnProxy(client) : client.withConfig({ useCdn: false })
+	process.env.NODE_ENV === "development"
+		? makeNoCdnProxy(client)
+		: client.withConfig({ useCdn: false })
 
 /**
  * Use defineLive to enable automatic revalidation and refreshing of your fetched content


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix CDN bypass in Sanity live client to persist across `withConfig()` calls
- Adds `makeNoCdnProxy` in [live.tsx](https://github.com/reformcollective/library/pull/516/files#diff-e0c43f034731be3d23a5f38dd179ccebf43c8c44fc42efae3894a6eb3a27ee90), a `Proxy` wrapper around a Sanity client that intercepts `.fetch()` to always pass `useCdn: false`, and wraps `.withConfig()` so derived clients inherit the same proxy.
- In development, `libraryClient` now uses this proxy instead of a plain `withConfig({ useCdn: false })`, ensuring CDN bypass is not lost when chaining `.withConfig()`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f57da7.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->