### PR TITLE
Support custom Studio document helpers

### DIFF
--- a/InfiniteSideScroll.tsx
+++ b/InfiniteSideScroll.tsx
@@ -119,15 +119,16 @@ export function InfiniteSideScroll({
 			)
 			const gap =
 				firstLastChild && secondFirstChild
-					? // distance from right edge of first to left edge of second,
+					? // distance from layout right edge of first to layout left edge of second,
 						// minus secondFirstLeftMargin only (already in totalWidth via spaceBefore[0]).
 						// The last item's right margin is NOT subtracted: horizontalLoop's getTotalWidth ends
 						// at the last item's offsetWidth (no trailing margin), so that margin must
 						// remain in paddingRight to produce an even gap at the loop point.
-						Math.abs(
-							firstLastChild.getBoundingClientRect().right -
-								secondFirstChild.getBoundingClientRect().left,
-						) - secondFirstLeftMargin
+						getLayoutGap(
+							firstLastChild,
+							secondFirstChild,
+							secondFirstLeftMargin,
+						)
 					: 0
 
 			const loop = horizontalLoop(rowRef.current.children, {
@@ -318,6 +319,25 @@ export function InfiniteSideScroll({
 				</ButtonWrapper>
 			)}
 		</Wrapper>
+	)
+}
+
+function getLayoutGap(
+	firstLastChild: Element,
+	secondFirstChild: Element,
+	secondFirstLeftMargin: number,
+) {
+	if (
+		!(firstLastChild instanceof HTMLElement) ||
+		!(secondFirstChild instanceof HTMLElement)
+	) {
+		return 0
+	}
+
+	return (
+		secondFirstChild.offsetLeft -
+		(firstLastChild.offsetLeft + firstLastChild.offsetWidth) -
+		secondFirstLeftMargin
 	)
 }
 

--- a/gsapHelpers/horizontalLoop.js
+++ b/gsapHelpers/horizontalLoop.js
@@ -174,7 +174,7 @@ export function horizontalLoop(items, config) {
 			},
 			onResize = () => refresh(true),
 			proxy
-		gsap.set(items, { x: 0 })
+		gsap.set(items, { x: 0, xPercent: 0 })
 		populateWidths()
 		populateTimeline()
 		populateOffsets()

--- a/list-pages.test.ts
+++ b/list-pages.test.ts
@@ -1,24 +1,74 @@
-import { describe, expect, test } from "vitest"
-import { isDynamicRoutePath, pageFilePathToRoute } from "./list-pages"
+import { describe, expect, test, vi } from "vitest"
+
+async function importListPagesWithRoutes(routes: string[]) {
+	vi.resetModules()
+	vi.doMock("node:fs/promises", () => ({
+		glob: async function* () {
+			yield* routes
+		},
+	}))
+
+	return await import("./list-pages")
+}
 
 describe("static route listing helpers", () => {
-	test("treats dynamic segments as dynamic unless a segment value is provided", () => {
+	test("treats dynamic segments as dynamic", async () => {
+		const { isDynamicRoutePath } = await importListPagesWithRoutes([])
+
 		expect(isDynamicRoutePath("app/[site]/text-demo/page.tsx")).toBe(true)
 	})
 
-	test("keeps catch-all and document dynamic routes out of static routes", () => {
+	test("keeps catch-all and document dynamic routes out of static routes", async () => {
+		const { isDynamicRoutePath } = await importListPagesWithRoutes([])
+
 		expect(isDynamicRoutePath("app/[site]/[[...slug]]/page.tsx")).toBe(true)
 		expect(isDynamicRoutePath("app/[site]/products/[slug]/page.tsx")).toBe(true)
 	})
 
-	test("substitutes configured dynamic segment values", () => {
-		const segments = { site: "temple" }
+	test("converts page file paths to route patterns", async () => {
+		const { pageFilePathToRoute } = await importListPagesWithRoutes([])
 
-		expect(isDynamicRoutePath("app/[site]/text-demo/page.tsx", segments)).toBe(
-			false,
+		expect(pageFilePathToRoute("app/(shop)/[site]/text-demo/page.tsx")).toBe(
+			"/[site]/text-demo",
 		)
-		expect(pageFilePathToRoute("app/[site]/text-demo/page.tsx", segments)).toBe(
-			"/temple/text-demo",
+	})
+
+	test("lists only fully static routes", async () => {
+		const { listStaticRoutes } = await importListPagesWithRoutes([
+			"app/(shop)/about/page.tsx",
+			"app/(shop)/about/page.tsx",
+			"app/[site]/shop/page.tsx",
+			"app/[site]/[[...slug]]/page.tsx",
+			"app/visual-tests/page.tsx",
+		])
+
+		expect(listStaticRoutes()).toEqual(["/about", "/visual-tests"])
+	})
+
+	test("substitutes simple dynamic segment values", async () => {
+		const { listRoutes } = await importListPagesWithRoutes([
+			"app/[site]/account/page.tsx",
+			"app/[site]/shop/page.tsx",
+			"app/[site]/[[...slug]]/page.tsx",
+			"app/[site]/products/[slug]/page.tsx",
+			"app/sample-form/page.tsx",
+		])
+
+		expect(listRoutes({ site: "temple" })).toEqual([
+			"/sample-form",
+			"/temple/account",
+			"/temple/shop",
+		])
+	})
+
+	test("rejects invalid segment values", async () => {
+		const { listRoutes } = await importListPagesWithRoutes([
+			"app/[site]/shop/page.tsx",
+		])
+
+		expect(() => listRoutes({ site: "" })).toThrow("must not be empty")
+		expect(() => listRoutes({ site: "temple/shop" })).toThrow(
+			"single path segment",
 		)
 	})
 })

--- a/list-pages.ts
+++ b/list-pages.ts
@@ -1,4 +1,5 @@
 import { glob } from "node:fs/promises"
+import { compileTime } from "./compile-time.ts"
 
 const pageFileGlob = "app/**/page.{js,jsx,ts,tsx}"
 const pageFilePattern = /^page\.(js|jsx|ts|tsx)$/
@@ -8,11 +9,6 @@ type StaticRouteSegments = Record<string, string | undefined>
 function getDynamicSegmentName(segment: string) {
 	const match = segment.match(/^\[([^.[\]]+)\]$/)
 	return match?.[1]
-}
-
-function hasSegmentValue(segment: string, segments: StaticRouteSegments) {
-	const segmentName = getDynamicSegmentName(segment)
-	return segmentName ? segments[segmentName] != null : false
 }
 
 export function normalizeRoutePath(path: string) {
@@ -25,47 +21,69 @@ export function normalizeRoutePath(path: string) {
 	return normalizedPath
 }
 
-export function isDynamicRoutePath(
-	path: string,
-	segments: StaticRouteSegments = {},
-) {
+export function isDynamicRoutePath(path: string) {
 	return path
 		.replaceAll("\\", "/")
 		.split("/")
-		.some(
-			(segment) =>
-				/\[.+\]/.test(segment) && !hasSegmentValue(segment, segments),
-		)
+		.some((segment) => /\[.+\]/.test(segment))
 }
 
-export function pageFilePathToRoute(
-	path: string,
-	segments: StaticRouteSegments = {},
-) {
+export function pageFilePathToRoute(path: string) {
 	const parts = path.replaceAll("\\", "/").split("/").filter(Boolean)
 	const withoutApp = parts[0] === "app" ? parts.slice(1) : parts
 	const withoutPageFile = pageFilePattern.test(withoutApp.at(-1) ?? "")
 		? withoutApp.slice(0, -1)
 		: withoutApp
 
-	const routeParts = withoutPageFile
-		.filter((segment) => !(segment.startsWith("(") && segment.endsWith(")")))
-		.map((segment) => {
-			const segmentName = getDynamicSegmentName(segment)
-			return segmentName ? (segments[segmentName] ?? segment) : segment
-		})
+	const routeParts = withoutPageFile.filter(
+		(segment) => !(segment.startsWith("(") && segment.endsWith(")")),
+	)
 
 	return normalizeRoutePath(`/${routeParts.join("/")}`)
 }
 
-export async function listStaticRoutes(segments: StaticRouteSegments = {}) {
+function validateSegmentValue(name: string, value: string | undefined) {
+	if (value == null) return
+	if (!value) throw new Error(`Route segment "${name}" must not be empty.`)
+	if (value.includes("/")) {
+		throw new Error(`Route segment "${name}" must be a single path segment.`)
+	}
+}
+
+function substituteRouteSegments(route: string, segments: StaticRouteSegments) {
+	return normalizeRoutePath(
+		route
+			.split("/")
+			.map((segment) => {
+				const segmentName = getDynamicSegmentName(segment)
+				return segmentName ? (segments[segmentName] ?? segment) : segment
+			})
+			.join("/"),
+	)
+}
+
+const allRoutes = await compileTime(async () => {
 	const routes = new Set<string>()
 
 	for await (const entry of glob(pageFileGlob)) {
-		if (isDynamicRoutePath(entry, segments)) continue
-
-		routes.add(pageFilePathToRoute(entry, segments))
+		routes.add(pageFilePathToRoute(entry))
 	}
 
 	return Array.from(routes).sort()
+})
+
+export function listStaticRoutes() {
+	return allRoutes.filter((route) => !isDynamicRoutePath(route))
+}
+
+export function listRoutes(segments: StaticRouteSegments) {
+	for (const [name, value] of Object.entries(segments)) {
+		validateSegmentValue(name, value)
+	}
+
+	const routes = allRoutes
+		.map((route) => substituteRouteSegments(route, segments))
+		.filter((route) => !isDynamicRoutePath(route))
+
+	return Array.from(new Set(routes)).sort()
 }

--- a/list-pages.ts
+++ b/list-pages.ts
@@ -3,6 +3,7 @@ import { compileTime } from "./compile-time.ts"
 
 const pageFileGlob = "app/**/page.{js,jsx,ts,tsx}"
 const pageFilePattern = /^page\.(js|jsx|ts|tsx)$/
+const sourceDirectory = process.cwd()
 
 type StaticRouteSegments = Record<string, string | undefined>
 
@@ -65,7 +66,7 @@ function substituteRouteSegments(route: string, segments: StaticRouteSegments) {
 const allRoutes = await compileTime(async () => {
 	const routes = new Set<string>()
 
-	for await (const entry of glob(pageFileGlob)) {
+	for await (const entry of glob(pageFileGlob, { cwd: sourceDirectory })) {
 		routes.add(pageFilePathToRoute(entry))
 	}
 

--- a/sanity/document-helpers.ts
+++ b/sanity/document-helpers.ts
@@ -1,3 +1,4 @@
+import type { DocumentPathResolver } from "library/sanity/define-document-paths"
 import { siteURL } from "library/siteURL"
 import { map } from "rxjs"
 import { documentPaths } from "sanity/lib/slug-resolver"
@@ -6,76 +7,158 @@ import type {
 	DocumentLocationsState,
 } from "sanity/presentation"
 
-type SanityDocument = {
+export type SanityDocument = {
 	_type?: string
+	[key: string]: unknown
 }
 
-const resolveDocumentRoute = (document: unknown) => {
+type DocumentRoute = {
+	path: string
+	title: string | null
+}
+
+export type DocumentUrlResolverContext = {
+	document: SanityDocument
+	path: string
+	title: string | null
+}
+
+export type DocumentHelpersOptions = {
+	documentPaths?: DocumentPathResolver
+	documentQuery?: string
+	resolveLocationHref?: (
+		context: DocumentUrlResolverContext,
+	) => string | null | undefined
+	resolveProductionUrl?: (
+		context: DocumentUrlResolverContext,
+	) => string | null | undefined
+}
+
+function resolveRoute(
+	documentPathsOption: DocumentPathResolver,
+	document: unknown,
+) {
 	const sanityDocument = document as SanityDocument | null | undefined
-	if (!sanityDocument?._type) return undefined
+	if (!sanityDocument?._type) return null
 
 	const resolver =
-		documentPaths[sanityDocument._type as keyof typeof documentPaths]
-	if (!resolver) return undefined
+		documentPathsOption[
+			sanityDocument._type as keyof typeof documentPathsOption
+		]
+	if (!resolver) return null
 
-	return resolver(sanityDocument as never)
+	const route = resolver(sanityDocument as never)
+	const path = route?.path || null
+	if (!path) return null
+
+	return {
+		document: sanityDocument,
+		path,
+		title: route?.title || null,
+	}
 }
 
-/**
- * Resolves a fetched Sanity document to its canonical public pathname
- */
-export const resolveDocumentPathname = (document: unknown) => {
-	return resolveDocumentRoute(document)?.path || null
-}
+export function createDocumentHelpers({
+	documentPaths: documentPathsOption = documentPaths,
+	documentQuery = `*[_id==$id][0]`,
+	resolveLocationHref,
+	resolveProductionUrl: resolveProductionUrlOption,
+}: DocumentHelpersOptions = {}) {
+	function resolveDocumentRoute(
+		document: unknown,
+	): (DocumentRoute & { document: SanityDocument }) | null {
+		return resolveRoute(documentPathsOption, document)
+	}
 
-/**
- * Resolves a fetched Sanity document to its canonical public title
- */
-export const resolveDocumentTitle = (document: unknown) => {
-	return resolveDocumentRoute(document)?.title || null
-}
+	/**
+	 * Resolves a fetched Sanity document to its canonical public pathname
+	 */
+	function resolveDocumentPathname(document: unknown) {
+		return resolveDocumentRoute(document)?.path || null
+	}
 
-/**
- * Resolves a fetched Sanity document to its absolute production URL
- */
-export const resolveProductionUrl = (document: unknown) => {
-	const path = resolveDocumentPathname(document)
-	if (!path) return undefined
+	/**
+	 * Resolves a fetched Sanity document to its canonical public title
+	 */
+	function resolveDocumentTitle(document: unknown) {
+		return resolveDocumentRoute(document)?.title || null
+	}
 
-	return `${siteURL}${path}`
-}
+	/**
+	 * Resolves a fetched Sanity document to its absolute production URL
+	 */
+	function resolveProductionUrl(document: unknown) {
+		const route = resolveDocumentRoute(document)
+		if (!route) return undefined
 
-/**
- * Returns the schema types that have document path declarations.
- */
-export const getLinkableTypes = () => {
-	return Object.keys(documentPaths)
-}
+		return (
+			resolveProductionUrlOption?.({
+				document: route.document,
+				path: route.path,
+				title: route.title,
+			}) ?? `${siteURL}${route.path}`
+		)
+	}
 
-/**
- * Adapts document path declarations to Sanity Presentation's locations API
- */
-export const resolveDocumentLocations: DocumentLocationResolver = (
-	{ id },
-	context,
-) => {
-	const doc$ = context.documentStore.listenQuery(
-		`*[_id==$id][0]`,
+	/**
+	 * Returns the schema types that have document path declarations.
+	 */
+	function getLinkableTypes() {
+		return Object.keys(documentPathsOption)
+	}
+
+	/**
+	 * Adapts document path declarations to Sanity Presentation's locations API
+	 */
+	const resolveDocumentLocations: DocumentLocationResolver = (
 		{ id },
-		{ perspective: "previewDrafts" },
-	)
+		context,
+	) => {
+		const doc$ = context.documentStore.listenQuery(
+			documentQuery,
+			{ id },
+			{ perspective: "previewDrafts" },
+		)
 
-	return doc$.pipe(
-		map((document: SanityDocument | null) => {
-			if (!document) return { locations: [] }
-			const href = resolveDocumentPathname(document)
-			if (!href) return { locations: [] }
+		return doc$.pipe(
+			map((document: SanityDocument | null) => {
+				const route = resolveDocumentRoute(document)
+				if (!route) return { locations: [] }
 
-			return {
-				locations: [
-					{ href, title: resolveDocumentTitle(document) || "No Title" },
-				],
-			} satisfies DocumentLocationsState
-		}),
-	)
+				const href =
+					resolveLocationHref?.({
+						document: route.document,
+						path: route.path,
+						title: route.title,
+					}) ?? route.path
+				if (!href) return { locations: [] }
+
+				return {
+					locations: [{ href, title: route.title || "No Title" }],
+				} satisfies DocumentLocationsState
+			}),
+		)
+	}
+
+	return {
+		getLinkableTypes,
+		resolveDocumentLocations,
+		resolveDocumentPathname,
+		resolveDocumentTitle,
+		resolveProductionUrl,
+	}
 }
+
+const defaultDocumentHelpers = createDocumentHelpers()
+
+export const getLinkableTypes = defaultDocumentHelpers.getLinkableTypes
+
+export const resolveDocumentLocations =
+	defaultDocumentHelpers.resolveDocumentLocations
+
+export const resolveDocumentPathname =
+	defaultDocumentHelpers.resolveDocumentPathname
+
+export const resolveDocumentTitle = defaultDocumentHelpers.resolveDocumentTitle
+
+export const resolveProductionUrl = defaultDocumentHelpers.resolveProductionUrl

--- a/sanity/live.tsx
+++ b/sanity/live.tsx
@@ -13,7 +13,32 @@ import { version as sanityVersion } from "sanity/package.json"
 import semver from "semver"
 import { handleError, SanityLiveRuntime } from "./live.client"
 
-const libraryClient = client.withConfig({ useCdn: false })
+// defineLive internally overrides useCdn per-request (`useCdn = perspective === "published"`),
+// making the client-level useCdn: false ineffective. In development, this means published
+// content is served from Sanity's API CDN (60s cache) and never updates without webhooks.
+// The proxy below intercepts every .fetch() call to force useCdn: false, and chains through
+// .withConfig() so the intercept survives defineLive's internal _client.withConfig() call.
+type SanityClientLike = typeof client
+function makeNoCdnProxy(target: SanityClientLike): SanityClientLike {
+	return new Proxy(target, {
+		get(t, prop, receiver) {
+			if (prop === "fetch") {
+				type FetchOptions = Parameters<typeof t.fetch>[2]
+				return (query: string, params?: QueryParams, options?: FetchOptions) =>
+					Reflect.get(t, prop, receiver).call(t, query, params, { ...options, useCdn: false } as FetchOptions)
+			}
+			if (prop === "withConfig") {
+				return (...args: Parameters<typeof t.withConfig>) =>
+					makeNoCdnProxy(Reflect.get(t, prop, receiver).call(t, ...args))
+			}
+			const value = Reflect.get(t, prop, receiver)
+			return typeof value === "function" ? (value as (...a: unknown[]) => unknown).bind(t) : value
+		},
+	})
+}
+
+const libraryClient =
+	process.env.NODE_ENV === "development" ? makeNoCdnProxy(client) : client.withConfig({ useCdn: false })
 
 /**
  * Use defineLive to enable automatic revalidation and refreshing of your fetched content

--- a/sanity/live.tsx
+++ b/sanity/live.tsx
@@ -25,20 +25,27 @@ function makeNoCdnProxy(target: SanityClientLike): SanityClientLike {
 			if (prop === "fetch") {
 				type FetchOptions = Parameters<typeof t.fetch>[2]
 				return (query: string, params?: QueryParams, options?: FetchOptions) =>
-					Reflect.get(t, prop, receiver).call(t, query, params, { ...options, useCdn: false } as FetchOptions)
+					Reflect.get(t, prop, receiver).call(t, query, params, {
+						...options,
+						useCdn: false,
+					} as FetchOptions)
 			}
 			if (prop === "withConfig") {
 				return (...args: Parameters<typeof t.withConfig>) =>
 					makeNoCdnProxy(Reflect.get(t, prop, receiver).call(t, ...args))
 			}
 			const value = Reflect.get(t, prop, receiver)
-			return typeof value === "function" ? (value as (...a: unknown[]) => unknown).bind(t) : value
+			return typeof value === "function"
+				? (value as (...a: unknown[]) => unknown).bind(t)
+				: value
 		},
 	})
 }
 
 const libraryClient =
-	process.env.NODE_ENV === "development" ? makeNoCdnProxy(client) : client.withConfig({ useCdn: false })
+	process.env.NODE_ENV === "development"
+		? makeNoCdnProxy(client)
+		: client.withConfig({ useCdn: false })
 
 /**
  * Use defineLive to enable automatic revalidation and refreshing of your fetched content

--- a/sanity/singletonPlugin.tsx
+++ b/sanity/singletonPlugin.tsx
@@ -2,8 +2,10 @@
  * This plugin contains all the logic for setting up the singletons
  */
 
+import type { ComponentType } from "react"
 import { type DocumentDefinition, definePlugin } from "sanity"
 import type {
+	Child,
 	ListItemBuilder,
 	StructureBuilder,
 	StructureResolver,
@@ -41,26 +43,141 @@ type GroupItem = {
 	hiddenTypes: string[]
 }
 
+type StructureListChild =
+	| ListItemBuilder
+	| ReturnType<StructureBuilder["divider"]>
+type StructureGroupItem = string | StructureListChild
+type StructureGroupBase = {
+	title: string
+	icon?: ComponentType
+	hiddenTypes?: string[]
+}
+type StructureGroupWithItems = StructureGroupBase & {
+	items:
+		| StructureGroupItem[]
+		| ((S: StructureBuilder) => StructureGroupItem[] | StructureListChild)
+}
+type StructureGroupWithChild = StructureGroupBase & {
+	child: (S: StructureBuilder) => Child
+}
+type StructureGroup = StructureGroupWithItems | StructureGroupWithChild
+type PageStructureOptions = {
+	singletons: DocumentDefinition[]
+	groups?: StructureGroup[]
+	hiddenTypes?: string[]
+}
+
+function singletonItem(S: StructureBuilder, typeDef: DocumentDefinition) {
+	return S.listItem()
+		.title(typeDef?.title ?? "Untitled")
+		.icon(typeDef.icon)
+		.child(
+			S.editor()
+				.id(typeDef.name)
+				.schemaType(typeDef.name)
+				.documentId(typeDef.name),
+		)
+}
+
+function resolveGroupItem(S: StructureBuilder, item: StructureGroupItem) {
+	if (typeof item === "string") return S.documentTypeListItem(item)
+	return item
+}
+
+function groupItem(S: StructureBuilder, group: StructureGroup) {
+	if ("child" in group) {
+		return S.listItem()
+			.title(group.title)
+			.icon(group.icon)
+			.child(group.child(S))
+	}
+
+	const rawItems =
+		typeof group.items === "function" ? group.items(S) : group.items
+	const items = Array.isArray(rawItems) ? rawItems : [rawItems]
+
+	return S.listItem()
+		.title(group.title)
+		.icon(group.icon)
+		.child(
+			S.list()
+				.title(group.title)
+				.items(items.map((item) => resolveGroupItem(S, item))),
+		)
+}
+
+function getGroupHiddenTypes(groups: StructureGroup[]) {
+	return groups.flatMap((group) => [
+		...(group.hiddenTypes ?? []),
+		...("items" in group && Array.isArray(group.items)
+			? group.items.filter((item): item is string => typeof item === "string")
+			: []),
+	])
+}
+
+function createPageStructure({
+	groups = [],
+	hiddenTypes = [],
+	singletons,
+}: PageStructureOptions): StructureResolver {
+	return (S) => {
+		const singletonItems = singletons.map((typeDef) =>
+			singletonItem(S, typeDef),
+		)
+		const hiddenTypeIds = [
+			...singletons.map((singleton) => singleton.name),
+			...hiddenTypes,
+			...getGroupHiddenTypes(groups),
+		]
+
+		const nonSingletonItems = S.documentTypeListItems().filter(
+			(listItem) => !hiddenTypeIds.includes(listItem.getId() ?? ""),
+		)
+		const middleItems = ["media.tag", "assist.instruction.context"]
+			.map((id) => nonSingletonItems.find((item) => item.getId() === id))
+			.filter(Boolean)
+		const hiddenItems = ["mux.videoAsset"].map((id) =>
+			nonSingletonItems.find((item) => item.getId() === id),
+		)
+		const restOfItems = nonSingletonItems.filter(
+			(item) => !middleItems.includes(item) && !hiddenItems.includes(item),
+		)
+		const groupItems = groups.map((group) => groupItem(S, group))
+
+		return S.list()
+			.title("Content Types")
+			.items([
+				...singletonItems,
+				...groupItems,
+				S.divider(),
+				...middleItems,
+				S.divider(),
+				...restOfItems,
+			])
+	}
+}
+
 // The StructureResolver is how we're changing the DeskTool structure to linking to document (named Singleton)
 // like how "Home" is handled.
-export const pageStructure = (
+export function pageStructure(options: PageStructureOptions): StructureResolver
+export function pageStructure(
 	typeDefArray: DocumentDefinition[],
 	groups?: GroupItem[],
-): StructureResolver => {
+): StructureResolver
+export function pageStructure(
+	optionsOrTypeDefArray: PageStructureOptions | DocumentDefinition[],
+	groups?: GroupItem[],
+): StructureResolver {
+	if (!Array.isArray(optionsOrTypeDefArray))
+		return createPageStructure(optionsOrTypeDefArray)
+
+	const typeDefArray = optionsOrTypeDefArray
 	return (S) => {
 		// Goes through all of the singletons that were provided and translates them into something the
 		// Structure tool can understand
-		const singletonItems = typeDefArray.map((typeDef) => {
-			return S.listItem()
-				.title(typeDef?.title ?? "Untitled")
-				.icon(typeDef.icon)
-				.child(
-					S.editor()
-						.id(typeDef.name)
-						.schemaType(typeDef.name)
-						.documentId(typeDef.name),
-				)
-		})
+		const singletonItems = typeDefArray.map((typeDef) =>
+			singletonItem(S, typeDef),
+		)
 
 		const hiddenTypes = [
 			...typeDefArray.map((s) => s.name),


### PR DESCRIPTION
- Adds a non-breaking factory for Sanity document helpers so apps can customize preview location hrefs, production URLs, document queries, and path resolvers. 
- Extends the singleton page structure helper with grouped sections and custom child escapes while preserving the existing API.
- fixes listStaticRoutes and adds a new listRoutes api

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `createDocumentHelpers` factory and options-based `pageStructure` overload to Studio
> - Adds `createDocumentHelpers` in [document-helpers.ts](https://github.com/reformcollective/library/pull/518/files#diff-0c27901ee5d08bae6fa5ad315dfc93c03daf00d1a553ebc570fbdd59d5d59b3f) to create customized Studio document helpers with configurable `documentPaths`, `documentQuery`, `resolveLocationHref`, and `resolveProductionUrl` options. Default exports are preserved for backward compatibility.
> - Extends `pageStructure` in [singletonPlugin.tsx](https://github.com/reformcollective/library/pull/518/files#diff-2e779049e887021e9fb35738a544e7e1fd95c254fd2a13cf41fd39576663a2f6) with a new options-object overload supporting groups (with custom children or item lists) and additional hidden types, delegating to a new `createPageStructure` factory.
> - Behavioral Change: `resolveDocumentPathname` and `resolveDocumentTitle` now return `null` when unresolved (previously used a fixed fallback); `resolveProductionUrl` returns `undefined` when no route is resolved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6cdc260. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->