### PR TITLE
styled: fix component selectors

### DIFF
--- a/styled/runtime.test.tsx
+++ b/styled/runtime.test.tsx
@@ -1,7 +1,15 @@
 import { expect, test } from "vitest"
 import { runtimeStyled } from "./runtime"
+import { withComponent } from "./withComponent"
 
 test("runtimeStyled component toString() returns class selector for use in selectors", () => {
 	const Child = runtimeStyled({ tag: "span", cvaBase: "child_class_abc123" })
 	expect(Child.toString()).toBe(".child_class_abc123")
+})
+
+test("withComponent wrapper toString() delegates to the raw styled component", () => {
+	const Raw = runtimeStyled({ tag: "span", cvaBase: "raw_class_abc123" })
+	const Wrapped = withComponent(() => null, Raw)
+
+	expect(Wrapped.toString()).toBe(".raw_class_abc123")
 })

--- a/styled/withComponent.ts
+++ b/styled/withComponent.ts
@@ -4,5 +4,10 @@ export function withComponent<BaseProps extends Record<string, unknown>>(
 	Target: ComponentType<unknown>,
 	Base: ComponentType<BaseProps>,
 ) {
-	return (props: BaseProps) => createElement(Base, { ...props, as: Target })
+	const Component = (props: BaseProps) =>
+		createElement(Base, { ...props, as: Target })
+
+	Component.toString = () => Base.toString()
+
+	return Component
 }

