### PR TITLE
Merge miscellaneous helper fixes

### DIFF
--- a/AutoAnimate.tsx
+++ b/AutoAnimate.tsx
@@ -135,7 +135,9 @@ export default function AutoAnimate({
 
 	// Use state instead of ref since this needs to be accessed during render
 	const [keyBasedCache, setKeyBasedCache] = useState<Record<string, ReactNode>>(
-		{},
+		() => ({
+			[childKey]: children,
+		}),
 	)
 
 	// Update the cache when children change

--- a/InfiniteSideScroll.tsx
+++ b/InfiniteSideScroll.tsx
@@ -119,15 +119,16 @@ export function InfiniteSideScroll({
 			)
 			const gap =
 				firstLastChild && secondFirstChild
-					? // distance from right edge of first to left edge of second,
+					? // distance from layout right edge of first to layout left edge of second,
 						// minus secondFirstLeftMargin only (already in totalWidth via spaceBefore[0]).
 						// The last item's right margin is NOT subtracted: horizontalLoop's getTotalWidth ends
 						// at the last item's offsetWidth (no trailing margin), so that margin must
 						// remain in paddingRight to produce an even gap at the loop point.
-						Math.abs(
-							firstLastChild.getBoundingClientRect().right -
-								secondFirstChild.getBoundingClientRect().left,
-						) - secondFirstLeftMargin
+						getLayoutGap(
+							firstLastChild,
+							secondFirstChild,
+							secondFirstLeftMargin,
+						)
 					: 0
 
 			const loop = horizontalLoop(rowRef.current.children, {
@@ -318,6 +319,25 @@ export function InfiniteSideScroll({
 				</ButtonWrapper>
 			)}
 		</Wrapper>
+	)
+}
+
+function getLayoutGap(
+	firstLastChild: Element,
+	secondFirstChild: Element,
+	secondFirstLeftMargin: number,
+) {
+	if (
+		!(firstLastChild instanceof HTMLElement) ||
+		!(secondFirstChild instanceof HTMLElement)
+	) {
+		return 0
+	}
+
+	return (
+		secondFirstChild.offsetLeft -
+		(firstLastChild.offsetLeft + firstLastChild.offsetWidth) -
+		secondFirstLeftMargin
 	)
 }
 

--- a/gsapHelpers/horizontalLoop.js
+++ b/gsapHelpers/horizontalLoop.js
@@ -174,7 +174,7 @@ export function horizontalLoop(items, config) {
 			},
 			onResize = () => refresh(true),
 			proxy
-		gsap.set(items, { x: 0 })
+		gsap.set(items, { x: 0, xPercent: 0 })
 		populateWidths()
 		populateTimeline()
 		populateOffsets()

--- a/sanity/redirect.tsx
+++ b/sanity/redirect.tsx
@@ -1,4 +1,5 @@
 import { library } from "library/layers.css"
+import UniversalLink from "library/link"
 import { css, f, styled } from "library/styled"
 import { draftMode } from "next/headers"
 import { redirect } from "next/navigation"
@@ -41,7 +42,7 @@ const Wrapper = styled("div", [
 	},
 ])
 
-const Link = styled("a", [
+const Link = styled(UniversalLink, [
 	{
 		"@layer": {
 			[library]: f.unresponsive(css`

--- a/useAutoHideHeader.ts
+++ b/useAutoHideHeader.ts
@@ -121,16 +121,10 @@ export default function useAutoHideHeader(
 
 			const onUpdate = () => {
 				const scroll = window.lenisInstance?.scroll ?? window.scrollY
-				const delta = scroll - lastScroll
+				const rawDelta = scroll - lastScroll
+				const delta = Math.abs(rawDelta) < 100 ? rawDelta : 0
 				lastScroll = scroll
 				const height = (wrapper.current?.offsetHeight ?? 0) + extraOffset
-				if (delta > 100 || delta < -100) {
-					// short circuit on large scrolls, since those are probably page transitions
-					// still update scrolled state so scroll-dependent styles remain correct
-					const el = wrapper.current
-					if (el) el.dataset.headerScrolled = scroll <= 5 ? "false" : "true"
-					return
-				}
 
 				const forceHideHeader = dataHideAreOnScreen.current
 				const forceShowHeader =
@@ -140,8 +134,7 @@ export default function useAutoHideHeader(
 
 				const el = wrapper.current
 				if (el) {
-					if (scroll <= 5) el.dataset.headerScrolled = "false"
-					else if (delta < 0 || isHovered) el.dataset.headerScrolled = "true"
+					el.dataset.headerScrolled = scroll <= 5 ? "false" : "true"
 				}
 
 				// if forced sticky
@@ -171,9 +164,11 @@ export default function useAutoHideHeader(
 
 			const onHover = () => {
 				isHovered = true
+				onUpdate()
 			}
 			const onLeave = () => {
 				isHovered = false
+				onUpdate()
 			}
 
 			const onPopState = () => {

--- a/vanilla/vanilla-split-loader.ts
+++ b/vanilla/vanilla-split-loader.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto"
 import fsSync from "node:fs"
 import fs from "node:fs/promises"
 import path from "node:path"
@@ -64,6 +65,13 @@ const COMPILE_TIME_IMPORT = "compileTime"
 const turboLoader =
 	// @ts-expect-error turbopack loader shape has default export in some builds
 	(turboLoaderRAW.default as typeof turboLoaderRAW) ?? turboLoaderRAW
+
+function safeWrite(filePath: string, content: string): void {
+	const tempPath = `${filePath}.${crypto.randomUUID()}.tmp`
+
+	fsSync.writeFileSync(tempPath, content, "utf8")
+	fsSync.renameSync(tempPath, filePath)
+}
 
 // =============================================================================
 // Tracked import registry
@@ -998,7 +1006,7 @@ async function transform(
 		.join(tmpRoot, `${relPathNoExt}${virtualExt}`)
 		.replace(/\\/g, "/")
 	fsSync.mkdirSync(path.dirname(tmpFile), { recursive: true })
-	fsSync.writeFileSync(tmpFile, virtualSourceResolved, "utf8")
+	safeWrite(tmpFile, virtualSourceResolved)
 
 	// 11) Run VE plugin
 	const veJs = await runVePluginOnTempFile(loaderThis, tmpFile, options)


### PR DESCRIPTION
## Summary
- use layout positions for InfiniteSideScroll gap math and reset `xPercent` in `horizontalLoop` refreshes
- normalize large scroll jumps in `useAutoHideHeader` while still refreshing header state
- seed `AutoAnimate`'s initial child cache and use `UniversalLink` for the Sanity redirect link
- write vanilla split temp files atomically without carrying over diagnostic logging

## Validation
- `pnpm --dir library format`
- `pnpm --dir library lint`
- `pnpm --dir library test`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix miscellaneous helper bugs across animation, scroll, and file write utilities
> - [useAutoHideHeader](https://github.com/reformcollective/library/pull/521/files#diff-b14a74e115bbf457ceb955667011fac6889f557e9b51103f4fc5e44dd70daffd): clamps large scroll deltas (|delta| >= 100) to 0 instead of skipping updates entirely; hover/leave now trigger immediate header updates
> - [InfiniteSideScroll](https://github.com/reformcollective/library/pull/521/files#diff-912ab74ce54e84d40466bef7a610ca8251f9a43e5632dfb3c7c36a9cadafb877): replaces `boundingClientRect` gap calculation with layout offset-based `getLayoutGap` helper for more accurate marquee padding
> - [horizontalLoop](https://github.com/reformcollective/library/pull/521/files#diff-aaedf2b2c172111f4a3cb3f18c2776d96f79b432c592a30c02a239e4663ae8d8): explicitly resets `xPercent` to 0 on init alongside `x`, fixing transforms when `xPercent` was previously non-zero
> - [AutoAnimate](https://github.com/reformcollective/library/pull/521/files#diff-c430f57cc8938addeaee4a9d912effde51749ff22c8f432e75c0d7a2f5ce8d77): seeds the key-based cache with the current child on initial render, avoiding an undefined lookup before the first effect runs
> - [vanilla-split-loader](https://github.com/reformcollective/library/pull/521/files#diff-7bb7546a3ca77ab09c0ef2aa56e75f457bd1c5f9937460a2887f61105091ecaf): writes temp files atomically via a UUID-named temp file and rename to prevent partial writes
> - Behavioral Change: gap values in `InfiniteSideScroll` may differ from previous values in some layouts due to the switch from bounding rect to layout offsets
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc7fe84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->