### PR TITLE
Safari video fix

### DIFF
--- a/videos/VideoEmbed.tsx
+++ b/videos/VideoEmbed.tsx
@@ -59,6 +59,7 @@ export function VideoEmbed({
 					width="100%"
 					height="100%"
 					controls={controls}
+					playsInline
 					onPlay={
 						resetOnPlay
 							? (e) => {


### PR DESCRIPTION
Safari videos weren't showing up  in actual iOS devices in some cases. Updated out component to allow for that. 

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Safari video playback by adding `playsInline` to `VideoEmbed`
> Adds the `playsInline` prop to the `ReactPlayer` element in [VideoEmbed.tsx](https://github.com/reformcollective/library/pull/522/files#diff-042b97c622f16cc850f109bc9e3adcb3693d911d3226374851c7b8e91bc96da4) so videos play inline rather than launching fullscreen on Safari.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4ff8dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->