### PR TITLE
sanity query size optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,64 @@
+# 2026-06-04
+
+## Sanity query size optimizations
+
+Sanity has a 300KB request body limit. To help keep queries below that size, asset metadata projections now use groq functions.
+
+`library/sanity/assetMetadata` now exports `assetMetadataFunctions`, which defines `reform::image`, `reform::images`, `reform::video`, `reform::videos`, `reform::link`, and `reform::links` for use in groq queries.
+
+`libraryFetch` now also warns when a GROQ query passed to `sanityFetch` exceeds 200kb.
+
+**Migration Advice**
+
+Prepend `assetMetadataFunctions` to any query that uses asset functions and update your query to use groq functions directly.
+
+Before:
+
+```ts
+import { imageField, linkField, videoField } from "library/sanity/assetMetadata"
+
+const pageQuery = defineQuery(`
+	*[_type == "page"][0] {
+		${imageField("myImageField")}
+		${videoField("myVideoField")}
+		${linkField("myLinkField")}
+
+		myImageListField[] {
+			...,
+			"data": {
+				"lqip": asset->metadata.lqip,
+				"url": asset->url
+			}
+		}
+	}
+`)
+```
+
+After:
+
+```ts
+import { assetMetadataFunctions } from "library/sanity/assetMetadata"
+
+const pageQuery = defineQuery(`
+	${assetMetadataFunctions}
+
+	*[_type == "page"][0] {
+		"myImageField": reform::image(myImageField),
+		"myVideoField": reform::video(myVideoField),
+		"myLinkField": reform::link(myLinkField),
+
+		"myImageListField": reform::images(myImageListField),
+		"myVideoListField": reform::videos(myVideoListField),
+		"myLinkListField": reform::links(myLinkListField),
+
+		richTextField[] {
+			...,
+			_type == "inlineImage" => reform::image(@)
+		}
+	}
+`)
+```
+
 # 2026-05-20
 
 ## Link fields support SMS and document downloads
@@ -210,7 +271,7 @@ Update sanity config to import utilities from `library/sanity/document-helpers`
 
 ## removed `fetchAssetMeta` / `enrichAssets`
 
-`fetchAssetMeta` and the `enrichAssets` option on `libraryFetch` / `sanityFetch` have been removed. Asset, video, and link metadata should be resolved inline with `imageField`, `videoField`, or `linkField`.
+`fetchAssetMeta` and the `enrichAssets` option on `libraryFetch` / `sanityFetch` have been removed. Asset, video, and link metadata should be resolved inline with `assetMetadataFunctions` and direct `reform::image`, `reform::video`, or `reform::link` calls.
 
 **Migration Advice**
 

--- a/sanity/assetMetadata.ts
+++ b/sanity/assetMetadata.ts
@@ -130,11 +130,11 @@ const muxVideoProjection = `{
 
 const videoProjection = `{ ..., muxVideo ${muxVideoProjection} }` as const
 
-export const linkField = <T extends string>(name: T) =>
-	`${name} ${linkProjection}` as const
-
-export const imageField = <T extends string>(name: T) =>
-	`${name} ${imageProjection}` as const
-
-export const videoField = <T extends string>(name: T) =>
-	`${name} ${videoProjection}` as const
+export const assetMetadataFunctions = `
+	fn reform::link($link) = $link ${linkProjection};
+	fn reform::links($links) = $links[] ${linkProjection};
+	fn reform::image($image) = $image ${imageProjection};
+	fn reform::images($images) = $images[] ${imageProjection};
+	fn reform::video($video) = $video ${videoProjection};
+	fn reform::videos($videos) = $videos[] ${videoProjection};
+` as const

--- a/sanity/live.tsx
+++ b/sanity/live.tsx
@@ -66,6 +66,8 @@ type LibraryFetchResult<QueryString extends string> = {
 	tags: string[]
 }
 
+const sanityFetchQuerySizeWarningThresholdBytes = 200 * 1024
+
 /**
  * Used to fetch data in Server Components, it has built in support for handling Draft Mode and perspectives.
  * When using the "published" perspective then time-based revalidation is used, set to match the time-to-live on Sanity's API CDN (60 seconds)
@@ -94,10 +96,15 @@ export async function libraryFetch<const QueryString extends string>({
 	disableStega?: boolean
 }): Promise<LibraryFetchResult<QueryString>> {
 	const resolvedParams = await params
-	console.log("sanityFetch body size", {
-		queryBytes: Buffer.byteLength(query),
-		paramsBytes: Buffer.byteLength(JSON.stringify(resolvedParams)),
-	})
+	const queryBytes = Buffer.byteLength(query)
+	const paramsBytes = Buffer.byteLength(JSON.stringify(resolvedParams))
+	if (queryBytes > sanityFetchQuerySizeWarningThresholdBytes) {
+		console.warn("sanityFetch query size exceeds warning threshold", {
+			queryBytes,
+			paramsBytes,
+			thresholdBytes: sanityFetchQuerySizeWarningThresholdBytes,
+		})
+	}
 	return await internalFetch({
 		query,
 		params: resolvedParams,


### PR DESCRIPTION
## Summary
- replace inline asset metadata field helpers with reusable GROQ function definitions
- add singular and plural asset functions so array projections stay Sanity TypeGen-safe
- warn from `libraryFetch` when GROQ query text exceeds 200kb
- document migration guidance in `CHANGELOG.md`

## Validation
- `WIREIT_LOGGER=metrics pnpm format`
- `WIREIT_LOGGER=metrics pnpm typecheck`
- `WIREIT_LOGGER=metrics pnpm lint` (existing unrelated `effectiveProductIds` warning)
- `WIREIT_LOGGER=metrics pnpm build`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `linkField`/`imageField`/`videoField` helpers with `assetMetadataFunctions` GROQ definitions in Sanity
> - Removes `linkField`, `imageField`, and `videoField` projection helpers from [sanity/assetMetadata.ts](https://github.com/reformcollective/library/pull/523/files#diff-21a1b0cf75903ec16dfab0236a2aae247d372e72ae08fc09cdeaef578cbc34b8) and replaces them with a single `assetMetadataFunctions` export containing inline GROQ function definitions (`reform::link`, `reform::links`, `reform::image`, etc.).
> - Adds a 200 KiB query size warning in [sanity/live.tsx](https://github.com/reformcollective/library/pull/523/files#diff-e0c43f034731be3d23a5f38dd179ccebf43c8c44fc42efae3894a6eb3a27ee90): `libraryFetch` now logs a `console.warn` with query/params byte sizes when the query string exceeds the threshold.
> - Also resolves `params` before passing to `internalFetch`, fixing a case where a Promise was forwarded instead of the resolved value.
> - Risk: Consumers importing `linkField`, `imageField`, or `videoField` will fail at import time after this change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6351893.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->