--- a/vanilla/source-builder.ts
+++ b/vanilla/source-builder.ts
@@ -122,7 +122,7 @@ export function reconstructImports(
  * Creates an import declaration AST node.
  */
 export function createImportDeclaration(
-	names: string[],
+	names: Array<string | { imported: string; local: string }>,
 	fromPath: string,
 ): ts.ImportDeclaration {
 	return ts.factory.createImportDeclaration(
@@ -131,13 +131,18 @@ export function createImportDeclaration(
 			false,
 			undefined,
 			ts.factory.createNamedImports(
-				names.map((n) =>
-					ts.factory.createImportSpecifier(
+				names.map((n) => {
+					const imported = typeof n === "string" ? n : n.imported
+					const local = typeof n === "string" ? n : n.local
+
+					return ts.factory.createImportSpecifier(
 						false,
-						undefined,
-						ts.factory.createIdentifier(n),
-					),
-				),
+						imported === local
+							? undefined
+							: ts.factory.createIdentifier(imported),
+						ts.factory.createIdentifier(local),
+					)
+				}),
 			),
 		),
 		ts.factory.createStringLiteral(fromPath),

--- a/vanilla/vanilla-split-loader.test.ts
+++ b/vanilla/vanilla-split-loader.test.ts
@@ -616,9 +616,11 @@ export { Something, SomethingElse, SomethingElseElse }`
 
 			// Should import Something (base, string tag - moved to virtual)
 			expect(importedNames).toContain("Something")
-			// Should import the ___raw versions
-			expect(importedNames).toContain("SomethingElse___raw")
-			expect(importedNames).toContain("SomethingElseElse___raw")
+			// Should import the wrapped components aliased to their ___raw local names
+			expect(importedNames).toContain("SomethingElse as SomethingElse___raw")
+			expect(importedNames).toContain(
+				"SomethingElseElse as SomethingElseElse___raw",
+			)
 			// Should NOT import SomethingElse or SomethingElseElse (they're created in original)
 			expect(importedNames).not.toContain("SomethingElse")
 			expect(importedNames).not.toContain("SomethingElseElse")
@@ -632,9 +634,12 @@ export { Something, SomethingElse, SomethingElseElse }`
 
 			// Virtual should have Something (string tag, moved entirely)
 			expect(virtualModule).toContain("Something")
-			// Virtual should have the raw versions for component-based styled
-			expect(virtualModule).toContain("SomethingElse___raw")
-			expect(virtualModule).toContain("SomethingElseElse___raw")
+			// Virtual should keep component-based styled declarations under their original
+			// names so selector interpolation can reference them locally.
+			expect(virtualModule).toContain("SomethingElse")
+			expect(virtualModule).toContain("SomethingElseElse")
+			expect(virtualModule).not.toContain("SomethingElse___raw")
+			expect(virtualModule).not.toContain("SomethingElseElse___raw")
 		})
 
 		it("should split styled(Component) into raw + wrapper", async () => {
@@ -654,6 +659,47 @@ export const Button = styled(BaseButton, { color: "red" })`
 			// Original should have withComponent wrapper
 			expect(result).toContain("withComponent")
 			expect(result).toContain("Button___raw")
+		})
+
+		it("should keep styled(Component) virtual declarations named for selector interpolation", async () => {
+			await using tmpDir = new TempDir()
+			const source = `import { styled, css } from "library/styled"
+import UniversalLink from "library/link"
+import ArrowIcon from "./arrow.svg"
+
+const CardAnchor = styled(UniversalLink, { color: "red" })
+const Card = styled("div", { color: "blue" })
+const CardLinkArrow = styled(ArrowIcon, [
+	css\`
+		margin-left: 8px;
+
+		\${CardAnchor}:hover &,
+		\${Card}:hover & {
+			margin-left: 16px;
+		}
+	\`,
+])`
+			const ctx = createMockContext(
+				path.join(await tmpDir.getPath(), "app/test.tsx"),
+				await tmpDir.getPath(),
+			)
+
+			const result = await vanillaSplitLoader.call(ctx, source)
+			expectValidTypeScript(result)
+
+			expect(result).toContain("CardAnchor as CardAnchor___raw")
+			expect(result).toContain("withComponent(UniversalLink, CardAnchor___raw)")
+
+			const preProcessPath = path.join(
+				await tmpDir.getPath(),
+				".next/debug/pre-process/app/test.css.tsx",
+			)
+			const virtualModule = await fs.readFile(preProcessPath, "utf-8")
+
+			expect(virtualModule).toContain("export const CardAnchor = styled")
+			expect(virtualModule).not.toContain("CardAnchor___raw")
+			expect(virtualModule).toContain("$" + "{CardAnchor}:hover &")
+			expect(virtualModule).toContain("$" + "{Card}:hover &")
 		})
 
 		it("should keep base component import in original", async () => {

--- a/vanilla/vanilla-split-loader.ts
+++ b/vanilla/vanilla-split-loader.ts
@@ -343,8 +343,8 @@ function analyzeStyledCalls(
 				.join(", ")
 
 			const rawSource = restArgsText
-				? `export const ${rawName} = styled("div", ${restArgsText}, ${JSON.stringify(node.name)});`
-				: `export const ${rawName} = styled("div");`
+				? `export const ${node.name} = styled("div", ${restArgsText}, ${JSON.stringify(node.name)});`
+				: `export const ${node.name} = styled("div");`
 
 			// Extract the component identifier from the first arg for exclusion from virtual deps.
 			// Handles: Component, Menu.Trigger, Thing.Menu.Trigger, Component as Type
@@ -402,7 +402,7 @@ interface SplitPartition {
 	/** Names to re-export from original (tainted + exported) */
 	reexports: string[]
 	/** Names to import from virtual module */
-	imports: string[]
+	imports: Array<string | { imported: string; local: string }>
 }
 
 /**
@@ -538,7 +538,7 @@ function partitionNodes(
 	const virtual: DependencyNode[] = []
 	const original: DependencyNode[] = []
 	const reexports: string[] = []
-	const imports: string[] = []
+	const imports: Array<string | { imported: string; local: string }> = []
 
 	for (const node of graph.ordered) {
 		const key = node.name ?? `__expr_${node.id}`
@@ -574,7 +574,10 @@ function partitionNodes(
 					(t) => t.originalName === node.name,
 				)
 				if (transform?.needsWrapper) {
-					imports.push(transform.rawName)
+					imports.push({
+						imported: transform.originalName,
+						local: transform.rawName,
+					})
 					// Also import the base component if it's tainted AND not itself wrapped
 					// (wrapped components are created in original via withComponent, not imported)
 					if (transform.excludedDep && tainted.has(transform.excludedDep)) {
@@ -590,14 +593,23 @@ function partitionNodes(
 				}
 			}
 
-			if (node.exportInfo) {
+			if (node.exportInfo && !wrappedNames.has(node.name)) {
 				reexports.push(node.name)
 			}
 		}
 	}
 
 	// Dedupe imports
-	return { virtual, original, reexports, imports: [...new Set(imports)] }
+	const seenImports = new Set<string>()
+	const dedupedImports = imports.filter((item) => {
+		const key =
+			typeof item === "string" ? item : `${item.imported} as ${item.local}`
+		if (seenImports.has(key)) return false
+		seenImports.add(key)
+		return true
+	})
+
+	return { virtual, original, reexports, imports: dedupedImports }
 }
 
 // =============================================================================


### PR DESCRIPTION
- keep component-based styled declarations under their original virtual module names
- import wrapped styled components back into runtime modules with ___raw aliases
- prevent virtual raw exports from being re-exported as public wrappers
- delegate withComponent toString output to the raw styled component
- add regression tests for component selector interpolation and wrapped toString behavior