### PR TITLE
Fix vitest JSX transform failing on jsx: preserve tsconfig

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,13 @@ import viteTsconfigPaths from "vite-tsconfig-paths"
 import { defineConfig } from "vitest/config"
 
 export default defineConfig({
+	// consuming projects set jsx: "preserve" in tsconfig for Next.js, but
+	// vitest's oxc transform needs to transform JSX itself when running tests
+	oxc: {
+		jsx: {
+			runtime: "automatic",
+		},
+	},
 	plugins: [viteTsconfigPaths({ projects: ["../tsconfig.json"] })],
 	test: {
 		typecheck: {


### PR DESCRIPTION
vitest 4.1's Vite dependency defaults to an oxc-based transform with its own config (oxc: { target: "node18" }), which silently overrides any esbuild.jsx setting and falls back to reading jsx: "preserve" from the consuming project's tsconfig.json (set there for Next.js). Set oxc.jsx.runtime directly so vitest transforms JSX itself regardless of the app's tsconfig.

yeehaw