### PR TITLE
sanity: support v6 live runtime

### DIFF
--- a/sanity/live.tsx
+++ b/sanity/live.tsx
@@ -118,8 +118,8 @@ if (!semver.satisfies(nextSanityVersion, "^13.0.0")) {
 		`next-sanity must satisfy version ^13.0.0! (installed: ${nextSanityVersion})`,
 	)
 }
-if (!semver.satisfies(sanityVersion, "^5.0.0")) {
+if (!semver.satisfies(sanityVersion, "^5.0.0 || ^6.0.0")) {
 	throw new Error(
-		`sanity must satisfy version ^5.0.0! (installed: ${sanityVersion})`,
+		`sanity must satisfy version ^5.0.0 || ^6.0.0! (installed: ${sanityVersion})`,
 	)
 }

--- a/sanity/liveEnvironment.test.ts
+++ b/sanity/liveEnvironment.test.ts
@@ -16,7 +16,7 @@ afterEach(() => {
 	process.env = originalEnv
 })
 
-function setEnv(env: NodeJS.ProcessEnv) {
+function setEnv(env: Partial<NodeJS.ProcessEnv>) {
 	process.env = { ...originalEnv, ...env }
 }
 


### PR DESCRIPTION
- allow sanity 6 in the live runtime compatibility guard
- relax live environment test helper typing for partial env patches
- merge latest next-main into the branch
