### PR TITLE
Expire Sanity live tags immediately

### DIFF
--- a/sanity/liveProxy.ts
+++ b/sanity/liveProxy.ts
@@ -92,7 +92,7 @@ export async function POST(request: Request) {
 
 	if (tags?.length) {
 		for (const tag of tags) {
-			revalidateTag(`sanity:${tag}`, "max")
+			revalidateTag(`sanity:${tag}`, { expire: 0 })
 		}
 	} else {
 		revalidatePath("/", "layout")


### PR DESCRIPTION
## Summary
- change Sanity live tag revalidation from stale-while-revalidate to immediate expiration
- use `revalidateTag(tag, { expire: 0 })`, matching Next docs guidance for third-party webhook route handlers that need immediate expiration

## Validation
- `pnpm --dir library test`
- `pnpm --dir library lint`
- `pnpm --dir library format`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expire Sanity live tags immediately on revalidation
> Changes `revalidateTag` calls in [liveProxy.ts](https://github.com/reformcollective/library/pull/520/files#diff-244288ad1411977584a688fbc6b013763c32f4bf695471d37314a3c41959c6ab) to pass `{ expire: 0 }` instead of `"max"`, causing live tags to expire immediately rather than at the maximum cache lifetime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b74aae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->