### PR TITLE
better route listing

### DIFF
--- a/list-pages.test.ts
+++ b/list-pages.test.ts
@@ -1,24 +1,74 @@
-import { describe, expect, test } from "vitest"
-import { isDynamicRoutePath, pageFilePathToRoute } from "./list-pages"
+import { describe, expect, test, vi } from "vitest"
+
+async function importListPagesWithRoutes(routes: string[]) {
+	vi.resetModules()
+	vi.doMock("node:fs/promises", () => ({
+		glob: async function* () {
+			yield* routes
+		},
+	}))
+
+	return await import("./list-pages")
+}
 
 describe("static route listing helpers", () => {
-	test("treats dynamic segments as dynamic unless a segment value is provided", () => {
+	test("treats dynamic segments as dynamic", async () => {
+		const { isDynamicRoutePath } = await importListPagesWithRoutes([])
+
 		expect(isDynamicRoutePath("app/[site]/text-demo/page.tsx")).toBe(true)
 	})
 
-	test("keeps catch-all and document dynamic routes out of static routes", () => {
+	test("keeps catch-all and document dynamic routes out of static routes", async () => {
+		const { isDynamicRoutePath } = await importListPagesWithRoutes([])
+
 		expect(isDynamicRoutePath("app/[site]/[[...slug]]/page.tsx")).toBe(true)
 		expect(isDynamicRoutePath("app/[site]/products/[slug]/page.tsx")).toBe(true)
 	})
 
-	test("substitutes configured dynamic segment values", () => {
-		const segments = { site: "temple" }
+	test("converts page file paths to route patterns", async () => {
+		const { pageFilePathToRoute } = await importListPagesWithRoutes([])
 
-		expect(isDynamicRoutePath("app/[site]/text-demo/page.tsx", segments)).toBe(
-			false,
+		expect(pageFilePathToRoute("app/(shop)/[site]/text-demo/page.tsx")).toBe(
+			"/[site]/text-demo",
 		)
-		expect(pageFilePathToRoute("app/[site]/text-demo/page.tsx", segments)).toBe(
-			"/temple/text-demo",
+	})
+
+	test("lists only fully static routes", async () => {
+		const { listStaticRoutes } = await importListPagesWithRoutes([
+			"app/(shop)/about/page.tsx",
+			"app/(shop)/about/page.tsx",
+			"app/[site]/shop/page.tsx",
+			"app/[site]/[[...slug]]/page.tsx",
+			"app/visual-tests/page.tsx",
+		])
+
+		expect(listStaticRoutes()).toEqual(["/about", "/visual-tests"])
+	})
+
+	test("substitutes simple dynamic segment values", async () => {
+		const { listRoutes } = await importListPagesWithRoutes([
+			"app/[site]/account/page.tsx",
+			"app/[site]/shop/page.tsx",
+			"app/[site]/[[...slug]]/page.tsx",
+			"app/[site]/products/[slug]/page.tsx",
+			"app/sample-form/page.tsx",
+		])
+
+		expect(listRoutes({ site: "temple" })).toEqual([
+			"/sample-form",
+			"/temple/account",
+			"/temple/shop",
+		])
+	})
+
+	test("rejects invalid segment values", async () => {
+		const { listRoutes } = await importListPagesWithRoutes([
+			"app/[site]/shop/page.tsx",
+		])
+
+		expect(() => listRoutes({ site: "" })).toThrow("must not be empty")
+		expect(() => listRoutes({ site: "temple/shop" })).toThrow(
+			"single path segment",
 		)
 	})
 })

--- a/list-pages.ts
+++ b/list-pages.ts
@@ -1,4 +1,5 @@
 import { glob } from "node:fs/promises"
+import { compileTime } from "./compile-time.ts"
 
 const pageFileGlob = "app/**/page.{js,jsx,ts,tsx}"
 const pageFilePattern = /^page\.(js|jsx|ts|tsx)$/
@@ -8,11 +9,6 @@ type StaticRouteSegments = Record<string, string | undefined>
 function getDynamicSegmentName(segment: string) {
 	const match = segment.match(/^\[([^.[\]]+)\]$/)
 	return match?.[1]
-}
-
-function hasSegmentValue(segment: string, segments: StaticRouteSegments) {
-	const segmentName = getDynamicSegmentName(segment)
-	return segmentName ? segments[segmentName] != null : false
 }
 
 export function normalizeRoutePath(path: string) {
@@ -25,47 +21,69 @@ export function normalizeRoutePath(path: string) {
 	return normalizedPath
 }
 
-export function isDynamicRoutePath(
-	path: string,
-	segments: StaticRouteSegments = {},
-) {
+export function isDynamicRoutePath(path: string) {
 	return path
 		.replaceAll("\\", "/")
 		.split("/")
-		.some(
-			(segment) =>
-				/\[.+\]/.test(segment) && !hasSegmentValue(segment, segments),
-		)
+		.some((segment) => /\[.+\]/.test(segment))
 }
 
-export function pageFilePathToRoute(
-	path: string,
-	segments: StaticRouteSegments = {},
-) {
+export function pageFilePathToRoute(path: string) {
 	const parts = path.replaceAll("\\", "/").split("/").filter(Boolean)
 	const withoutApp = parts[0] === "app" ? parts.slice(1) : parts
 	const withoutPageFile = pageFilePattern.test(withoutApp.at(-1) ?? "")
 		? withoutApp.slice(0, -1)
 		: withoutApp
 
-	const routeParts = withoutPageFile
-		.filter((segment) => !(segment.startsWith("(") && segment.endsWith(")")))
-		.map((segment) => {
-			const segmentName = getDynamicSegmentName(segment)
-			return segmentName ? (segments[segmentName] ?? segment) : segment
-		})
+	const routeParts = withoutPageFile.filter(
+		(segment) => !(segment.startsWith("(") && segment.endsWith(")")),
+	)
 
 	return normalizeRoutePath(`/${routeParts.join("/")}`)
 }
 
-export async function listStaticRoutes(segments: StaticRouteSegments = {}) {
+function validateSegmentValue(name: string, value: string | undefined) {
+	if (value == null) return
+	if (!value) throw new Error(`Route segment "${name}" must not be empty.`)
+	if (value.includes("/")) {
+		throw new Error(`Route segment "${name}" must be a single path segment.`)
+	}
+}
+
+function substituteRouteSegments(route: string, segments: StaticRouteSegments) {
+	return normalizeRoutePath(
+		route
+			.split("/")
+			.map((segment) => {
+				const segmentName = getDynamicSegmentName(segment)
+				return segmentName ? (segments[segmentName] ?? segment) : segment
+			})
+			.join("/"),
+	)
+}
+
+const allRoutes = await compileTime(async () => {
 	const routes = new Set<string>()
 
 	for await (const entry of glob(pageFileGlob)) {
-		if (isDynamicRoutePath(entry, segments)) continue
-
-		routes.add(pageFilePathToRoute(entry, segments))
+		routes.add(pageFilePathToRoute(entry))
 	}
 
 	return Array.from(routes).sort()
+})
+
+export function listStaticRoutes() {
+	return allRoutes.filter((route) => !isDynamicRoutePath(route))
+}
+
+export function listRoutes(segments: StaticRouteSegments) {
+	for (const [name, value] of Object.entries(segments)) {
+		validateSegmentValue(name, value)
+	}
+
+	const routes = allRoutes
+		.map((route) => substituteRouteSegments(route, segments))
+		.filter((route) => !isDynamicRoutePath(route))
+
+	return Array.from(new Set(routes)).sort()
 }

--- a/list-pages.ts
+++ b/list-pages.ts
@@ -3,6 +3,7 @@ import { compileTime } from "./compile-time.ts"
 
 const pageFileGlob = "app/**/page.{js,jsx,ts,tsx}"
 const pageFilePattern = /^page\.(js|jsx|ts|tsx)$/
+const sourceDirectory = process.cwd()
 
 type StaticRouteSegments = Record<string, string | undefined>
 
@@ -65,7 +66,7 @@ function substituteRouteSegments(route: string, segments: StaticRouteSegments) {
 const allRoutes = await compileTime(async () => {
 	const routes = new Set<string>()
 
-	for await (const entry of glob(pageFileGlob)) {
+	for await (const entry of glob(pageFileGlob, { cwd: sourceDirectory })) {
 		routes.add(pageFilePathToRoute(entry))
 	}
 


### PR DESCRIPTION
updates our static route helpers. use these in e.g. a sitemap to list all the page files in the app.
you can pass segments to the function too if needed to generate routes for specific dynamic path subsets.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor route listing to precompute routes and add `listRoutes` with dynamic segment substitution
> - [`list-pages.ts`](https://github.com/reformcollective/library/pull/519/files#diff-3ee1911f8de9ab71875f85b0b64aa7d6069fd5886bffa535c2826c5aa785325b) now precomputes all route patterns at module initialization via `compileTime`, caching them in `allRoutes` for synchronous access.
> - `isDynamicRoutePath` and `pageFilePathToRoute` no longer accept a `segments` parameter; both now return raw patterns preserving dynamic placeholders like `[site]`.
> - Adds `listStaticRoutes` (synchronous, filters `allRoutes` to fully static paths) and `listRoutes` (substitutes provided segment values, deduplicates, and sorts results).
> - Adds `validateSegmentValue` to reject empty or slash-containing segment values with explicit errors.
> - Behavioral Change: callers previously passing `segments` to `isDynamicRoutePath` or `pageFilePathToRoute` must migrate to `listRoutes`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a27f9dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->