### PR TITLE
sanity: skip live proxy during builds

### DIFF
--- a/sanity/live.tsx
+++ b/sanity/live.tsx
@@ -17,6 +17,7 @@ import { notifySanityLiveRefreshAction, SanityRuntime } from "./live.client"
 import {
 	getLiveProxySupport,
 	getLiveProxyUnsupportedMessage,
+	isNextProductionBuild,
 } from "./liveEnvironment"
 
 const libraryClient = client.withConfig({ useCdn: false })
@@ -88,17 +89,21 @@ export async function libraryFetch<const QueryString extends string>({
 
 export const LibraryRuntime = async () => {
 	const { isEnabled: isDraftMode } = await draftMode()
+	const isProductionBuild = isNextProductionBuild()
 	const { allowProxy, canUseLiveProxy, runtimeSupportsLiveProxy } =
 		getLiveProxySupport({
 			allowProxy: libraryConfig.allowProxy,
 			currentSiteURL: siteURL,
 		})
-	if (allowProxy && !runtimeSupportsLiveProxy) {
+	if (allowProxy && !runtimeSupportsLiveProxy && !isProductionBuild) {
 		throw new Error(getLiveProxyUnsupportedMessage())
 	}
 
 	return (
-		<SanityRuntime isDraftMode={isDraftMode} useLiveProxy={canUseLiveProxy}>
+		<SanityRuntime
+			isDraftMode={isDraftMode}
+			useLiveProxy={canUseLiveProxy && !isProductionBuild}
+		>
 			{(isDraftMode || !allowProxy) && (
 				<InternalLive
 					action={isDraftMode ? notifySanityLiveRefreshAction : undefined}

--- a/sanity/liveEnvironment.test.ts
+++ b/sanity/liveEnvironment.test.ts
@@ -3,6 +3,7 @@ import {
 	fluidComputeUnavailableEnvironmentVariables,
 	getLiveProxySupport,
 	isLocalSiteURL,
+	isNextProductionBuild,
 } from "./liveEnvironment"
 
 const originalEnv = process.env
@@ -24,6 +25,18 @@ test("detects local site URLs", () => {
 	expect(isLocalSiteURL("http://127.0.0.1:3000")).toBe(true)
 	expect(isLocalSiteURL("http://[::1]:3000")).toBe(true)
 	expect(isLocalSiteURL("https://example.com")).toBe(false)
+})
+
+test("detects Next production builds", () => {
+	setEnv({ NEXT_PHASE: "phase-production-build" })
+
+	expect(isNextProductionBuild()).toBe(true)
+})
+
+test("ignores other Next phases", () => {
+	setEnv({ NEXT_PHASE: "phase-production-server" })
+
+	expect(isNextProductionBuild()).toBe(false)
 })
 
 test("allows the live proxy for local site URLs", () => {

--- a/sanity/liveEnvironment.ts
+++ b/sanity/liveEnvironment.ts
@@ -18,6 +18,10 @@ export const fluidComputeUnavailableEnvironmentVariables = [
 	"_LAMBDA_TELEMETRY_LOG_FD",
 ] as const
 
+export function isNextProductionBuild() {
+	return process.env.NEXT_PHASE === "phase-production-build"
+}
+
 export function isLocalSiteURL(candidate: string) {
 	try {
 		const { hostname } = new URL(candidate)


### PR DESCRIPTION
- add Next production build phase detection to Sanity live environment helpers
- skip the Sanity live proxy runtime assertion while Next prerenders during build
- disable live proxy refresh wiring during production build prerender
- add coverage for production build phase detection