### PR TITLE
link: require projected cms links

### DIFF
--- a/link/resolve.ts
+++ b/link/resolve.ts
@@ -1,5 +1,5 @@
-import { stegaClean } from "next-sanity"
 import type { LinkField } from "library/sanity/assetMetadata"
+import { stegaClean } from "next-sanity"
 import { linkIsInternal } from "../functions"
 
 export const staticPageLinkType = "static-page"

--- a/link/resolve.ts
+++ b/link/resolve.ts
@@ -1,27 +1,12 @@
 import { stegaClean } from "next-sanity"
+import type { LinkField } from "library/sanity/assetMetadata"
 import { linkIsInternal } from "../functions"
 
 export const staticPageLinkType = "static-page"
 export const smsLinkType = "sms"
 export const documentLinkType = "document"
 
-export type CMSLink = {
-	_type: "link"
-	text?: string
-	type?: string
-	/** Resolved by inline GROQ projection; null when not an internal link. */
-	internalSlug?: string | null
-	url?: string
-	email?: string
-	phone?: string
-	sms?: string
-	value?: string
-	fileUrl?: string | null
-	fileName?: string | null
-	blank?: boolean
-	parameters?: string
-	anchor?: string
-}
+export type CMSLink = LinkField
 
 /** All values accepted by resolveRoute / isRouteDefined. */
 export type LinkHref = string | null | undefined | CMSLink


### PR DESCRIPTION
- Require CMS link objects passed to UniversalLink/resolveRoute to use the projected LinkField shape.
- Remove the loose duplicate CMSLink type so missing reform::link projections surface as type errors.
