### PR TITLE
fit images and bg color

### DIFF
--- a/defaultConfig.ts
+++ b/defaultConfig.ts
@@ -61,6 +61,10 @@ type Config<
 	 */
 	allowProxy: boolean
 	/**
+	 * default background color for section preview icons in the Sanity studio
+	 */
+	sectionPreviewBackground: string
+	/**
 	 * additional responsive utilities to merge into the default f.* set
 	 */
 	utilities: Utilities
@@ -76,6 +80,7 @@ const defaultConfig = {
 	vanillaExtractEngine: "calc",
 	overridePreloaderResolvers: false,
 	allowProxy: true,
+	sectionPreviewBackground: "white",
 	utilities: {},
 } as const satisfies Config
 

--- a/sanity/reusables.tsx
+++ b/sanity/reusables.tsx
@@ -255,7 +255,10 @@ export function definePageSection<const TName extends string>(
 		{
 			...options,
 			groups: [{ name: group }],
-			icon: createSectionPreview(icon, iconBackground ?? libraryConfig.sectionPreviewBackground),
+			icon: createSectionPreview(
+				icon,
+				iconBackground ?? libraryConfig.sectionPreviewBackground,
+			),
 		},
 		secondary,
 	)

--- a/sanity/reusables.tsx
+++ b/sanity/reusables.tsx
@@ -52,19 +52,35 @@ function isFieldHidden(
 	)
 }
 
-export const createSectionPreview = (image: StaticImageData) =>
+export const createSectionPreview = (
+	image: StaticImageData,
+	background?: "white" | "dark",
+) =>
 	function SectionPreview() {
+		const bg =
+			background === "white" ? "#fff" : background === "dark" ? "#000" : undefined
 		return (
-			<img
-				alt=""
-				src={image.src}
+			<div
 				style={{
-					width: 160,
-					height: 90,
+					width: "160px",
+					height: "90px",
 					borderRadius: "0.1875rem",
-					objectFit: "cover",
+					overflow: "hidden",
+					flexShrink: 0,
+					background: bg,
 				}}
-			/>
+			>
+				<img
+					alt=""
+					src={image.src}
+					style={{
+						width: "100%",
+						height: "100%",
+						objectFit: "contain",
+						display: "block",
+					}}
+				/>
+			</div>
 		)
 	}
 
@@ -201,6 +217,7 @@ export function definePageSection<const TName extends string>(
 	{
 		group,
 		icon,
+		iconBackground = "white",
 		...options
 	}: Omit<
 		ArrayOfEntry<ObjectDefinition>,
@@ -221,6 +238,8 @@ export function definePageSection<const TName extends string>(
 		 * use browser devtools to capture an image of the section (ideally 1600x900 but can be any size)
 		 */
 		icon: StaticImageData
+		/** optional background color for the section preview icon */
+		iconBackground?: "white" | "dark"
 	},
 	secondary?: Parameters<
 		typeof defineArrayMember<
@@ -237,7 +256,7 @@ export function definePageSection<const TName extends string>(
 		{
 			...options,
 			groups: [{ name: group }],
-			icon: createSectionPreview(icon),
+			icon: createSectionPreview(icon, iconBackground),
 		},
 		secondary,
 	)

--- a/sanity/reusables.tsx
+++ b/sanity/reusables.tsx
@@ -1,5 +1,5 @@
 import { InfoOutlineIcon, PlayIcon } from "@sanity/icons"
-import type libraryConfig from "app/libraryConfig"
+import libraryConfig from "app/libraryConfig"
 import type { StaticImageData } from "next/image"
 import {
 	MATCH_URL_SPOTIFY,
@@ -54,15 +54,10 @@ function isFieldHidden(
 
 export const createSectionPreview = (
 	image: StaticImageData,
-	background?: "white" | "dark",
+	background?: string,
 ) =>
 	function SectionPreview() {
-		const bg =
-			background === "white"
-				? "#fff"
-				: background === "dark"
-					? "#000"
-					: undefined
+		const bg = background
 		return (
 			<div
 				style={{
@@ -221,7 +216,7 @@ export function definePageSection<const TName extends string>(
 	{
 		group,
 		icon,
-		iconBackground = "white",
+		iconBackground,
 		...options
 	}: Omit<
 		ArrayOfEntry<ObjectDefinition>,
@@ -242,8 +237,8 @@ export function definePageSection<const TName extends string>(
 		 * use browser devtools to capture an image of the section (ideally 1600x900 but can be any size)
 		 */
 		icon: StaticImageData
-		/** optional background color for the section preview icon */
-		iconBackground?: "white" | "dark"
+		/** optional CSS background color for the section preview icon (e.g. "#fff", "black") */
+		iconBackground?: string
 	},
 	secondary?: Parameters<
 		typeof defineArrayMember<
@@ -260,7 +255,7 @@ export function definePageSection<const TName extends string>(
 		{
 			...options,
 			groups: [{ name: group }],
-			icon: createSectionPreview(icon, iconBackground),
+			icon: createSectionPreview(icon, iconBackground ?? libraryConfig.sectionPreviewBackground),
 		},
 		secondary,
 	)

--- a/sanity/reusables.tsx
+++ b/sanity/reusables.tsx
@@ -58,7 +58,11 @@ export const createSectionPreview = (
 ) =>
 	function SectionPreview() {
 		const bg =
-			background === "white" ? "#fff" : background === "dark" ? "#000" : undefined
+			background === "white"
+				? "#fff"
+				: background === "dark"
+					? "#000"
+					: undefined
 		return (
 			<div
 				style={{


### PR DESCRIPTION
Adds an option to pass a bg color to at he preview images and attempts to size them more correctly for a better reference image. 