### PR TITLE
styled: add neverresponsive

### DIFF
--- a/styled/README.md
+++ b/styled/README.md
@@ -121,9 +121,25 @@ takes standard css with pixel values and converts them into a responsive `calc()
 
 ```ts
 f.responsive({
-	fontSize: "16px", // becomes a complex calc() covering all breakpoints
+	padding: "16px", // becomes a complex calc() covering all breakpoints
 	margin: "20px 40px",
 })
+```
+
+### `neverResponsive`
+
+wrap css in `neverResponsive(...)` when pixel values should survive responsive conversion.
+
+```ts
+import { css, f, neverResponsive } from "library/styled"
+
+f.responsive(css`
+	padding: 20px;
+	${neverResponsive(css`
+		font-size: 16px;
+		line-height: 20px;
+	`)}
+`)
 ```
 
 ### breakpoint helpers

--- a/styled/vanilla.test.ts
+++ b/styled/vanilla.test.ts
@@ -1,0 +1,53 @@
+import { expect, test, vi } from "vitest"
+
+vi.mock("./breakpoints.css", () => ({
+	isDesktop: "var(--is-desktop)",
+	isFull: "var(--is-full)",
+	isMobile: "var(--is-mobile)",
+	isTablet: "var(--is-tablet)",
+}))
+
+const css = String.raw
+
+const getGeneratedCss = (rule: Record<string, unknown>) =>
+	Object.values(rule).join("")
+
+test("responsive utilities preserve pixels marked with neverResponsive", async () => {
+	const { f, neverResponsive } = await import("./vanilla")
+	const generated = getGeneratedCss(
+		f.responsive(
+			css`
+				padding: 20px;
+				${neverResponsive(css`
+					font-size: 16px;
+					line-height: 20px;
+				`)}
+			`,
+			{ engine: "calc" },
+		),
+	)
+
+	expect(generated).toContain("padding:calc(")
+	expect(generated).toContain("font-size:16px")
+	expect(generated).toContain("line-height:20px")
+	expect(generated).not.toContain("neverpx")
+})
+
+test("media engine preserves pixels marked with neverResponsive", async () => {
+	const { f, neverResponsive } = await import("./vanilla")
+	const generated = getGeneratedCss(
+		f.responsive(
+			css`
+				margin: 20px;
+				${neverResponsive(css`
+					font-size: 16px;
+				`)}
+			`,
+			{ engine: "media" },
+		),
+	)
+
+	expect(generated).toContain("margin:")
+	expect(generated).toContain("font-size:16px")
+	expect(generated).not.toContain("neverpx")
+})

--- a/styled/vanilla.ts
+++ b/styled/vanilla.ts
@@ -216,6 +216,10 @@ const hasUniformOutput = (rules: readonly BreakpointRule[]): boolean =>
 	)
 
 const pixelRegex = /-?\d+(\.\d+)?px/g
+const neverResponsiveUnitRegex = /neverpx/g
+
+const restoreNeverResponsiveUnits = (cssText: string): string =>
+	cssText.replaceAll(neverResponsiveUnitRegex, "px")
 
 const replacePxInAst = (
 	root: csstree.CssNode,
@@ -316,7 +320,9 @@ const calcEngine = (
 	if (!ast) return cssText
 
 	replacePxInAst(ast, (px) => getCalcExpression(px, rules, options))
-	const processed = unwrapGeneratedCss(csstree.generate(ast))
+	const processed = restoreNeverResponsiveUnits(
+		unwrapGeneratedCss(csstree.generate(ast)),
+	)
 	return wrapWithMediaQueries(processed, rules)
 }
 
@@ -336,7 +342,9 @@ const mediaEngine = (
 	for (const rule of rules) {
 		const cloned = csstree.clone(ast)
 		replacePxInAst(cloned, (px) => computeResponsiveValue(px, rule, options))
-		contents.push(unwrapGeneratedCss(csstree.generate(cloned)))
+		contents.push(
+			restoreNeverResponsiveUnits(unwrapGeneratedCss(csstree.generate(cloned))),
+		)
 	}
 
 	const allIdentical =
@@ -371,6 +379,9 @@ const generateStyle = (
 
 const unresponsive = (cssText: string): StyleRule =>
 	toInjectedStyleRule(cssText)
+
+export const neverResponsive = (cssText: string): string =>
+	cssText.replaceAll(pixelRegex, (match) => match.replace("px", "neverpx"))
 
 // =============================================================================
 // Public API


### PR DESCRIPTION
- added neverResponsive helper for fixed pixel values inside responsive utilities
- restored neverResponsive sentinel units in calc and media engines
- documented the generic neverResponsive helper
- added coverage for calc and media responsive generation
